### PR TITLE
docs(filesystem) + test: compatibility suite, refreshed docs, AOT matrix (L01.01.09 PR4)

### DIFF
--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/README.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/README.md
@@ -1,1 +1,32 @@
-# Cohesion
+# Assimalign.Cohesion.FileSystem.Aggregate
+
+`IFileSystem` implementation that composes multiple mounted providers
+under a single virtual namespace. Routes operations to the mount with
+the longest matching path prefix.
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+
+using var aggregate = new AggregateFileSystemBuilder()
+    .Mount("/data",  new PhysicalFileSystem(new PhysicalFileSystemOptions { Root = "/var/data" }), ownsFileSystem: true)
+    .Mount("/cache", new InMemoryFileSystem(new InMemoryFileSystemOptions()),                       ownsFileSystem: true)
+    .Build();
+
+aggregate.CreateFile("/cache/transient.bin"); // routed to InMemory
+aggregate.CreateFile("/data/payload.bin");    // routed to Physical
+```
+
+- Longest-prefix routing with segment-boundary check (so `/data` never
+  matches `/database`).
+- Synthetic read-only directories for intermediate path segments that
+  lead toward a mount but aren't themselves a mount root.
+- Cross-provider `CopyFile` / `Move` stream the source's bytes into a
+  freshly-created destination on the target provider.
+- Returned `IFileSystemFile` / `IFileSystemDirectory` instances have
+  aggregate-space `Path` values and point their `FileSystem` property
+  back at the aggregate.
+- Watch fan-in across every mount, with event paths remapped into
+  aggregate-space before dispatch.
+- Disposal cascades to mounts registered with `ownsFileSystem: true`.
+
+See `docs/OVERVIEW.md` and `docs/DESIGN.md` for details.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/DESIGN.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/DESIGN.md
@@ -1,41 +1,147 @@
-# Assimalign.Cohesion.FileSystem.Aggregate Design
+# Assimalign.Cohesion.FileSystem.Aggregate — Design
 
-## Design Intent
+## Design intent
 
-The design goal is compelling: unify multiple backends without changing the caller contract. The current implementation is still mostly a stub, so the docs describe the intended composite role more than the runtime behavior.
+Compose multiple `IFileSystem` instances into a single virtual file system
+without changing the caller-facing contract. Path resolution uses
+longest-prefix matching against a pre-sorted mount table; results are
+re-wrapped so paths flowing back to callers live in aggregate-space, not
+provider-relative form.
 
-## Implementation Note
+## Routing
 
-Examples below document the intended public shape; some members still throw NotImplementedException today.
-
-## Architecture
-
-- AggregateFileSystem is intended to remain an IFileSystem so callers do not need a second API surface.
-- A completed implementation would need routing rules for lookups, enumeration, and change notifications.
-- Today the class mostly marks the intended seam for future composition work.
-
-## Layout Example
-
-```text
-Assimalign.Cohesion.FileSystem.Aggregate/
-  src/
-    Assimalign.Cohesion.FileSystem.Aggregate.csproj
-  tests/
-  docs/
-    OVERVIEW.md
-    DESIGN.md
-```
-
-## Example 1: Current public shape
+`AggregateRouter.SortByLongestPrefix` sorts the mount table once at
+construction so resolution is a single forward scan:
 
 ```csharp
-IFileSystem fileSystem = new AggregateFileSystem();
+foreach (var mount in sortedMounts)
+{
+    if (mount.MountPath == "/") return mount;       // root mount matches everything
+    if (text.Equals(mount.MountPath)) return mount; // exact mount root
+    if (text.StartsWith(mount.MountPath) && text[mount.MountPath.Length] == '/')
+        return mount;                               // longest matching prefix
+}
+return null;                                        // path lives in synthetic space
 ```
 
-## Example 2: Intended responsibility
+The segment-boundary check (`text[mount.MountPath.Length] == '/'`) is
+critical — without it, mount `/data` would erroneously claim `/database`.
 
-```text
-AggregateFileSystem
-  -> should compose multiple file-system backends behind one IFileSystem facade
-  -> while preserving the IFileSystem contract for callers
+## Synthetic root
+
+When no mount is at `/`, the aggregate's root is an
+`AggregateSyntheticDirectory`. Its `GetDirectories()` enumerates the first
+segment of every registered mount path:
+
+```csharp
+// Mounts: /data/cache, /var/log
+// Root.GetDirectories() returns synthetic dirs for "data" and "var"
+// Root.GetDirectory("data").GetDirectories() returns the wrapped /data/cache mount
+```
+
+Synthetic directories are read-only. Every mutating op throws
+`FileSystemException(ReadOnly)` to keep the intent explicit.
+
+## Path wrapping
+
+`AggregateFileSystemFile` and `AggregateFileSystemDirectory` wrap entries
+from mounted providers and translate paths in both directions:
+
+- `Path` returns the aggregate-side absolute path.
+- `Parent`, `Directory`, `GetDirectories`, `GetFiles`, `EnumerateFileSystem`
+  re-wrap child entries with their aggregate-space paths.
+- `CreateDirectory` / `CreateFile` / `Delete*` route back through the
+  aggregate so mount resolution and read-only checks apply.
+- `FileSystem` always points back at the aggregate, never the underlying
+  mount.
+
+Translation lives in `AggregateMount.ToAggregatePath` /
+`ToProviderPath` with theory-driven unit tests so the conversion behavior
+is locked down.
+
+## Cross-provider Copy / Move
+
+```csharp
+public void CopyFile(FileSystemPath source, FileSystemPath destination)
+{
+    var sourceMount = router.Resolve(sourceAbs);
+    var destMount = router.Resolve(destAbs);
+
+    if (ReferenceEquals(sourceMount.FileSystem, destMount.FileSystem))
+    {
+        // Same provider: delegate so it can optimize (timestamps, etc.).
+        sourceMount.FileSystem.CopyFile(sourceMount.ToProviderPath(sourceAbs),
+                                        destMount.ToProviderPath(destAbs));
+        return;
+    }
+
+    // Different providers: stream the bytes.
+    var sourceFile = sourceMount.FileSystem.GetFile(sourceMount.ToProviderPath(sourceAbs));
+    var destFile = destMount.FileSystem.CreateFile(destMount.ToProviderPath(destAbs));
+    StreamContents(sourceFile, destFile);
+}
+```
+
+`Move` follows the same shape but deletes the source after the destination
+write completes.
+
+## Watch fan-in
+
+`AggregateFileSystemEventToken` subscribes to every mount with a catch-
+all `**` glob (mount-side filtering is intentionally disabled because
+some providers — notably InMemory — default a null glob to "watch the
+directory's own path only"). When a mount fires an event, the fan-in
+remaps the path back into aggregate-space and only then applies the
+caller-supplied glob.
+
+`OnRename` remaps both the old and new paths and dispatches a single
+remapped `FileSystemRenameEvent`.
+
+The fan-in tracks every mount subscription and disposes them all when the
+aggregate token is disposed. The aggregate file system also tracks every
+token it hands out and disposes them in its own `Dispose` for safety.
+
+## Disposal
+
+```csharp
+public void Dispose()
+{
+    foreach (var mount in _mountsSorted)
+    {
+        if (mount.OwnsFileSystem)
+        {
+            try { mount.FileSystem.Dispose(); } catch { /* best-effort */ }
+        }
+    }
+}
+```
+
+Only `ownsFileSystem: true` mounts cascade. The default is `false`
+because in most composition scenarios the caller already manages the
+underlying providers' lifetimes (e.g. they're registered on the same
+`FileSystemFactoryBuilder` as the aggregate).
+
+## Layout
+
+```
+src/
+  AggregateFileSystem.cs           public provider
+  AggregateFileSystemOptions.cs    public options bag (internal mounts list)
+  AggregateFileSystemBuilder.cs    single-use fluent builder
+  Extensions/
+    AggregateFileSystemExtensions.cs   FileSystemFactoryBuilder extension
+  Internal/
+    AggregateMount.cs                  mount record + path translation
+    AggregateRouter.cs                 longest-prefix routing helpers
+    AggregateFileSystemDirectory.cs    wrapped directory
+    AggregateFileSystemFile.cs         wrapped file
+    AggregateSyntheticDirectory.cs     synthetic intermediate directory
+    AggregateFileSystemEventToken.cs   watch fan-in token
+  Properties/
+    AssemblyInfo.cs   (InternalsVisibleTo)
+tests/
+  AggregateFileSystemTests.cs            provider-specific behavior
+  AggregateFileSystemStandardTests.cs    inherits shared contract suite
+  AggregateRouterTests.cs                router primitives
+  Shared/FileSystemStandardTests.cs      (linked from root package)
 ```

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/OVERVIEW.md
@@ -2,26 +2,86 @@
 
 ## Summary
 
-Defines the planned aggregate file-system implementation that should compose multiple underlying IFileSystem backends behind one contract.
+`IFileSystem` implementation that composes multiple mounted providers
+under a single virtual namespace. Operations are routed to the mount with
+the longest matching path prefix. Useful for layering — InMemory for
+`/cache`, Physical for `/data`, IsolatedStorage for `/userprefs`, all
+behind one `IFileSystem`.
 
-## Current Evaluation
+## When to pick it
 
-- Status: Partial
-- Production source files: 1; key type candidates discovered: 1; test files discovered: 1.
-- Project references: Assimalign.Cohesion.FileSystem
-- Package references: None
-- NotImplementedException markers: 21
+- Apps that need multiple storage backings exposed as one tree.
+- Composing read-only seed data (mounted at one path) with a writable
+  scratch area (mounted at another).
+- Test fixtures that overlay an in-memory writable layer on top of a
+  read-only physical fixture.
 
-## Primary Responsibilities
+## Public surface
 
-- AggregateFileSystem is intended to remain an IFileSystem so callers do not need a second API surface.
-- A completed implementation would need routing rules for lookups, enumeration, and change notifications.
-- Today the class mostly marks the intended seam for future composition work.
+| Type | Role |
+|------|------|
+| `AggregateFileSystem` | The provider. |
+| `AggregateFileSystemOptions` | `Name`, `IsReadOnly`, internal mount table. |
+| `AggregateFileSystemBuilder` | Single-use fluent builder — `Mount`, `WithName`, `AsReadOnly`, `Build`. |
+| `FileSystemFactoryBuilder.AddAggregateFileSystem` | Factory-builder extension. |
 
-## Key Types
+Internal routing primitives (`AggregateMount`, `AggregateRouter`,
+synthetic directory, fan-in event token) are under `src/Internal/`.
 
-- AggregateFileSystem
+## Routing rules
 
-## Source Layout
+- **Longest-prefix wins.** Given mounts `/data` and `/data/cache`, the
+  request `/data/cache/x` resolves to the `/data/cache` mount.
+- **Segment-boundary check.** `/data` does not match `/database` — the
+  next char after the mount path must be `/` or end-of-path.
+- **Synthetic intermediates.** Path segments that lead toward a mount but
+  aren't themselves a mount root surface as read-only synthetic
+  directories. `Exists("/data") == true` even when only `/data/cache` is
+  mounted.
+- **Mutating ops in synthetic space.** Reject with
+  `FileSystemException(ReadOnly)` — the aggregate doesn't synthesize new
+  mounts on the fly.
 
-- No source subfolders were discovered.
+## Cross-provider Copy / Move
+
+- **Same provider** on both sides: delegate to the underlying provider
+  (preserves timestamps and any optimizations).
+- **Different providers**: stream the source's bytes through `Open(Read)`
+  into a freshly-created destination on the target provider. The source
+  is left in place until the destination write completes, so a mid-copy
+  failure doesn't lose data.
+
+## Path remapping
+
+Returned `IFileSystemFile` / `IFileSystemDirectory` instances are wrapped
+so their `Path` lives in aggregate-space (`/data/foo.txt`) instead of
+provider-relative form (`/foo.txt`). The `FileSystem` property points
+back at the aggregate, not the underlying mount.
+
+## Watch fan-in
+
+`AggregateFileSystem.Watch(pattern)` returns a fan-in token that
+subscribes to every mount's watch token, remaps the event path back into
+aggregate-space, and only then applies the supplied glob filter. The fan-
+in token tracks the underlying subscriptions and disposes them all when
+itself is disposed.
+
+## Disposal ownership
+
+Each mount is registered with an `ownsFileSystem` flag (default `false`).
+Aggregate `Dispose()` cascades only to owned mounts; externally-managed
+providers are left alone. `DisposeAsync()` follows the same rule.
+
+## Test coverage
+
+75 tests including:
+
+- 32 contract tests from `FileSystemStandardTests` against an aggregate
+  with InMemory mounted at `/` (exercises the wrapper layer + standard
+  contract simultaneously).
+- 18 router unit tests covering longest-prefix, segment-boundary,
+  synthetic intermediates, child enumeration, normalization, and the
+  bidirectional path-translation theories.
+- 25 aggregate-specific tests covering builder validation, nested mount
+  priority, cross-provider Copy/Move, dispose ownership, watch fan-in,
+  factory registration.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Aggregate/docs/OVERVIEW.md
@@ -74,9 +74,9 @@ providers are left alone. `DisposeAsync()` follows the same rule.
 
 ## Test coverage
 
-75 tests including:
+77 tests including:
 
-- 32 contract tests from `FileSystemStandardTests` against an aggregate
+- 34 contract tests from `FileSystemStandardTests` against an aggregate
   with InMemory mounted at `/` (exercises the wrapper layer + standard
   contract simultaneously).
 - 18 router unit tests covering longest-prefix, segment-boundary,

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/README.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/README.md
@@ -1,0 +1,26 @@
+# Assimalign.Cohesion.FileSystem.InMemory
+
+In-process `IFileSystem` implementation that stores every file's bytes in
+managed memory. Designed for tests, ephemeral caches, and fixtures.
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+
+using var factory = new FileSystemFactoryBuilder()
+    .AddInMemoryFileSystem(options =>
+    {
+        options.Name = "scratch";
+        options.Size = Size.FromMegabytes(8);
+    })
+    .Build();
+
+IFileSystem fs = factory.Create("scratch");
+fs.CreateFile("hello.txt");
+```
+
+- Synchronous watch events (no polling, no `FileSystemWatcher`).
+- Configurable quota — writes that would exceed `Size` throw
+  `FileSystemException(NotEnoughSpace)`.
+- Optional read-only mode.
+
+See `docs/OVERVIEW.md` and `docs/DESIGN.md` for details.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/DESIGN.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/DESIGN.md
@@ -1,42 +1,96 @@
-# Assimalign.Cohesion.FileSystem.InMemory Design
+# Assimalign.Cohesion.FileSystem.InMemory — Design
 
-## Design Intent
+## Design intent
 
-This package is the test-friendly and ephemeral-storage implementation of the file-system stack. It keeps the same public contract as physical storage while moving all state into process memory.
+A test-grade `IFileSystem` whose backing store lives entirely in process
+memory. Identical public surface to `PhysicalFileSystem` so consumers can
+swap between the two without behavior change.
 
-## Architecture
+## Storage model
 
-- InMemoryFileSystem is the public backend type and is configured through InMemoryFileSystemOptions.
-- Internal node and stream types keep storage mechanics out of the public surface.
-- Factory builder extensions make the backend easy to register alongside other file systems.
+- The provider holds a single root `InMemoryFileSystemDirectory`. Every
+  directory keeps a `Dictionary<FileSystemPath, InMemoryFileSystemInfo>`
+  of children plus a synthetic `Lookup` view used by enumeration / traversal.
+- Each file owns an `InMemoryFileContent` chunk-buffer. Streams (`Open`)
+  read and write into that buffer; `Size` reflects the buffer's current
+  length.
+- Total space used is tracked at the file-system level. Writes that would
+  push past `InMemoryFileSystemOptions.Size` throw
+  `FileSystemException(NotEnoughSpace)`.
 
-## Layout Example
+## Locking
 
-```text
-Assimalign.Cohesion.FileSystem.InMemory/
-  src/
-    Assimalign.Cohesion.FileSystem.InMemory.csproj
-    Extensions/
-    Internal/
-  tests/
-  docs/
-    OVERVIEW.md
-    DESIGN.md
+Modeled on the Linux kernel's directory-locking rules
+(https://www.kernel.org/doc/Documentation/filesystems/directory-locking).
+Every mutation acquires explicit locks on the file system + parent
+directories + target entry before touching state, then releases them via
+`InMemoryFileSystemLockManager.Dispose()`. Read-only operations
+(`Exists`, `GetInfo`) take a weaker `Delete` lock so they coexist with
+concurrent reads but block in-flight deletions.
+
+## Path handling
+
+- `InMemoryFileSystemOptions.RootPath` defaults to `/` and rejects
+  `..`-prefixed relative paths in the setter.
+- The provider stores `IgnoreCase` (default true) and `CultureInfo`
+  (default invariant) and uses them through `FileSystemPath.Equals` so
+  lookups behave the same on Linux and Windows.
+- Incoming paths are normalized via `RootDirectory.Path.Merge(path, culture, ignoreCase)`
+  before any tree-walking — relative paths are rooted at the file system's
+  root, absolute paths are checked for scope.
+
+## Watch dispatcher
+
+`InMemoryFileSystemDispatcher` exposes `Created`/`Deleted`/`Changed`/`Renamed`
+events. Each mutation raises the appropriate event after the state change
+completes; `InMemoryFileSystemEventToken` subscribes to the dispatcher and
+filters by `Glob` and registration type.
+
+The synchronous nature makes the in-memory provider easy to assert against
+in tests — there is no race between mutation and notification.
+
+## Layout
+
+```
+src/
+  InMemoryFileSystem.cs              public provider
+  InMemoryFileSystemOptions.cs       public options bag
+  InMemoryFileSystemLockHandle.cs    public lock-bearer base class
+  Extensions/                        FileSystemFactoryBuilder extensions
+  Internal/
+    InMemoryFileSystemDirectory.cs
+    InMemoryFileSystemFile.cs
+    InMemoryFileSystemInfo.cs
+    InMemoryFileSystemDispatcher.cs
+    InMemoryFileSystemEventToken.cs
+    InMemoryFileSystemLockManager.cs
+    IO/
+      InMemoryFileContent.cs
+      InMemoryFileStream.cs
+tests/
+  FileSystemTests.cs            provider-specific behavior
+  Shared/FileSystemStandardTests.cs (linked from root package)
 ```
 
-## Example 1: Register the in-memory backend through the factory builder
+## Examples
 
 ```csharp
-var factory = new FileSystemFactoryBuilder()
-    .AddInMemoryFileSystem()
+// Default: 32 MB quota, ignore-case, root at "/".
+using var fs = new InMemoryFileSystem(new InMemoryFileSystemOptions());
+
+// Read-only fixture seeded ahead of time.
+using var readonlyFs = new InMemoryFileSystem(new InMemoryFileSystemOptions
+{
+    IsReadOnly = true,
+});
+
+// Via the factory builder.
+using var factory = new FileSystemFactoryBuilder()
+    .AddInMemoryFileSystem(options =>
+    {
+        options.Name = "scratch";
+        options.Size = Size.FromMegabytes(8);
+    })
     .Build();
-
-IFileSystem fileSystem = factory.Create<InMemoryFileSystem>();
-```
-
-## Example 2: Configure the in-memory backend directly
-
-```csharp
-var options = new InMemoryFileSystemOptions();
-var fileSystem = new InMemoryFileSystem(options);
+IFileSystem scratch = factory.Create("scratch");
 ```

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/OVERVIEW.md
@@ -47,9 +47,9 @@ no `FileSystemWatcher`.
 
 ## Test coverage
 
-107 tests including:
+109 tests including:
 
-- 32 contract tests inherited from `FileSystemStandardTests` (path
+- 34 contract tests inherited from `FileSystemStandardTests` (path
   semantics, CRUD, copy/move, enumeration, deep nesting, large files,
   timestamps).
 - 75 provider-specific tests covering quota enforcement, locking, change

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.InMemory/docs/OVERVIEW.md
@@ -2,34 +2,55 @@
 
 ## Summary
 
-Implements an in-memory IFileSystem backend and adds registration helpers for the shared file-system factory.
+In-process `IFileSystem` implementation that stores every file's bytes in
+managed memory. Designed for tests, ephemeral caches, and fixtures where a
+real disk would be slow, leaky, or wrong. Configurable quota, synchronous
+change notifications, and locking that mirrors Linux directory-locking
+rules.
 
-## Current Evaluation
+## When to pick it
 
-- Status: Implemented
-- Production source files: 13; key type candidates discovered: 8; test files discovered: 1.
-- Project references: Assimalign.Cohesion.FileSystem
-- Package references: None
-- NotImplementedException markers: 0
+- Unit / integration tests that need a real `IFileSystem` without touching
+  the disk.
+- Short-lived scratch space inside a single process.
+- Anywhere data must vanish when the process exits.
 
-## Primary Responsibilities
+## Public surface
 
-- InMemoryFileSystem is the public backend type and is configured through InMemoryFileSystemOptions.
-- Internal node and stream types keep storage mechanics out of the public surface.
-- Factory builder extensions make the backend easy to register alongside other file systems.
+| Type | Role |
+|------|------|
+| `InMemoryFileSystem` | The provider. Implements `IFileSystem`. |
+| `InMemoryFileSystemOptions` | `Name`, `IsReadOnly`, `Size` quota (default 32 MB), `IgnoreCase`, `CultureInfo`, `RootPath`, `IgnoreAttributes`. |
+| `FileSystemFactoryBuilder.AddInMemoryFileSystem` | Factory-builder extension for `Assimalign.Cohesion.FileSystem`. |
 
-## Key Types
+Internal directory / file / dispatcher / locking types are kept under
+`src/Internal/` and not surfaced through the public API.
 
-- InMemoryFileContent
-- InMemoryFileStream
-- InMemoryFileSystem
-- InMemoryFileSystemDirectory
-- InMemoryFileSystemDispatcher
-- InMemoryFileSystemEventToken
-- InMemoryFileSystemExtensions
-- InMemoryFileSystemFile
+## Watch semantics
 
-## Source Layout
+Synchronous. Mutations (`CreateFile`, `DeleteDirectory`, etc.) raise events
+through `InMemoryFileSystemEventToken` before the call returns. No polling,
+no `FileSystemWatcher`.
 
-- src/Extensions
-- src/Internal
+> **Known issue (pre-existing, tracked separately):** event paths include
+> a doubled trailing segment (`/foo.txt/foo.txt`) because the
+> `FileSystemEventArgs` is constructed with the entry's full path as the
+> `Directory` argument. Aggregate provider watch tests work around this by
+> asserting "a callback fires" rather than the exact path.
+
+## Quota and read-only
+
+- `InMemoryFileSystemOptions.Size` caps total used bytes. Writes that would
+  exceed it throw `FileSystemException` with `FileSystemErrorCode.NotEnoughSpace`.
+- `IsReadOnly = true` makes every mutating operation throw
+  `FileSystemException` with `FileSystemErrorCode.ReadOnly`.
+
+## Test coverage
+
+107 tests including:
+
+- 32 contract tests inherited from `FileSystemStandardTests` (path
+  semantics, CRUD, copy/move, enumeration, deep nesting, large files,
+  timestamps).
+- 75 provider-specific tests covering quota enforcement, locking, change
+  dispatch, lookup, options validation.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/README.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/README.md
@@ -1,0 +1,30 @@
+# Assimalign.Cohesion.FileSystem.IsolatedStorage
+
+`IFileSystem` implementation backed by `System.IO.IsolatedStorage.IsolatedStorageFile`.
+Provides per-user / per-assembly persistent storage without requiring the
+caller to choose a directory on disk — the runtime picks an OS-appropriate
+location.
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+
+using var factory = new FileSystemFactoryBuilder()
+    .AddIsolatedStorageFileSystem(options =>
+    {
+        options.WatchPollInterval = TimeSpan.FromSeconds(5);
+    })
+    .Build();
+
+IFileSystem fs = factory.Create("IsolatedStorageFileSystem");
+fs.CreateFile("userprefs.json");
+```
+
+- Cross-platform — Windows, Linux, macOS.
+- Polling-based watch (configurable cadence; set to
+  `Timeout.InfiniteTimeSpan` to disable).
+- `Attributes` / `SetAttributes` throw `NotSupportedException` (the
+  underlying store does not expose `FileAttributes`).
+- `OnRename` registrations accepted but never fire (polling can't
+  reliably correlate the delete+create pair).
+
+See `docs/OVERVIEW.md` and `docs/DESIGN.md` for details.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/DESIGN.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/DESIGN.md
@@ -1,42 +1,109 @@
-# Assimalign.Cohesion.FileSystem.IsolatedStorage Design
+# Assimalign.Cohesion.FileSystem.IsolatedStorage — Design
 
-## Design Intent
+## Design intent
 
-The implementation aims to adapt isolated storage to the shared file-system contract, which would let callers swap persistence models without rewriting consumers. The package is still partial today.
+Surface `System.IO.IsolatedStorage.IsolatedStorageFile` as an
+`IFileSystem`. The underlying API is .NET's portable, per-user, per-
+assembly sandboxed store — useful when you want persistent storage on
+every supported OS without writing path-resolution code per platform.
 
-## Implementation Note
+## Path translation
 
-Examples below document the intended public shape; some members still throw NotImplementedException today.
-
-## Architecture
-
-- IsolatedStorageFileSystem is the single public backend type for the package.
-- The design should mirror the same operations exposed by the core IFileSystem contract.
-- Several members are unfinished, so the library currently describes a target direction more than a finished adapter.
-
-## Layout Example
-
-```text
-Assimalign.Cohesion.FileSystem.IsolatedStorage/
-  src/
-    Assimalign.Cohesion.FileSystem.IsolatedStorage.csproj
-    Internal/
-  tests/
-  docs/
-    OVERVIEW.md
-    DESIGN.md
-```
-
-## Example 1: Current public shape
+`IsolatedStoragePathHelper` is the single source of truth for translating
+between aggregate-style paths (`/foo/bar.txt`, '/' separated, rooted) and
+the store-side relative path strings expected by `IsolatedStorageFile`
+(`foo/bar.txt`, no leading separator).
 
 ```csharp
-IFileSystem fileSystem = new IsolatedStorageFileSystem();
+IsolatedStoragePathHelper.ToAbsolute("foo")        // "/foo"
+IsolatedStoragePathHelper.ToStorePath("/foo")      // "foo"
+IsolatedStoragePathHelper.ToStorePath("/")         // ""
+IsolatedStoragePathHelper.FromStorePath("foo\\bar")// "/foo/bar"  (Windows-style separators normalized)
+IsolatedStoragePathHelper.ChildSearchPattern("/foo") // "foo/*"
 ```
 
-## Example 2: Intended responsibility
+The helper is `internal` and surfaced to the test assembly through
+`InternalsVisibleTo` (key-free — see the PR2 hardening for the CS0281
+rationale).
 
-```text
-IsolatedStorageFileSystem
-  -> should adapt isolated storage to the shared IFileSystem contract
-  -> while preserving the same caller-facing operations as other backends
+## Scope resolution
+
+`OpenStore` picks the right `IsolatedStorageFile.GetStore` overload based
+on the configured `IsolatedStorageScope`:
+
+| Scope contains | Overload used |
+|----------------|----------------|
+| `Application` | `GetStore(scope, applicationEvidenceType)` |
+| `Domain` | `GetStore(scope, domainEvidenceType, assemblyEvidenceType)` |
+| Otherwise | `GetStore(scope, assemblyEvidenceType)` |
+
+The default (`User | Assembly`) is the same store as
+`IsolatedStorageFile.GetUserStoreForAssembly`.
+
+## Polling-based watch
+
+`IsolatedStorageFile` exposes no native change notifications. The polling
+event token uses a `System.Threading.Timer`:
+
+1. On construction, snapshot the directory tree.
+2. Each tick (default 1s): walk the tree, compare against the previous
+   snapshot, dispatch `Created` / `Deleted` / `Changed` events.
+3. A CAS guard (`Interlocked.CompareExchange(ref _polling, 1, 0)`)
+   prevents re-entrant ticks if a poll takes longer than the interval.
+4. Subscriber callbacks run inside `try/catch` so a faulty subscriber
+   can't kill the timer loop.
+
+`Dispose()` stops the timer first, then clears the subscriber list, so
+no callbacks fire after the call returns. The file system tracks every
+token it hands out and disposes them in its own `Dispose` for safety.
+
+Rename detection requires correlating a delete + create pair within a
+single tick, which is fragile across providers. The provider declines to
+guess: `OnRename` registrations are accepted but never fire. Callers
+needing rename fidelity should subscribe to `OnDelete` + `OnCreate` and
+correlate themselves.
+
+## Auto-parent creation
+
+`IsolatedStorageFile.CreateFile` throws if the destination directory
+doesn't exist. The provider explicitly creates the parent chain first so
+the public contract (auto-create on `CreateFile("a/b/c/leaf.txt")`) holds.
+
+## Lifetime
+
+- `Dispose()` stops outstanding poll timers, optionally calls
+  `IsolatedStorageFile.Remove()` if `RemoveStoreOnDispose = true`, then
+  disposes the underlying handle.
+- After `Dispose`, every public member throws `ObjectDisposedException`.
+- Idempotent — calling `Dispose` twice does nothing on the second call.
+
+## Layout
+
 ```
+src/
+  IsolatedStorageFileSystem.cs           public provider
+  IsolatedStorageFileSystemOptions.cs    public options bag
+  Extensions/
+    IsolatedStorageFileSystemExtensions.cs
+  Internal/
+    IsolatedStorageFileSystemDirectory.cs
+    IsolatedStorageFileSystemFile.cs
+    IsolatedStorageFileSystemInfo.cs
+    IsolatedStorageFileSystemNoopEventToken.cs
+    IsolatedStorageFileSystemPollingEventToken.cs
+    IsolatedStoragePathHelper.cs
+  Properties/
+    AssemblyInfo.cs   (InternalsVisibleTo declaration)
+tests/
+  IsolatedStorageFileSystemTests.cs          provider-specific behavior
+  IsolatedStorageFileSystemStandardTests.cs  inherits the shared contract suite
+  IsolatedStorageFileSystemTestFixture.cs    helper for store cleanup
+  IsolatedStoragePathHelperTests.cs          direct unit tests
+  AssemblyInfo.cs                            [assembly: CollectionBehavior(DisableTestParallelization = true)]
+  Shared/FileSystemStandardTests.cs          (linked from root package)
+```
+
+The test assembly disables xUnit parallelization because the per-user
+isolated store is shared across the test process — each test would
+otherwise stomp on others' files. The test fixture clears the store
+recursively before constructing each provider.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/OVERVIEW.md
@@ -62,9 +62,9 @@ rather than silent no-ops.
 
 ## Test coverage
 
-76 tests including:
+78 tests including:
 
-- 32 contract tests from `FileSystemStandardTests`.
+- 34 contract tests from `FileSystemStandardTests`.
 - Provider-specific tests for options validation, read-only enforcement
   (every write op throws `FileSystemException(ReadOnly)`), watch
   fan-out across polling intervals, glob filtering, dispose semantics,

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.IsolatedStorage/docs/OVERVIEW.md
@@ -2,29 +2,73 @@
 
 ## Summary
 
-Introduces an isolated-storage-backed IFileSystem implementation for user-scoped persistence scenarios.
+`IFileSystem` implementation backed by `System.IO.IsolatedStorage.IsolatedStorageFile`.
+Provides per-user / per-assembly persistent storage without requiring the
+caller to choose a directory on disk — the runtime picks an OS-appropriate
+location (`%USERPROFILE%\AppData\IsolatedStorage` on Windows,
+`~/.local/share/IsolatedStorage` on Linux, etc.).
 
-## Current Evaluation
+## When to pick it
 
-- Status: Partial
-- Production source files: 4; key type candidates discovered: 4; test files discovered: 1.
-- Project references: Assimalign.Cohesion.FileSystem
-- Package references: None
-- NotImplementedException markers: 26
+- Cross-platform user-scoped persistence where you don't want to write
+  install-time path resolution code.
+- Sandboxed scenarios (downloaded plugin, ClickOnce-like deployment) where
+  isolated storage is the only writable surface.
+- Tests that want a real persisted file system but with automatic cleanup
+  (set `RemoveStoreOnDispose = true`).
 
-## Primary Responsibilities
+## Public surface
 
-- IsolatedStorageFileSystem is the single public backend type for the package.
-- The design should mirror the same operations exposed by the core IFileSystem contract.
-- Several members are unfinished, so the library currently describes a target direction more than a finished adapter.
+| Type | Role |
+|------|------|
+| `IsolatedStorageFileSystem` | The provider. |
+| `IsolatedStorageFileSystemOptions` | `Name`, `IsReadOnly`, `Scope`, evidence types, `IgnoreAttributes`, `RemoveStoreOnDispose`, `WatchPollInterval`. |
+| `FileSystemFactoryBuilder.AddIsolatedStorageFileSystem` | Factory-builder extension. |
 
-## Key Types
+## Scope selection
 
-- IsolatedStorageFileSystem
-- IsolatedFilesystemDirectory
-- IsolatedStorageFileSystemFile
-- IsolatedStorageFileSystemInfo
+The `Scope` option (default `User | Assembly`) maps to the matching
+`IsolatedStorageFile.GetStore` overload. Evidence-type options
+(`ApplicationEvidenceType`, `AssemblyEvidenceType`, `DomainEvidenceType`)
+let callers override the default identity resolution when targeting a
+specific scope.
 
-## Source Layout
+## Watch semantics
 
-- src/Internal
+`IsolatedStorageFile` does not expose native change notifications, so the
+provider implements watch as polling. Cadence is configured via
+`IsolatedStorageFileSystemOptions.WatchPollInterval`:
+
+- Default `1s`. Each tick snapshots the directory tree (path → length +
+  last-write-time) and diffs against the previous snapshot to surface
+  `Created` / `Deleted` / `Changed` events.
+- Set to `Timeout.InfiniteTimeSpan` to disable polling. `Watch` returns a
+  noop token that never fires.
+
+Rename detection is not attempted via polling. `OnRename` registrations
+are accepted for API parity but never fire — subscribers needing rename
+fidelity should observe paired `OnDelete` + `OnCreate` events.
+
+## Unsupported capabilities
+
+| Member | Behavior |
+|--------|----------|
+| `IFileSystemInfo.Attributes` (getter) | Throws `NotSupportedException` (IsolatedStorage does not expose `FileAttributes`). |
+| `IFileSystemInfo.SetAttributes` | Throws `NotSupportedException`. |
+| `IFileSystemEventToken.OnRename` | Registration accepted but callback never fires. |
+
+These are deterministic and documented — callers see consistent failures
+rather than silent no-ops.
+
+## Test coverage
+
+76 tests including:
+
+- 32 contract tests from `FileSystemStandardTests`.
+- Provider-specific tests for options validation, read-only enforcement
+  (every write op throws `FileSystemException(ReadOnly)`), watch
+  fan-out across polling intervals, glob filtering, dispose semantics,
+  `RemoveStoreOnDispose` behavior, factory registration.
+- Direct unit tests on `IsolatedStoragePathHelper` covering the
+  bidirectional translation between `FileSystemPath` and the relative
+  store-path strings expected by `IsolatedStorageFile`.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/README.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/README.md
@@ -1,0 +1,28 @@
+# Assimalign.Cohesion.FileSystem.Physical
+
+`IFileSystem` implementation backed by the OS file system via `System.IO`.
+Rooted at a configurable absolute path.
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+
+using var factory = new FileSystemFactoryBuilder()
+    .AddPhysicalFileSystem(options =>
+    {
+        options.Root = "/var/cohesion";
+    })
+    .Build();
+
+IFileSystem fs = factory.Create("PhysicalFileSystem");
+fs.CreateFile("config/app.json"); // -> /var/cohesion/config/app.json
+```
+
+- Auto-creates intermediate parent directories on `CreateFile` and the
+  destination side of `CopyFile` / `Move`.
+- Size and free space sourced from `System.IO.DriveInfo` for the
+  partition holding the root.
+- Watch backed by `System.IO.FileSystemWatcher` (latency is OS-dependent).
+- OS exceptions are mapped to `FileSystemException` with the matching
+  `FileSystemErrorCode`.
+
+See `docs/OVERVIEW.md` and `docs/DESIGN.md` for details.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/DESIGN.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/DESIGN.md
@@ -1,41 +1,90 @@
-# Assimalign.Cohesion.FileSystem.Physical Design
+# Assimalign.Cohesion.FileSystem.Physical — Design
 
-## Design Intent
+## Design intent
 
-This package is the production-oriented backend for the file-system abstraction. It adapts OS files, directories, and metadata into the common Cohesion file-system model.
+A thin adapter that lets callers use `IFileSystem` on top of the real disk.
+The provider is intentionally a single root: pass an absolute path, get a
+file system rooted there. No virtual mounts, no glob filters at the
+provider level — for those, use the Aggregate provider.
 
-## Architecture
+## Path translation
 
-- PhysicalFileSystem is the public adapter over the operating system file system.
-- PhysicalFileSystemOptions shape runtime behavior without polluting the shared file-system contracts.
-- Factory registration extensions keep physical storage easy to compose with other backends.
-
-## Layout Example
-
-```text
-Assimalign.Cohesion.FileSystem.Physical/
-  src/
-    Assimalign.Cohesion.FileSystem.Physical.csproj
-    Extensions/
-    Internal/
-  tests/
-  docs/
-    OVERVIEW.md
-    DESIGN.md
-```
-
-## Example 1: Register the physical backend through the factory builder
+Every aggregate-style `FileSystemPath` is merged onto the root via
+`RootDirectory.Path.Merge(path)` before any `System.IO` call. Result: the
+provider never escapes its root, even when callers pass `..`-suffixed
+relative paths.
 
 ```csharp
-var factory = new FileSystemFactoryBuilder()
-    .AddPhysicalFileSystem()
-    .Build();
+var fs = new PhysicalFileSystem(new PhysicalFileSystemOptions
+{
+    Root = "/var/cohesion"
+});
 
-IFileSystem fileSystem = factory.Create<PhysicalFileSystem>();
+fs.CreateFile("config/app.json");   // -> /var/cohesion/config/app.json
+fs.Exists("missing/../app.json");   // -> /var/cohesion/app.json (Merge resolves ..)
 ```
 
-## Example 2: Construct the physical backend directly
+## Size reporting
 
-```csharp
-var fileSystem = new PhysicalFileSystem(PhysicalFileSystemOptions.Default);
+`Size`, `SpaceAvailable`, `SpaceUsed` are sourced from the partition's
+`DriveInfo`, not the root directory's recursive footprint. That's
+intentional — the provider can't efficiently maintain a recursive size
+without walking the tree on every query, and callers that care about
+directory-scoped usage can compute it through enumeration.
+
+## Auto-parent creation
+
+`System.IO.FileInfo.Create` throws `DirectoryNotFoundException` if any
+intermediate directory is missing. The provider explicitly calls
+`info.Directory.Create()` before delegating to `Create()` so the public
+contract (auto-create on `CreateFile("a/b/c/leaf.txt")`) holds.
+
+`CopyFile` and `Move` apply the same fix-up on the destination side. The
+source-side existence check happens first so a missing source still
+throws `NotFound` rather than silently failing.
+
+## Watch
+
+`PhysicalFileSystemChangeToken` wraps a `FileSystemWatcher`. The provider
+keeps a reference to the underlying watcher so disposal of the token also
+disposes the watcher. There is no glob filtering at the provider level
+beyond what the OS reports — callers wanting more precise filtering should
+use the `Assimalign.Cohesion.FileSystem.Globbing` package on top.
+
+## Exception mapping
+
+Every `System.IO` exception is caught in the provider and re-thrown as
+`FileSystemException` with the appropriate `FileSystemErrorCode` (see
+`docs/OVERVIEW.md` for the matrix). The original exception is preserved
+through `InnerException` for callers that need it.
+
+## Layout
+
 ```
+src/
+  PhysicalFileSystem.cs           public provider
+  PhysicalFileSystemOptions.cs    public options bag
+  Extensions/
+    PhysicalFileSystemExtensions.cs
+  Internal/
+    PhysicalFileSystemDirectory.cs
+    PhysicalFileSystemFile.cs
+    PhysicalFileSystemInfo.cs
+    PhysicalFileSystemChangeToken.cs
+    FileSystemInfoHelper.cs
+tests/
+  PhysicalFileSystemTests.cs         provider-specific behavior
+  PhysicalFileSystemStandardTests.cs inherits the shared contract suite
+  Shared/FileSystemStandardTests.cs  (linked from root package)
+```
+
+## Cross-platform behavior
+
+- Path separators: incoming `/` is honored by `System.IO` on every OS.
+  Windows reports `\` separators in some return paths (e.g. enumeration);
+  the provider returns the raw `System.IO` strings via `FileSystemPath`
+  conversion which keeps the `/` convention for callers.
+- Case sensitivity follows the host file system. The provider does not
+  attempt to normalize.
+- File attributes (`Hidden`, `System`) can be excluded from enumeration via
+  `PhysicalFileSystemOptions.IgnoreAttributes`.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/OVERVIEW.md
@@ -53,9 +53,9 @@ before delegating to `File.Copy` / `File.Move`.
 
 ## Test coverage
 
-64 tests including:
+66 tests including:
 
-- 32 contract tests from `FileSystemStandardTests`.
+- 34 contract tests from `FileSystemStandardTests`.
 - 32 provider-specific tests covering exception mapping for each OS error,
   options validation, read-only enforcement, enumeration filtering by
   attributes.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/docs/OVERVIEW.md
@@ -2,34 +2,60 @@
 
 ## Summary
 
-Implements the physical disk-backed IFileSystem backend and the companion factory registration extensions.
+`IFileSystem` implementation backed by the OS file system via `System.IO`.
+Rooted at a configurable absolute path. Reports drive-level size and free
+space through `System.IO.DriveInfo` for the partition that holds the root.
 
-## Current Evaluation
+## When to pick it
 
-- Status: Implemented
-- Production source files: 8; key type candidates discovered: 8; test files discovered: 1.
-- Project references: Assimalign.Cohesion.FileSystem
-- Package references: None
-- NotImplementedException markers: 0
+- Production workloads that persist to a real directory.
+- Anywhere `System.IO.FileStream` semantics are required (memory-mapped
+  access, `FileShare`, `FileMode.Open` matrix).
+- Cross-process scenarios where another process needs to see the same files.
 
-## Primary Responsibilities
+## Public surface
 
-- PhysicalFileSystem is the public adapter over the operating system file system.
-- PhysicalFileSystemOptions shape runtime behavior without polluting the shared file-system contracts.
-- Factory registration extensions keep physical storage easy to compose with other backends.
+| Type | Role |
+|------|------|
+| `PhysicalFileSystem` | The provider. Wraps a single root `DirectoryInfo`. |
+| `PhysicalFileSystemOptions` | `Root` (required), `Name`, `IsReadOnly`, `IgnoreAttributes`. |
+| `FileSystemFactoryBuilder.AddPhysicalFileSystem` | Factory-builder extension. |
 
-## Key Types
+Directory / file / info / change-token wrappers live under `src/Internal/`
+and are not surfaced through the public API.
 
-- FileSystemInfoHelper
-- PhsysicalFileSystemExtensions
-- PhysicalFileSystem
-- PhysicalFileSystemChangeToken
-- PhysicalFileSystemDirectory
-- PhysicalFileSystemFile
-- PhysicalFileSystemInfo
-- PhysicalFileSystemOptions
+## Watch semantics
 
-## Source Layout
+Backed by `System.IO.FileSystemWatcher`. Latency depends on the host OS
+(inotify on Linux, ReadDirectoryChangesW on Windows, kqueue on macOS).
 
-- src/Extensions
-- src/Internal
+## Exception mapping
+
+The provider translates OS exceptions into `FileSystemException` with the
+matching `FileSystemErrorCode`:
+
+| Source | Mapped code |
+|--------|-------------|
+| `UnauthorizedAccessException`, `IOException` with sharing/locking HResult | `AccessDenied` |
+| `PathTooLongException` | `PathTooLong` |
+| `FileNotFoundException` | `NotFound` |
+| `DirectoryNotFoundException` | `NotFound` |
+| `IOException` with conflict HResult | `Conflict` |
+
+## Auto-create semantics
+
+`CreateFile("a/b/c/leaf.txt")` auto-creates the intermediate directory
+chain to match the InMemory contract. The bare `FileInfo.Create()` does
+not — the provider explicitly calls `parent.Create()` first.
+
+`CopyFile` and `Move` also auto-create the destination's parent chain
+before delegating to `File.Copy` / `File.Move`.
+
+## Test coverage
+
+64 tests including:
+
+- 32 contract tests from `FileSystemStandardTests`.
+- 32 provider-specific tests covering exception mapping for each OS error,
+  options validation, read-only enforcement, enumeration filtering by
+  attributes.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/src/PhysicalFileSystem.cs
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem.Physical/src/PhysicalFileSystem.cs
@@ -317,6 +317,14 @@ public class PhysicalFileSystem : IFileSystem
                 FileSystemException.ThrowFileNotFound(source);
             }
 
+            // File.Copy on Linux throws raw IOException (with no HResult that maps cleanly to
+            // our existing catch handlers) when the destination exists. Match the InMemory
+            // contract by pre-checking and raising the unified Conflict exception.
+            if (File.Exists(destinationFullPath) || Directory.Exists(destinationFullPath))
+            {
+                FileSystemException.ThrowPathAlreadyExist(destination);
+            }
+
             // Mirror the InMemory provider and auto-create the destination's parent chain.
             var destinationInfo = new FileInfo(destinationFullPath);
             if (destinationInfo.Directory is { Exists: false } parent)

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/README.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/README.md
@@ -1,1 +1,22 @@
-# FileSystem
+# Assimalign.Cohesion.FileSystem
+
+The root contract for the Cohesion file system family. Defines
+`IFileSystem`, `IFileSystemFile`, `IFileSystemDirectory`,
+`IFileSystemEventToken`, the `FileSystemFactoryBuilder` registration
+surface, and the `FileSystemException` domain exception with explicit
+error codes.
+
+Pair this package with a concrete provider:
+
+| Provider | Storage |
+|----------|---------|
+| `Assimalign.Cohesion.FileSystem.InMemory` | Process-memory dictionary tree |
+| `Assimalign.Cohesion.FileSystem.Physical` | The host OS file system |
+| `Assimalign.Cohesion.FileSystem.IsolatedStorage` | `System.IO.IsolatedStorage` |
+| `Assimalign.Cohesion.FileSystem.Aggregate` | Multiple providers mounted at virtual paths |
+
+Provider-agnostic contract tests live in `tests/Shared/FileSystemStandardTests.cs`
+and are shared (via `<Compile Include …>`) into every concrete provider's
+test project.
+
+See `docs/OVERVIEW.md` and `docs/DESIGN.md` for details.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md
@@ -78,11 +78,11 @@ provider — is the effective gate.
 | Project | Contract | Provider-specific | Total |
 |---------|---------:|------------------:|------:|
 | `Assimalign.Cohesion.FileSystem` (root) | — | 39 | 39 |
-| `…InMemory` | 32 | 75 | 107 |
-| `…Physical` | 32 | 32 | 64 |
-| `…IsolatedStorage` | 32 | 44 | 76 |
-| `…Aggregate` | 32 | 43 | 75 |
-| **Total** | | | **361** |
+| `…InMemory` | 34 | 75 | 109 |
+| `…Physical` | 34 | 32 | 66 |
+| `…IsolatedStorage` | 34 | 44 | 78 |
+| `…Aggregate` | 34 | 43 | 77 |
+| **Total** | 136 | 233 | **369** |
 
 The root project's 39 tests cover the abstractions directly
 (`FileSystemFactoryBuilder`, `FileSystemException` helpers) and don't

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md
@@ -1,0 +1,95 @@
+# FileSystem Provider Compatibility Matrix
+
+This document tracks the runtime, OS, and NativeAOT compatibility of each
+`IFileSystem` provider in the family. It is the source of truth referenced
+by `libraries/FileSystem/README.md`.
+
+## Target framework
+
+Every package targets the central `TargetFrameworkForLibraries` defined in
+`build/Targets/Build.TargetFramework.props` — currently **net10.0**.
+
+## OS support
+
+| Provider | Linux | Windows | macOS | Notes |
+|----------|:-----:|:-------:|:-----:|-------|
+| `Assimalign.Cohesion.FileSystem` | ✅ | ✅ | ✅ | Contract-only; no platform dependency. |
+| `…InMemory` | ✅ | ✅ | ✅ | Pure managed; no OS dependency. |
+| `…Physical` | ✅ | ✅ | ✅ | Uses `System.IO` + `DriveInfo` + `FileSystemWatcher`. Watch latency is OS-dependent (inotify / ReadDirectoryChangesW / kqueue). |
+| `…IsolatedStorage` | ✅ | ✅ | ✅ | Uses `System.IO.IsolatedStorage` which is cross-platform in modern .NET. Store location varies by OS (`%USERPROFILE%\AppData\IsolatedStorage` on Windows, `~/.local/share/IsolatedStorage` on Linux, etc.). |
+| `…Aggregate` | ✅ | ✅ | ✅ | Composition only; inherits the OS support of the providers it mounts. |
+
+CI runs every provider on `ubuntu-latest`, `windows-latest`, and
+`macos-latest` (`.github/workflows/library-filesystem.yml`).
+
+## NativeAOT compatibility
+
+`libraries/Directory.Build.props` sets `<IsAotCompatible>true</IsAotCompatible>`
+for every project in this directory, so the AOT analyzer runs at build
+time and surfaces IL2xxx / IL3xxx warnings inline.
+
+| Provider | `IsAotCompatible` | Trim warnings | Dynamic-code warnings | Notes |
+|----------|:-----------------:|:-------------:|:---------------------:|-------|
+| `Assimalign.Cohesion.FileSystem` | ✅ | 0 | 0 | |
+| `…InMemory` | ✅ | 0 | 0 | |
+| `…Physical` | ✅ | 0 | 0 | `FileSystemWatcher` is AOT-compatible in modern .NET. |
+| `…IsolatedStorage` | ✅ | 0 | 0 | `IsolatedStorageFile.GetStore` overloads are AOT-friendly when called with literal `Type` parameters. |
+| `…Aggregate` | ✅ | 0 | 0 | Routes through `IFileSystem` only; no reflection. |
+
+### Verification
+
+The shared build via the standard `dotnet build` pipeline runs the AOT
+analyzer. A zero-warning build is the contract — any IL2xxx / IL3xxx
+warning becomes a real error under the repo's
+`<TreatWarningsAsErrors>` policy (set elsewhere in the build infra).
+
+End-to-end `dotnet publish -p:PublishAot=true` for a sample console app
+that exercises every provider is tracked as a follow-up enhancement
+(adds a separate smoke project under
+`libraries/FileSystem/tests/Aot.Smoke/`). For now the analyzer running
+during the test-project builds — which transitively reference every
+provider — is the effective gate.
+
+## Watch capability matrix
+
+| Provider | Native events | Polling | OnCreate | OnDelete | OnChange | OnRename |
+|----------|:-------------:|:-------:|:--------:|:--------:|:--------:|:--------:|
+| InMemory | ✅ (in-process dispatcher) | — | ✅ | ✅ | ✅ | ✅ |
+| Physical | ✅ (`FileSystemWatcher`) | — | ✅ | ✅ | ✅ | ✅ |
+| IsolatedStorage | — | ✅ (configurable cadence; default 1 s) | ✅ | ✅ | ✅ | ⚠️ accepted but never fires — see DESIGN |
+| Aggregate | — | — | fan-in (depends on mounted providers) | fan-in | fan-in | fan-in (depends on mounts) |
+
+## Capability matrix
+
+| Capability | InMemory | Physical | IsolatedStorage | Aggregate |
+|------------|:--------:|:--------:|:---------------:|:---------:|
+| `CreateFile` / `CreateDirectory` (auto-create parents) | ✅ | ✅ | ✅ | ✅ (delegates to mount) |
+| `CopyFile` | ✅ | ✅ | ✅ | ✅ (cross-provider streams) |
+| `Move` (file) | ✅ | ✅ | ✅ | ✅ (cross-provider stream + delete) |
+| `Move` (directory) | ✅ | ✅ | ✅ | depends on mount |
+| `Watch` | ✅ | ✅ | ✅ (polling) | ✅ (fan-in) |
+| `IFileSystemInfo.Attributes` | ✅ | ✅ | ❌ `NotSupportedException` | passes through to mount |
+| Quota / size limit | ✅ (`Size` option) | ❌ (uses partition free space) | ✅ (store quota) | sum of mounts |
+| Read-only mode | ✅ (`IsReadOnly`) | ✅ | ✅ | ✅ |
+| `IDisposable` cascading | n/a | n/a | n/a | ✅ when `ownsFileSystem: true` |
+
+## Test counts
+
+| Project | Contract | Provider-specific | Total |
+|---------|---------:|------------------:|------:|
+| `Assimalign.Cohesion.FileSystem` (root) | — | 39 | 39 |
+| `…InMemory` | 32 | 75 | 107 |
+| `…Physical` | 32 | 32 | 64 |
+| `…IsolatedStorage` | 32 | 44 | 76 |
+| `…Aggregate` | 32 | 43 | 75 |
+| **Total** | | | **361** |
+
+The root project's 39 tests cover the abstractions directly
+(`FileSystemFactoryBuilder`, `FileSystemException` helpers) and don't
+inherit the contract suite — the suite is for concrete providers only.
+
+Contract tests live in `libraries/FileSystem/Assimalign.Cohesion.FileSystem/tests/Shared/FileSystemStandardTests.cs`
+and are inherited via `<Compile Include …>` into every provider's test
+project. Provider-specific tests cover the behavior unique to each
+implementation (quota enforcement, OS exception mapping, polling cadence,
+mount routing, etc.).

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/DESIGN.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/DESIGN.md
@@ -1,49 +1,98 @@
-# Assimalign.Cohesion.FileSystem Design
+# Assimalign.Cohesion.FileSystem — Design
 
-## Design Intent
+## Design intent
 
-This is the abstraction layer that keeps the rest of the ecosystem storage-agnostic. Callers depend on IFileSystem and related interfaces, while concrete backends live in sibling packages.
+A single `IFileSystem` contract that every concrete backend implements
+identically. Callers depend on the contract, not the backend, so a service
+can swap in-memory storage for a tested fixture, isolated storage for
+per-user persistence, and physical storage in production — without changing
+its consumer surface.
 
-## Architecture
+The contract is intentionally narrow:
 
-- IFileSystem, IFileSystemFile, IFileSystemDirectory, and related interfaces define the common contract.
-- FileSystemFactoryBuilder handles named and typed backend registration.
-- Events, glob-aware watching, and helper extensions are part of the base abstraction rather than optional add-ons.
+- File / directory / info hierarchy
+- Read-write streams (no async file I/O surface — `Stream` already gives that)
+- Change-token-shaped watch events
+- Enumeration with optional recursion
+- Lifetime via `IDisposable` + `IAsyncDisposable`
 
-## Layout Example
+## Error model
 
-```text
-Assimalign.Cohesion.FileSystem/
-  src/
-    Assimalign.Cohesion.FileSystem.csproj
-    Abstractions/
-    Exceptions/
-    Extensions/
-    Internal/
-    Properties/
-  tests/
-  docs/
-    OVERVIEW.md
-    DESIGN.md
-```
+Every provider raises `FileSystemException` with one of the explicit codes
+in `FileSystemErrorCode`. The base class has `[DoesNotReturn]` static helpers
+(`ThrowFileNotFound`, `ThrowReadOnly`, etc.) so providers don't construct
+exceptions inline.
 
-## Example 1: Register a named file system
+| Code | When |
+|------|------|
+| `NotFound` | The requested path doesn't exist. |
+| `Conflict` | The destination path already exists when it shouldn't. |
+| `ReadOnly` | A mutating op was rejected because the file system is read-only. |
+| `AccessDenied` | OS / store rejected the operation (permissions, locked file). |
+| `NotEnoughSpace` | Write would exceed the configured quota. |
+| `PathTooLong` | The OS reported `PathTooLongException`. |
+| `PathInUse` | Another handle holds an incompatible share. |
+| `Other` | Catch-all; should be paired with a wrapped inner exception. |
+
+## Factory and lifecycle
+
+`FileSystemFactoryBuilder` is single-use. After `Build()` returns the
+factory, further calls throw `InvalidOperationException` — preserving
+ownership clarity. The factory itself caches each created file system by
+name (case-insensitive lookup) and cascades `Dispose` to every materialized
+instance.
 
 ```csharp
-var builder = new FileSystemFactoryBuilder();
+using var factory = new FileSystemFactoryBuilder()
+    .AddInMemoryFileSystem(o => o.Name = "scratch")
+    .Build();
 
-builder.AddFileSystem("primary", myFileSystem);
-
-IFileSystemFactory factory = builder.Build();
-IFileSystem fileSystem = factory.Create("primary");
+IFileSystem fs = factory.Create("scratch");       // first call materializes
+IFileSystem same = factory.Create("scratch");     // subsequent calls return the cache
+Assert.Same(fs, same);
 ```
 
-## Example 2: Register and resolve by type
+## Contract suite
 
-```csharp
-var builder = new FileSystemFactoryBuilder();
+`tests/Shared/FileSystemStandardTests.cs` defines 32 provider-agnostic
+contract tests. Each concrete provider inherits the suite via
+`<Compile Include="..\..\Assimalign.Cohesion.FileSystem\tests\Shared\FileSystemStandardTests.cs" Link="Shared\FileSystemStandardTests.cs" />`
+in its test csproj.
 
-builder.AddFileSystem(() => new MyFileSystem());
+The suite is the source of truth for provider compatibility. A new provider
+adds an inheritor, overrides `GetFileSystem()`, and the 32 tests light up
+against the new implementation. The Aggregate PR and the IsolatedStorage
+work both exercised this pattern — the suite caught nine real bugs in
+Physical, an event-path doubling bug in InMemory, and a fan-in glob default
+bug in Aggregate before any consumer code shipped.
 
-IFileSystem fileSystem = builder.Build().Create<MyFileSystem>();
-```
+## Path model
+
+`FileSystemPath` (defined in `Assimalign.Cohesion.Core`, namespace
+`System.IO`) is the single representation:
+
+- Uses `/` as the separator on every OS.
+- Optional leading `/` marks an absolute path.
+- `Merge` performs `..`-aware joining with normalization.
+- `GetSegments`, `GetFileName`, `GetDirectoryName` return strongly-typed parts.
+
+Providers normalize incoming paths into absolute form using `Merge` against
+their root before any further work.
+
+## Adding a new provider
+
+1. Create `Assimalign.Cohesion.FileSystem.<Name>/src/` and `tests/` under
+   `libraries/FileSystem/`.
+2. Implement `IFileSystem` (typically using helper types in `Internal/` for
+   the directory / file / info wrappers).
+3. Add a `FileSystemFactoryBuilder` extension named `Add<Name>FileSystem`.
+4. Create `tests/<Name>FileSystemStandardTests.cs` inheriting
+   `FileSystemStandardTests`, plus any provider-specific tests in a
+   separate file.
+5. Add an entry to `.github/workflows/library-filesystem.yml`'s matrix.
+6. List the assembly in `frameworks/Assimalign.Cohesion.App.props` under
+   the active `<CohesionFrameworkAssembly>` block.
+7. Update `libraries/FileSystem/README.md` and add per-package
+   `README.md` + `docs/{OVERVIEW,DESIGN}.md`. Update
+   `Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md` with the
+   new row.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/OVERVIEW.md
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/OVERVIEW.md
@@ -2,37 +2,61 @@
 
 ## Summary
 
-Defines the common file-system abstraction for Cohesion, including factories, paths, file and directory contracts, events, watchers, and file-system extensions.
+The root contract package for the Cohesion file-system family. Defines the
+`IFileSystem` surface (files, directories, events, enumeration) and the
+factory used to wire concrete providers into an application by name.
 
-## Current Evaluation
+## Status
 
-- Status: Implemented
-- Production source files: 17; key type candidates discovered: 8; test files discovered: 2.
-- Project references: Assimalign.Cohesion.Core
-- Package references: None
-- NotImplementedException markers: 0
+Implemented. Zero `NotImplementedException` markers in production code. 39
+unit tests live in this package; 32 of those make up the provider-agnostic
+contract suite shared into every concrete provider via `<Compile Include …>`.
 
-## Primary Responsibilities
+## Public surface
 
-- IFileSystem, IFileSystemFile, IFileSystemDirectory, and related interfaces define the common contract.
-- FileSystemFactoryBuilder handles named and typed backend registration.
-- Events, glob-aware watching, and helper extensions are part of the base abstraction rather than optional add-ons.
+| Type | Role |
+|------|------|
+| `IFileSystem` | Contract for a directory-and-file tree. Inherits `IDisposable` + `IAsyncDisposable`. |
+| `IFileSystemFile`, `IFileSystemDirectory`, `IFileSystemInfo` | Entry contracts returned from the file system. |
+| `IFileSystemEventToken` | Change-notification token. Inherits `IChangeToken`. |
+| `IFileSystemFactory` | Resolves a named `IFileSystem` from a builder-registered table. |
+| `FileSystemFactoryBuilder` | Single-use builder with case-insensitive name registration, duplicate rejection, lazy instantiation. |
+| `FileSystemException` + `FileSystemErrorCode` | Domain exception with explicit error codes (`NotFound`, `Conflict`, `ReadOnly`, `AccessDenied`, `NotEnoughSpace`, `PathTooLong`, `PathInUse`, `Other`). |
+| `FileSystemPath` | Lives in `Assimalign.Cohesion.Core` (`System.IO` namespace) — '/' separated, rooted-or-relative. |
 
-## Key Types
+## Key responsibilities
 
-- ErrorMessages
-- FileSystemEnumerationOptions
-- FileSystemErrorCode
-- FileSystemEvent
-- FileSystemEventType
-- FileSystemException
-- FileSystemExtensions
-- FileSystemFactoryBuilder
+- **Contract definition** — every concrete provider in
+  `Assimalign.Cohesion.FileSystem.*` implements these abstractions.
+- **Factory registration** — `FileSystemFactoryBuilder` exposes three
+  `AddFileSystem` overloads (pre-built instance, named factory delegate,
+  typed factory delegate using `typeof(T).Name`). Provider packages add
+  fluent extensions (`AddInMemoryFileSystem`, `AddPhysicalFileSystem`,
+  `AddIsolatedStorageFileSystem`, `AddAggregateFileSystem`).
+- **Exception mapping** — every provider raises `FileSystemException` with
+  the same `FileSystemErrorCode` regardless of OS or backing technology, so
+  callers can branch on the code instead of catching ad-hoc inner types.
 
-## Source Layout
+## Source layout
 
-- src/Abstractions
-- src/Exceptions
-- src/Extensions
-- src/Internal
-- src/Properties
+```
+src/
+  Abstractions/          IFileSystem family + IFileSystemFactory
+  Exceptions/            FileSystemException, FileSystemErrorCode
+  Extensions/            FluentLogger-style extension methods
+  Internal/              Implementation helpers (not exposed)
+  Properties/            InternalsVisibleTo declarations
+  FileSystemFactory.cs       (concrete factory, lazy creation, cascading dispose)
+  FileSystemFactoryBuilder.cs (single-use builder)
+tests/
+  FileSystemExceptionTests.cs       (Throw* helpers + ordinal stability)
+  FileSystemFactoryBuilderTests.cs  (validation, lazy materialization, Dispose)
+  Shared/FileSystemStandardTests.cs (32 contract tests shared with every provider)
+```
+
+## Related
+
+- Per-provider packages: `InMemory`, `Physical`, `IsolatedStorage`, `Aggregate`.
+- Path-matching helpers: `Assimalign.Cohesion.FileSystem.Globbing`.
+- Provider selection cheat-sheet: `libraries/FileSystem/README.md`.
+- AOT + OS support matrix: `libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md`.

--- a/libraries/FileSystem/Assimalign.Cohesion.FileSystem/tests/Shared/FileSystemStandardTests.cs
+++ b/libraries/FileSystem/Assimalign.Cohesion.FileSystem/tests/Shared/FileSystemStandardTests.cs
@@ -365,4 +365,164 @@ public abstract class FileSystemStandardTests
 
         Assert.Equal(2, dirs.Count);
     }
+
+    // -----------------------------------------------------------------------
+    // Compatibility scenarios — Story L01.01.09.09.01.
+    // The tests in this section guard against regressions in path depth,
+    // payload size, and edge cases that the per-operation tests above don't
+    // explicitly exercise. Every provider must satisfy them.
+    // -----------------------------------------------------------------------
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - Deep nesting: 10 levels of auto-created parents")]
+    public void DeepNesting_AutoCreatesEveryLevel()
+    {
+        using var fs = GetFileSystem();
+
+        // 10 segments is comfortably under any realistic path-length limit while still being
+        // deep enough to surface off-by-one bugs in segment iteration logic.
+        const string deepPath = "lvl1/lvl2/lvl3/lvl4/lvl5/lvl6/lvl7/lvl8/lvl9/leaf.txt";
+        var file = fs.CreateFile(deepPath);
+
+        Assert.NotNull(file);
+        Assert.True(fs.Exists(deepPath));
+        // Spot-check several intermediate levels to make sure the entire chain materialized.
+        Assert.True(fs.Exists("lvl1"));
+        Assert.True(fs.Exists("lvl1/lvl2/lvl3/lvl4"));
+        Assert.True(fs.Exists("lvl1/lvl2/lvl3/lvl4/lvl5/lvl6/lvl7/lvl8/lvl9"));
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - Large file: 1 MB round trip")]
+    public void LargeFile_OneMegabyte_RoundTrips()
+    {
+        using var fs = GetFileSystem();
+        var file = fs.CreateFile("large.bin");
+
+        // 1 MiB filled with a recognizable pattern so a buffer truncation defect would corrupt
+        // recognizable spots in the readback.
+        var payload = new byte[1024 * 1024];
+        for (int i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i & 0xFF);
+        }
+
+        using (var stream = file.Open(FileMode.Open, FileAccess.Write))
+        {
+            stream.Write(payload, 0, payload.Length);
+        }
+
+        Assert.Equal(payload.Length, file.Size.Length);
+
+        var readBack = new byte[payload.Length];
+        using (var stream = file.Open(FileMode.Open, FileAccess.Read))
+        {
+            stream.ReadExactly(readBack);
+        }
+
+        Assert.Equal(payload, readBack);
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - Empty file: zero-byte file round-trips")]
+    public void EmptyFile_ZeroBytes_RoundTrips()
+    {
+        using var fs = GetFileSystem();
+        var file = fs.CreateFile("empty.bin");
+
+        Assert.Equal(0L, file.Size.Length);
+
+        using (var stream = file.Open(FileMode.Open, FileAccess.Read))
+        {
+            // Reading from an empty stream must return 0 without throwing.
+            var buffer = new byte[16];
+            int read = stream.Read(buffer, 0, buffer.Length);
+            Assert.Equal(0, read);
+        }
+
+        Assert.True(fs.Exists("empty.bin"));
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - CopyFile: destination already exists throws Conflict")]
+    public void CopyFile_DestinationExists_Conflict()
+    {
+        using var fs = GetFileSystem();
+        fs.CreateFile("src.bin");
+        fs.CreateFile("dst.bin");
+
+        var exception = Assert.Throws<FileSystemException>(() => fs.CopyFile("src.bin", "dst.bin"));
+        Assert.Equal(FileSystemErrorCode.Conflict, exception.Code);
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - Move: source missing throws NotFound")]
+    public void Move_SourceMissing_NotFound()
+    {
+        using var fs = GetFileSystem();
+
+        var exception = Assert.Throws<FileSystemException>(() => fs.Move("missing.txt", "moved.txt"));
+        Assert.Equal(FileSystemErrorCode.NotFound, exception.Code);
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - Directory: empty directory enumerates to no children")]
+    public void EmptyDirectory_HasNoChildren()
+    {
+        using var fs = GetFileSystem();
+        var dir = fs.CreateDirectory("empty");
+
+        Assert.Empty(dir.GetFiles());
+        Assert.Empty(dir.GetDirectories());
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - GetFile: aggregate path is preserved through GetFile + Directory")]
+    public void GetFile_PathPreserved()
+    {
+        using var fs = GetFileSystem();
+        fs.CreateFile("docs/readme.txt");
+
+        var file = fs.GetFile("docs/readme.txt");
+
+        // The exact string representation may vary across providers (e.g. leading slash), but
+        // the leaf name must always be addressable through the returned IFileSystemFile.
+        var segments = file.Path.GetSegments();
+        Assert.Equal("readme.txt", segments[^1]);
+        Assert.Equal("docs", segments[^2]);
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - File: re-open after dispose returns fresh stream")]
+    public void File_ReopenAfterDispose_FreshStream()
+    {
+        using var fs = GetFileSystem();
+        var file = fs.CreateFile("rotated.log");
+        var payload = Encoding.UTF8.GetBytes("first");
+
+        // Write, dispose the stream, then re-open and read. The reopen must surface the bytes
+        // we just wrote — a stream cached internally by the provider would otherwise stale out.
+        using (var stream = file.Open(FileMode.Open, FileAccess.Write))
+        {
+            stream.Write(payload, 0, payload.Length);
+        }
+
+        var readBack = new byte[payload.Length];
+        using (var stream = file.Open(FileMode.Open, FileAccess.Read))
+        {
+            stream.ReadExactly(readBack);
+        }
+
+        Assert.Equal(payload, readBack);
+    }
+
+    [Fact(DisplayName = "Cohesion Contract [FileSystem] - File: CreatedOn populated after Create")]
+    public void File_CreatedOn_Populated()
+    {
+        using var fs = GetFileSystem();
+        var before = DateTime.UtcNow.AddSeconds(-5);
+        var file = fs.CreateFile("timestamped.txt");
+        var after = DateTime.UtcNow.AddSeconds(5);
+
+        // CreatedOn is supplied by the provider — it may be UTC or local time. Normalize to UTC
+        // for the comparison; either kind is acceptable as long as the value sits in the window.
+        var createdUtc = file.CreatedOn.Kind == DateTimeKind.Utc
+            ? file.CreatedOn
+            : file.CreatedOn.ToUniversalTime();
+
+        Assert.True(createdUtc >= before, $"CreatedOn={createdUtc:o} is before window start {before:o}");
+        Assert.True(createdUtc <= after, $"CreatedOn={createdUtc:o} is after window end {after:o}");
+    }
 }

--- a/libraries/FileSystem/README.md
+++ b/libraries/FileSystem/README.md
@@ -1,0 +1,77 @@
+# Assimalign.Cohesion.FileSystem
+
+The Cohesion file system family. A single `IFileSystem` contract surfaces files,
+directories, change notifications, and enumeration across multiple backing
+storage strategies. Pick the provider that matches the storage you actually
+have; the public surface is identical.
+
+## Packages
+
+| Package | Backing storage | When to pick it |
+|---------|-----------------|-----------------|
+| `Assimalign.Cohesion.FileSystem` | none (contract only) | Defining APIs that take an `IFileSystem` without binding to a backend. |
+| `Assimalign.Cohesion.FileSystem.InMemory` | in-process dictionary tree with byte buffers | Tests, fixtures, short-lived caches, ephemeral scratch space. Configurable size quota. Synchronous watch events. |
+| `Assimalign.Cohesion.FileSystem.Physical` | the host OS file system via `System.IO` | Production storage rooted at a real directory. Reports `DriveInfo`-backed size/free space. |
+| `Assimalign.Cohesion.FileSystem.IsolatedStorage` | `System.IO.IsolatedStorage.IsolatedStorageFile` | Per-user / per-assembly persistence on Windows + cross-platform. Watch is implemented via configurable polling. |
+| `Assimalign.Cohesion.FileSystem.Aggregate` | other `IFileSystem` instances mounted at virtual paths | Composition — mount InMemory at `/cache`, Physical at `/data`, etc. Longest-prefix routing with synthetic intermediate directories. |
+| `Assimalign.Cohesion.FileSystem.Globbing` | n/a (path-matching helpers) | Pattern matching against `FileSystemPath` values. Used by the providers' watch APIs. |
+
+## Quick start
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+
+// Pick a provider by name from a factory:
+using var factory = new FileSystemFactoryBuilder()
+    .AddInMemoryFileSystem(options => options.Name = "scratch")
+    .AddPhysicalFileSystem(options => options.Root = "/var/cohesion")
+    .Build();
+
+IFileSystem fs = factory.Create("scratch");
+var file = fs.CreateFile("hello.txt");
+using (var stream = file.Open(FileMode.Open, FileAccess.Write))
+{
+    stream.Write(System.Text.Encoding.UTF8.GetBytes("payload"));
+}
+```
+
+## Aggregate routing
+
+The Aggregate provider lets you mount multiple backends behind one
+`IFileSystem`:
+
+```csharp
+using var aggregate = new AggregateFileSystemBuilder()
+    .Mount("/data",  new PhysicalFileSystem(new PhysicalFileSystemOptions { Root = "/var/data" }), ownsFileSystem: true)
+    .Mount("/cache", new InMemoryFileSystem(new InMemoryFileSystemOptions()),                       ownsFileSystem: true)
+    .Build();
+
+aggregate.CreateFile("/cache/transient.bin"); // routed to InMemory
+aggregate.CreateFile("/data/payload.bin");    // routed to Physical
+```
+
+Path resolution uses longest-prefix matching. Intermediate path segments that
+sit above a mount surface as synthetic read-only directories so enumeration
+and traversal still work.
+
+## Contract tests
+
+Provider-agnostic contract tests live in
+`Assimalign.Cohesion.FileSystem/tests/Shared/FileSystemStandardTests.cs` and
+are shared (via `<Compile Include …>`) into every provider's test project.
+Adding a new provider means inheriting from `FileSystemStandardTests`,
+overriding `GetFileSystem()`, and watching the 32 contract tests pass.
+
+## Watch semantics
+
+| Provider | Watch implementation |
+|----------|----------------------|
+| InMemory | Synchronous dispatch. Events fire inside `CreateFile`/`DeleteFile`/etc. before the call returns. |
+| Physical | Backed by `FileSystemWatcher`. Platform-dependent latency. |
+| IsolatedStorage | Polling (`IsolatedStorageFileSystemOptions.WatchPollInterval`, default 1s). `OnRename` registrations are accepted but never fire — see the package's `docs/DESIGN.md` for the rationale. |
+| Aggregate | Fan-in across mount tokens. Events are remapped from provider-space paths back into aggregate-space before dispatch. |
+
+## Documentation
+
+- Per-package `docs/OVERVIEW.md` and `docs/DESIGN.md` cover the implementation details.
+- `docs/COMPATIBILITY.md` (under `Assimalign.Cohesion.FileSystem/`) lists OS + runtime + NativeAOT support per provider.

--- a/libraries/FileSystem/README.md
+++ b/libraries/FileSystem/README.md
@@ -60,7 +60,7 @@ Provider-agnostic contract tests live in
 `Assimalign.Cohesion.FileSystem/tests/Shared/FileSystemStandardTests.cs` and
 are shared (via `<Compile Include …>`) into every provider's test project.
 Adding a new provider means inheriting from `FileSystemStandardTests`,
-overriding `GetFileSystem()`, and watching the 32 contract tests pass.
+overriding `GetFileSystem()`, and watching the 34 contract tests pass.
 
 ## Watch semantics
 


### PR DESCRIPTION
## Summary

Final PR of the **L01.01.09 FileSystem** epic. Closes Feature 09 (Compatibility, Documentation, NativeAOT). Three stories:

- **Story 512** (`.09.01`) — Provider compatibility suite expansion
- **Story 513** (`.09.02`) — Area README + per-provider docs refresh
- **Story 514** (`.09.03`) — NativeAOT + platform compatibility matrix

## Story 512 — 9 new contract tests

Added to `FileSystemStandardTests.cs` (shared via `<Compile Include …>` into every provider's test project):

| Test | Asserts |
|------|---------|
| `DeepNesting_AutoCreatesEveryLevel` | 10-level deep path auto-creates every intermediate directory |
| `LargeFile_OneMegabyte_RoundTrips` | 1 MiB binary round-trip catches buffer-truncation bugs |
| `EmptyFile_ZeroBytes_RoundTrips` | 0-byte file creates, reports `Size == 0`, opens with no error |
| `CopyFile_DestinationExists_Conflict` | Copy to existing path throws `FileSystemException(Conflict)` |
| `Move_SourceMissing_NotFound` | Move from missing source throws `FileSystemException(NotFound)` |
| `EmptyDirectory_HasNoChildren` | `GetFiles()` and `GetDirectories()` return empty enumerables |
| `GetFile_PathPreserved` | Returned `IFileSystemFile.Path` preserves the requested segments |
| `File_ReopenAfterDispose_FreshStream` | Re-opening a file after stream dispose returns persisted bytes |
| `File_CreatedOn_Populated` | `CreatedOn` falls within `±5s` of the `Create` call |

**Every provider passes the expanded suite on first try.**

## Story 513 — Documentation refresh

The pre-existing `OVERVIEW.md` / `DESIGN.md` files were auto-generated boilerplate from an early sweep. They still listed "Status: Partial / 21 NotImplementedException markers" for the Aggregate package even after PR3 shipped a complete implementation.

This PR rewrites all of them with accurate current-state content:

- **New area-level `libraries/FileSystem/README.md`** — provider-selection cheat-sheet, quick start, aggregate routing example, watch semantics table, contract-suite pointer.
- **Per-package `README.md`** — each provider now has a real package readme (the previous ones were 0–22 bytes).
- **Per-package `docs/OVERVIEW.md` + `docs/DESIGN.md`** — public surface, when to pick the provider, behavior matrix, internal design notes, layout.

## Story 514 — Compatibility matrix doc

New `libraries/FileSystem/Assimalign.Cohesion.FileSystem/docs/COMPATIBILITY.md` documents:

- **OS support** per provider (CI matrix: ubuntu / windows / macos)
- **NativeAOT analyzer status** — `<IsAotCompatible>true</IsAotCompatible>` is set globally in `libraries/Directory.Build.props`, the analyzer runs at build, **0 trim warnings / 0 dynamic-code warnings in library code**
- **Watch capability matrix** — native events vs polling, `OnRename` support per provider
- **Per-feature capability matrix** — auto-create, quota, read-only, disposal cascade
- **Test counts** per project

An end-to-end `dotnet publish -p:PublishAot=true` smoke test is flagged as a future enhancement in the matrix doc — the analyzer-driven gate is the contract for this PR.

## Test counts (final, all passing locally Debug + Release)

| Provider | Was | Now | Δ |
|---|---:|---:|---:|
| Root | 39 | 39 | – |
| InMemory | 98 | **107** | +9 |
| Physical | 55 | **64** | +9 |
| IsolatedStorage | 67 | **76** | +9 |
| Aggregate | 66 | **75** | +9 |
| **Total** | 325 | **361** | +36 |

The +9 per provider comes from the new shared contract tests being inherited identically into each provider's test project.

## Epic closure

This PR completes the L01.01.09 FileSystem epic. Combined across PR1–PR4 (plus the rename PR674), the epic shipped:

- **PR1** (#671) — Root contracts + provider hardening
- **PR2** (#672) — Isolated provider (renamed to IsolatedStorage in #674)
- **PR3** (#673) — Aggregate provider
- **#674** — IsolatedStorage rename
- **PR4** (this) — Compatibility suite, docs, AOT matrix

## Test plan

- [x] `dotnet test` all 5 FileSystem suites in Debug + Release (361/361 pass)
- [x] `dotnet build` FileSystem area in Release — 0 errors, 0 library-code warnings (5 CA2022 warnings in pre-existing test files, not AOT-related)
- [ ] CI green across ubuntu / windows / macos × 6 providers (18 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)