### PR TITLE
feat(dns): wire format + EDNS (L01.01.08 PR2)

### DIFF
--- a/libraries/Dns/Assimalign.Cohesion.Dns/docs/DESIGN.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/docs/DESIGN.md
@@ -118,17 +118,49 @@ the dedicated codes for the specific failure mode.
 
 ## Wire-format scope
 
-`DnsMessage` is currently a placeholder. PR 2 (Feature 03) will:
+`DnsMessage` exposes the full RFC 1035 §4 binary read/write surface:
 
-1. Add the binary read/write surface — `DnsMessage.Parse(ReadOnlySpan<byte>)`
-   and `DnsMessage.TryWriteTo(Span<byte>, out int written)`.
-2. Implement RFC 1035 §4 name compression on both sides.
-3. Add strongly-typed `DnsRecord` subclasses for A / AAAA / CNAME / MX /
-   TXT / NS / SOA / PTR / SRV / OPT.
-4. Build a golden-corpus test against well-known packets so any future
-   change has to round-trip the same bytes.
+1. `DnsMessage.Parse(ReadOnlySpan<byte>)` parses a complete message,
+   including the header, every question, and every record across all
+   four sections.
+2. `DnsMessage.WriteTo(Span<byte>)` / `TryWriteTo(Span<byte>, out int)`
+   serialize the message. Section counts are derived from the
+   collection sizes so callers don't have to keep the header in sync.
+3. RFC 1035 §4.1.4 name compression is applied on write (per-message
+   suffix table; pointers emitted when the offset fits in 14 bits)
+   and tolerated on read with pointer-chain depth, offset-direction,
+   and reassembled-length validation.
+4. The strongly-typed record family covers A / AAAA / CNAME / NS / PTR
+   / MX / TXT / SOA / SRV plus the EDNS OPT pseudo-record. Anything
+   else round-trips through `DnsUnknownRecord` per RFC 3597.
 
-PR 3 (Feature 04) adds EDNS OPT handling on top.
+### EDNS (RFC 6891)
+
+`DnsOptRecord` re-purposes the underlying record fields per
+RFC 6891 §6.1:
+
+| Record field | EDNS meaning |
+|--------------|--------------|
+| `Class` | UDP payload size advertised by the requestor |
+| `TTL` (high byte) | Extended RCODE high 8 bits |
+| `TTL` (mid byte) | EDNS version |
+| `TTL` (low 16 bits) | EDNS flag bits (`DnsEdnsFlags`) |
+| `RDATA` | Sequence of `DnsEdnsOption` |
+
+The option family follows the same closed-extension pattern as the
+record family: typed subclasses (`ClientSubnet`, `Cookie`,
+`ExtendedError`) for the common cases, `DnsEdnsUnknownOption` for
+forward compatibility per RFC 6891 §4.
+
+### Internal wire helpers
+
+`Internal/DnsWireReader` and `Internal/DnsWireWriter` are
+<see langword="ref struct"/> wrappers over a `ReadOnlySpan<byte>` /
+`Span<byte>` that centralize bounds-checking and big-endian
+conversion. `Internal/DnsNameDecoder` and `Internal/DnsNameEncoder`
+implement RFC 1035 §4.1.4 with a shared compression table on
+`DnsWireWriter` so consecutive name writes within one message
+deduplicate suffixes automatically.
 
 ## AOT posture
 

--- a/libraries/Dns/Assimalign.Cohesion.Dns/docs/OVERVIEW.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/docs/OVERVIEW.md
@@ -29,14 +29,32 @@ DNSSEC validation, per-transport plugins if useful.
 
 ## Status
 
-Initial scaffolding. Ships:
+Contracts (PR 1) plus the complete wire format and EDNS layer (PR 2).
+Now ships:
 
-- `DnsException` + `DnsErrorCode` (Story `.02.03`, AOT-safe)
+- `DnsException` + `DnsErrorCode` (AOT-safe)
 - `DnsClient`, `DnsResolver`, `DnsAuthority`, `DnsZone`,
-  `DnsTransport` abstract classes (Story `.02.01`)
-- `DnsName`, `DnsQuestion`, `DnsRecord` value-type/data-shape stubs
-- Wire enums: `DnsRecordType`, `DnsClass`, `DnsOpCode`, `DnsResponseCode`
-- `DnsMessage` placeholder — wire-format implementation lands in PR 2
+  `DnsTransport` abstract classes
+- `DnsName`, `DnsQuestion`, `DnsHeader`, `DnsHeaderFlags` value types
+- `DnsMessage` with `Parse(ReadOnlySpan<byte>)` and
+  `WriteTo(Span<byte>)` — RFC 1035 §4 wire format including §4.1.4
+  name compression on both sides (pointer-chain depth + offset-
+  direction validation)
+- `DnsRecord` abstract base + the strongly-typed family:
+  `DnsARecord` / `DnsAaaaRecord` / `DnsCnameRecord` / `DnsNsRecord` /
+  `DnsPtrRecord` / `DnsMxRecord` / `DnsTxtRecord` / `DnsSoaRecord` /
+  `DnsSrvRecord` / `DnsOptRecord` / `DnsUnknownRecord` (RFC 3597
+  round-trip for unrecognised types)
+- EDNS OPT pseudo-record (RFC 6891) with the typed option family:
+  `DnsEdnsClientSubnetOption` (RFC 7871),
+  `DnsEdnsCookieOption` (RFC 7873),
+  `DnsEdnsExtendedErrorOption` (RFC 8914),
+  `DnsEdnsUnknownOption` for forward compatibility
+- Wire enums: `DnsRecordType`, `DnsClass`, `DnsOpCode`,
+  `DnsResponseCode`, `DnsEdnsFlags`, `DnsEdnsOptionCode`
+
+The concrete `DnsClient.Client` package &#8211; transports + recursive
+resolver &#8211; lands in PR 3.
 
 ## Public surface
 
@@ -56,17 +74,29 @@ Initial scaffolding. Ships:
 - `DnsAuthority` exposes `Zones` and `FindZone(name)` for authoritative
   servers, with the same lifecycle plumbing as `DnsClient`.
 - `DnsZone` carries `Origin`, `Serial`, `GetRecords`, `Contains`.
-- `DnsTransport.ExchangeAsync(endpoint, request, ct)` is the
-  network-layer plug point used by the resolver, again with shared
-  lifecycle.
+- `DnsTransport.ExchangeAsync(request, ct)` is the network-layer plug
+  point used by the resolver. One transport binds to one
+  `Endpoint` (set at construction), matching the
+  `Assimalign.Cohesion.Transports` family's `ClientTransport` shape so
+  PR 3 transports can adapt cleanly. Resolvers that need to fail over
+  hold a list of transports rather than a single transport with N
+  endpoints.
 
 ### Wire-level types
 - `DnsName` — RFC 1035 §2.3.3 case-insensitive name, validates
   label/total-length limits at construction.
 - `DnsQuestion(name, type, class = IN)` — readonly value type.
-- `DnsRecord(name, type, class, ttl, data)` — opaque RDATA today; the
-  typed record family lands in PR 2.
-- `DnsMessage(id, question)` — placeholder; wire format in PR 2.
+- `DnsHeader` — 12-octet header (RFC 1035 §4.1.1) with field-level
+  parse/write. Carries `Id`, `Flags`, `OpCode`, `ResponseCode`, and
+  the four section counts.
+- `DnsHeaderFlags` — `[Flags]` enum for QR / AA / TC / RD / RA / AD / CD.
+- `DnsMessage` — full DNS message with `Parse` + `WriteTo`. Section
+  counts are derived from the actual collection sizes on write, so
+  callers don't have to keep the header in sync.
+- `DnsRecord` — abstract base for every typed record. Subclasses
+  expose strongly-typed fields (e.g. `DnsARecord.Address`,
+  `DnsSoaRecord.Serial`). Unknown wire types parse as
+  `DnsUnknownRecord` preserving the opaque RDATA bytes per RFC 3597.
 
 ### Wire-level enums
 - `DnsRecordType` — A / AAAA / CNAME / MX / TXT / NS / SOA / PTR /
@@ -89,16 +119,22 @@ By design, this package owns contracts only. It does NOT:
 
 ## Test coverage
 
-- 32 tests in `Assimalign.Cohesion.Dns.Tests`:
+- 58 tests in `Assimalign.Cohesion.Dns.Tests`:
   - `DnsExceptionTests` — every `Throw*` helper + ordinal-stability theory.
   - `DnsNameTests` — validation, label extraction, case-insensitive
     equality, implicit conversions.
   - `DnsQuestionTests` — equality and ToString.
   - `DnsClientLifecycleTests` — Dispose idempotency,
     DisposeAsync fallback to DisposeCore, DisposeAsyncCore override
-    path, ThrowIfDisposed guard. Validates the lifecycle plumbing in
-    `DnsClient` that every derived client inherits.
-
-The contract-suite pattern used by FileSystem (provider-agnostic tests
-shared via `<Compile Include …>`) is not yet applicable here — that
-arrives in PR 2 once `DnsMessage` has a serializer to test against.
+    path, ThrowIfDisposed guard.
+  - `DnsHeaderTests` — header round-trip, OPCODE/RCODE bit packing,
+    DNSSEC AD/CD bits, under-sized buffer rejection.
+  - `DnsMessageTests` — query and answer round-trips for every
+    supported record type (A / AAAA / CNAME / NS / PTR / MX / TXT /
+    SOA / SRV), name-compression smoke test (size-bound on
+    serialized output), unknown-RR round-trip (RFC 3597), malformed-
+    name rejection.
+  - `DnsEdnsTests` — OPT round-trip with payload size + DO bit, ECS
+    option (IPv4 + IPv6), Cookie option (client-only + client+server),
+    Extended-DNS-Error option, unknown-option preservation, multi-
+    option ordering, extended-RCODE high byte, malformed ECS family.

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsHeader.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsHeader.cs
@@ -1,0 +1,166 @@
+using System;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// The fixed 12-octet header that prefixes every DNS message on the wire (RFC 1035
+/// &#167; 4.1.1). Carries the transaction identifier, the OPCODE / RCODE,
+/// <see cref="DnsHeaderFlags"/>, and the four section counts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The wire layout is:
+/// </para>
+/// <pre>
+///                                 1  1  1  1  1  1
+///   0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |                      ID                       |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |                    QDCOUNT                    |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |                    ANCOUNT                    |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |                    NSCOUNT                    |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// |                    ARCOUNT                    |
+/// +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/// </pre>
+/// <para>
+/// The <c>Z</c> field is reserved (must be zero) except for the AD and CD bits added by
+/// DNSSEC (RFC 4035 §3.2); <see cref="DnsHeaderFlags"/> exposes both.
+/// </para>
+/// </remarks>
+public readonly struct DnsHeader : IEquatable<DnsHeader>
+{
+    /// <summary>
+    /// On-wire size of the header in octets. Every DNS message starts with this many bytes.
+    /// </summary>
+    public const int WireSize = 12;
+
+    /// <summary>Initializes a new header.</summary>
+    public DnsHeader(
+        ushort id,
+        DnsHeaderFlags flags,
+        DnsOpCode opCode,
+        DnsResponseCode responseCode,
+        ushort questionCount,
+        ushort answerCount,
+        ushort authorityCount,
+        ushort additionalCount)
+    {
+        Id = id;
+        Flags = flags;
+        OpCode = opCode;
+        ResponseCode = responseCode;
+        QuestionCount = questionCount;
+        AnswerCount = answerCount;
+        AuthorityCount = authorityCount;
+        AdditionalCount = additionalCount;
+    }
+
+    /// <summary>16-bit transaction identifier. Echoed by the responder so the client can
+    /// correlate the response with its query.</summary>
+    public ushort Id { get; }
+
+    /// <summary>Single-bit flags carried in the second 16-bit word.</summary>
+    public DnsHeaderFlags Flags { get; }
+
+    /// <summary>4-bit operation code (RFC 1035 §4.1.1).</summary>
+    public DnsOpCode OpCode { get; }
+
+    /// <summary>4-bit response code (RFC 1035 §4.1.1). Extended to twelve bits via the EDNS
+    /// OPT pseudo-record; the high eight bits live there.</summary>
+    public DnsResponseCode ResponseCode { get; }
+
+    /// <summary>Number of entries in the question section.</summary>
+    public ushort QuestionCount { get; }
+
+    /// <summary>Number of entries in the answer section.</summary>
+    public ushort AnswerCount { get; }
+
+    /// <summary>Number of entries in the authority section.</summary>
+    public ushort AuthorityCount { get; }
+
+    /// <summary>Number of entries in the additional section.</summary>
+    public ushort AdditionalCount { get; }
+
+    /// <summary>
+    /// Reads a 12-octet header from <paramref name="buffer"/>.
+    /// </summary>
+    /// <exception cref="DnsException">The buffer is shorter than <see cref="WireSize"/> or
+    /// uses a reserved bit pattern.</exception>
+    public static DnsHeader Parse(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < WireSize)
+        {
+            DnsException.ThrowMalformed($"header requires {WireSize} octets but only {buffer.Length} available");
+        }
+
+        var reader = new DnsWireReader(buffer);
+        ushort id = reader.ReadUInt16();
+        ushort flagsWord = reader.ReadUInt16();
+        ushort qdcount = reader.ReadUInt16();
+        ushort ancount = reader.ReadUInt16();
+        ushort nscount = reader.ReadUInt16();
+        ushort arcount = reader.ReadUInt16();
+
+        DnsOpCode opCode = (DnsOpCode)((flagsWord >> 11) & 0x0F);
+        DnsResponseCode rcode = (DnsResponseCode)(flagsWord & 0x0F);
+
+        // Strip OPCODE + RCODE from the flags word; the rest is the boolean-flag mask.
+        DnsHeaderFlags flags = (DnsHeaderFlags)(flagsWord & 0b1000_0111_1011_0000);
+
+        return new DnsHeader(id, flags, opCode, rcode, qdcount, ancount, nscount, arcount);
+    }
+
+    /// <summary>
+    /// Writes this header to <paramref name="buffer"/>. The buffer must have at least
+    /// <see cref="WireSize"/> octets available.
+    /// </summary>
+    public void WriteTo(Span<byte> buffer)
+    {
+        var writer = new DnsWireWriter(buffer);
+        WriteTo(ref writer);
+    }
+
+    internal void WriteTo(ref DnsWireWriter writer)
+    {
+        writer.WriteUInt16(Id);
+
+        ushort flagsWord = (ushort)Flags;
+        flagsWord |= (ushort)(((byte)OpCode & 0x0F) << 11);
+        flagsWord |= (ushort)((ushort)ResponseCode & 0x0F);
+        writer.WriteUInt16(flagsWord);
+
+        writer.WriteUInt16(QuestionCount);
+        writer.WriteUInt16(AnswerCount);
+        writer.WriteUInt16(AuthorityCount);
+        writer.WriteUInt16(AdditionalCount);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(DnsHeader other)
+        => Id == other.Id
+        && Flags == other.Flags
+        && OpCode == other.OpCode
+        && ResponseCode == other.ResponseCode
+        && QuestionCount == other.QuestionCount
+        && AnswerCount == other.AnswerCount
+        && AuthorityCount == other.AuthorityCount
+        && AdditionalCount == other.AdditionalCount;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is DnsHeader other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(Id, Flags, OpCode, ResponseCode,
+            QuestionCount, AnswerCount, AuthorityCount, AdditionalCount);
+
+    public static bool operator ==(DnsHeader left, DnsHeader right) => left.Equals(right);
+    public static bool operator !=(DnsHeader left, DnsHeader right) => !left.Equals(right);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsHeaderFlags.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsHeaderFlags.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Boolean flag bits carried in the 16-bit flags word of the DNS header (RFC 1035
+/// &#167; 4.1.1, RFC 4035 &#167; 3.2 for the DNSSEC additions).
+/// </summary>
+/// <remarks>
+/// The flag word also encodes <see cref="DnsOpCode"/> (4 bits) and <see cref="DnsResponseCode"/>
+/// (4 bits) which are NOT part of this enum &#8211; they have dedicated properties on
+/// <see cref="DnsHeader"/>. <see cref="DnsHeaderFlags"/> only covers the single-bit flags.
+/// </remarks>
+[Flags]
+public enum DnsHeaderFlags : ushort
+{
+    /// <summary>No flags set.</summary>
+    None = 0,
+
+    /// <summary>QR &#8211; query / response indicator. Set on responses, cleared on queries.</summary>
+    Response = 1 << 15,
+
+    /// <summary>AA &#8211; authoritative answer. Set in responses from a server that is
+    /// authoritative for the queried zone.</summary>
+    AuthoritativeAnswer = 1 << 10,
+
+    /// <summary>TC &#8211; truncated. The response was truncated because it didn't fit the
+    /// payload size negotiated for the transport.</summary>
+    Truncated = 1 << 9,
+
+    /// <summary>RD &#8211; recursion desired. Set in queries that ask the server to recurse.</summary>
+    RecursionDesired = 1 << 8,
+
+    /// <summary>RA &#8211; recursion available. Set in responses from a server that supports
+    /// recursive queries.</summary>
+    RecursionAvailable = 1 << 7,
+
+    /// <summary>AD &#8211; authentic data (DNSSEC, RFC 4035 §3.2). Set in responses whose
+    /// data the validator considers authentic.</summary>
+    AuthenticData = 1 << 5,
+
+    /// <summary>CD &#8211; checking disabled (DNSSEC, RFC 4035 §3.2). Set in queries that
+    /// ask the server to suppress DNSSEC validation.</summary>
+    CheckingDisabled = 1 << 4,
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsMessage.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsMessage.cs
@@ -1,37 +1,262 @@
+using System;
 using System.Collections.Generic;
+using Assimalign.Cohesion.Dns.Internal;
 
 namespace Assimalign.Cohesion.Dns;
 
 /// <summary>
 /// A complete DNS message &#8211; header plus question, answer, authority, and additional
-/// sections (RFC 1035 &#167; 4.1).
+/// sections (RFC 1035 &#167; 4.1). Supports round-trip serialization through
+/// <see cref="Parse"/> and <see cref="WriteTo"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// PR 1 ships only the public surface so the contract layer can compile. The wire-format
-/// implementation (read/write of the binary representation, name compression, EDNS handling)
-/// lands in PR 2 alongside the resource-record family.
+/// Messages are immutable after construction. To synthesize a query, build the message via
+/// the constructor and call <see cref="WriteTo"/> against a caller-owned buffer. To consume
+/// a response, call <see cref="Parse"/> on the received bytes.
 /// </para>
 /// <para>
-/// Until then, callers can hold a <see cref="DnsMessage"/> reference but the only meaningful
-/// member is <see cref="Questions"/>. Sealed against subclassing so the wire-format layer can
-/// rely on a known shape.
+/// The wire format follows RFC 1035 with RFC 6891 extensions (EDNS OPT). Name compression
+/// is applied on write per RFC 1035 §4.1.4 and tolerated on read with pointer-chain depth
+/// and offset-direction validation.
 /// </para>
 /// </remarks>
 public sealed class DnsMessage
 {
     /// <summary>
-    /// Initializes a new <see cref="DnsMessage"/> with the supplied identifier and question.
+    /// Initializes a new message from its sections.
     /// </summary>
-    public DnsMessage(ushort id, DnsQuestion question)
+    public DnsMessage(
+        DnsHeader header,
+        IReadOnlyList<DnsQuestion> questions,
+        IReadOnlyList<DnsRecord> answers,
+        IReadOnlyList<DnsRecord> authorities,
+        IReadOnlyList<DnsRecord> additionals)
     {
-        Id = id;
-        Questions = new[] { question };
+        ArgumentNullException.ThrowIfNull(questions);
+        ArgumentNullException.ThrowIfNull(answers);
+        ArgumentNullException.ThrowIfNull(authorities);
+        ArgumentNullException.ThrowIfNull(additionals);
+
+        Header = header;
+        Questions = questions;
+        Answers = answers;
+        Authorities = authorities;
+        Additionals = additionals;
     }
 
-    /// <summary>The 16-bit transaction identifier from the DNS header.</summary>
-    public ushort Id { get; }
+    /// <summary>
+    /// Convenience constructor for a single-question query message.
+    /// </summary>
+    public DnsMessage(ushort id, DnsQuestion question)
+        : this(
+            new DnsHeader(
+                id,
+                DnsHeaderFlags.RecursionDesired,
+                DnsOpCode.Query,
+                DnsResponseCode.NoError,
+                questionCount: 1,
+                answerCount: 0,
+                authorityCount: 0,
+                additionalCount: 0),
+            new[] { question },
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>())
+    {
+    }
 
-    /// <summary>The questions section. Most messages carry exactly one question.</summary>
+    /// <summary>The 12-octet header.</summary>
+    public DnsHeader Header { get; }
+
+    /// <summary>The questions section.</summary>
     public IReadOnlyList<DnsQuestion> Questions { get; }
+
+    /// <summary>The answers section.</summary>
+    public IReadOnlyList<DnsRecord> Answers { get; }
+
+    /// <summary>The authority section (NS records, SOA records for NXDomain proofs, etc.).</summary>
+    public IReadOnlyList<DnsRecord> Authorities { get; }
+
+    /// <summary>The additional section (glue, OPT, DNSSEC supporting RRs).</summary>
+    public IReadOnlyList<DnsRecord> Additionals { get; }
+
+    /// <summary>
+    /// Convenience getter that returns the OPT pseudo-record from the additional section, if
+    /// any. Per RFC 6891 a message may carry at most one OPT.
+    /// </summary>
+    public DnsOptRecord? Edns
+    {
+        get
+        {
+            foreach (DnsRecord record in Additionals)
+            {
+                if (record is DnsOptRecord opt)
+                {
+                    return opt;
+                }
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a DNS message from <paramref name="buffer"/>.
+    /// </summary>
+    /// <exception cref="DnsException">The buffer cannot be parsed as a valid DNS message.</exception>
+    public static DnsMessage Parse(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < DnsHeader.WireSize)
+        {
+            DnsException.ThrowMalformed(
+                $"DNS message must be at least {DnsHeader.WireSize} octets; got {buffer.Length}");
+        }
+
+        DnsHeader header = DnsHeader.Parse(buffer);
+        var reader = new DnsWireReader(buffer, DnsHeader.WireSize);
+
+        var questions = new List<DnsQuestion>(header.QuestionCount);
+        for (int i = 0; i < header.QuestionCount; i++)
+        {
+            DnsName name = DnsNameDecoder.Read(ref reader, buffer);
+            DnsRecordType type = (DnsRecordType)reader.ReadUInt16();
+            DnsClass @class = (DnsClass)reader.ReadUInt16();
+            questions.Add(new DnsQuestion(name, type, @class));
+        }
+
+        var answers = ReadRecordSection(ref reader, buffer, header.AnswerCount);
+        var authorities = ReadRecordSection(ref reader, buffer, header.AuthorityCount);
+        var additionals = ReadRecordSection(ref reader, buffer, header.AdditionalCount);
+
+        return new DnsMessage(header, questions, answers, authorities, additionals);
+    }
+
+    /// <summary>
+    /// Serializes this message into <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">A caller-owned buffer large enough to hold the serialized form
+    /// (1232 octets is a safe ceiling for UDP per modern guidance; TCP allows up to 65535).</param>
+    /// <param name="bytesWritten">Set to the number of octets written.</param>
+    /// <returns><see langword="true"/> on success; <see langword="false"/> when the buffer is too small.</returns>
+    public bool TryWriteTo(Span<byte> buffer, out int bytesWritten)
+    {
+        try
+        {
+            WriteToCore(buffer, out bytesWritten);
+            return true;
+        }
+        catch (DnsException ex) when (ex.Code == DnsErrorCode.Malformed)
+        {
+            // The internal writer signals buffer underrun via Malformed; we translate to a
+            // false return so callers can size up and retry.
+            bytesWritten = 0;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Serializes this message into <paramref name="buffer"/>. Throws when the buffer is too
+    /// small.
+    /// </summary>
+    public int WriteTo(Span<byte> buffer)
+    {
+        WriteToCore(buffer, out int written);
+        return written;
+    }
+
+    private void WriteToCore(Span<byte> buffer, out int bytesWritten)
+    {
+        var writer = new DnsWireWriter(buffer);
+
+        // Patch the section counts from the actual collection sizes so callers don't have to
+        // keep the header in sync with the section lists.
+        DnsHeader headerToWrite = new DnsHeader(
+            Header.Id,
+            Header.Flags,
+            Header.OpCode,
+            Header.ResponseCode,
+            (ushort)Questions.Count,
+            (ushort)Answers.Count,
+            (ushort)Authorities.Count,
+            (ushort)Additionals.Count);
+        headerToWrite.WriteTo(ref writer);
+
+        foreach (DnsQuestion question in Questions)
+        {
+            DnsNameEncoder.Write(ref writer, question.Name);
+            writer.WriteUInt16((ushort)question.Type);
+            writer.WriteUInt16((ushort)question.Class);
+        }
+
+        WriteRecordSection(ref writer, Answers);
+        WriteRecordSection(ref writer, Authorities);
+        WriteRecordSection(ref writer, Additionals);
+
+        bytesWritten = writer.Position;
+    }
+
+    private static List<DnsRecord> ReadRecordSection(
+        ref DnsWireReader reader,
+        ReadOnlySpan<byte> message,
+        ushort count)
+    {
+        var records = new List<DnsRecord>(count);
+        for (int i = 0; i < count; i++)
+        {
+            DnsName name = DnsNameDecoder.Read(ref reader, message);
+            DnsRecordType type = (DnsRecordType)reader.ReadUInt16();
+            DnsClass @class = (DnsClass)reader.ReadUInt16();
+            uint ttl = reader.ReadUInt32();
+            ushort rdLength = reader.ReadUInt16();
+            int rdataStart = reader.Position;
+
+            DnsRecord record = type switch
+            {
+                DnsRecordType.A => DnsARecord.ReadRData(name, @class, ttl, ref reader, rdLength),
+                DnsRecordType.AAAA => DnsAaaaRecord.ReadRData(name, @class, ttl, ref reader, rdLength),
+                DnsRecordType.CNAME => DnsCnameRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.NS => DnsNsRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.PTR => DnsPtrRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.MX => DnsMxRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.TXT => DnsTxtRecord.ReadRData(name, @class, ttl, ref reader, rdLength),
+                DnsRecordType.SOA => DnsSoaRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.SRV => DnsSrvRecord.ReadRData(name, @class, ttl, ref reader, message, rdataStart, rdLength),
+                DnsRecordType.OPT => DnsOptRecord.ReadRData(@class, ttl, ref reader, rdLength),
+                _ => DnsUnknownRecord.ReadRData(name, type, @class, ttl, ref reader, rdLength),
+            };
+
+            int consumed = reader.Position - rdataStart;
+            if (consumed != rdLength)
+            {
+                DnsException.ThrowMalformed(
+                    $"record {type}: declared RDLENGTH {rdLength} but reader consumed {consumed} octets");
+            }
+
+            records.Add(record);
+        }
+        return records;
+    }
+
+    private static void WriteRecordSection(ref DnsWireWriter writer, IReadOnlyList<DnsRecord> records)
+    {
+        foreach (DnsRecord record in records)
+        {
+            DnsNameEncoder.Write(ref writer, record.Name);
+            writer.WriteUInt16((ushort)record.Type);
+            writer.WriteUInt16((ushort)record.Class);
+            writer.WriteUInt32(record.TimeToLive);
+
+            int rdLengthOffset = writer.Position;
+            writer.WriteUInt16(0); // placeholder for RDLENGTH
+            int rdataStart = writer.Position;
+            record.WriteRData(ref writer);
+            int rdLength = writer.Position - rdataStart;
+            if (rdLength > ushort.MaxValue)
+            {
+                DnsException.ThrowMalformed(
+                    $"record {record.Type} RDATA exceeds the wire limit (65535 octets); got {rdLength}");
+            }
+            writer.PatchUInt16(rdLengthOffset, (ushort)rdLength);
+        }
+    }
 }

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsRecord.cs
@@ -1,42 +1,37 @@
 using System;
+using Assimalign.Cohesion.Dns.Internal;
 
 namespace Assimalign.Cohesion.Dns;
 
 /// <summary>
 /// A DNS resource record &#8211; the unit of data exchanged by every DNS protocol operation
-/// (RFC 1035 &#167; 3.2). Carries a name, a type, a class, a time-to-live, and an opaque
-/// <em>RDATA</em> payload whose interpretation depends on <see cref="Type"/>.
+/// (RFC 1035 &#167; 3.2). Carries a name, a type, a class, a time-to-live, and (in derived
+/// types) a strongly-typed payload whose interpretation depends on <see cref="Type"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// PR 1 ships only the public shape so the contract layer compiles. The strongly-typed RDATA
-/// hierarchy (A / AAAA / CNAME / MX / SOA / etc.) lands in PR 2 alongside the wire-format
-/// implementation. Until then, callers can hold a <see cref="DnsRecord"/> reference but its
-/// <see cref="Data"/> is an opaque byte buffer in wire encoding.
+/// Derived types expose strongly-typed properties for the well-known record families
+/// (A, AAAA, CNAME, MX, TXT, NS, SOA, PTR, SRV, OPT). Any record whose type code isn't
+/// recognized parses as a <see cref="DnsUnknownRecord"/> preserving the opaque RDATA bytes
+/// so the message can round-trip without loss.
+/// </para>
+/// <para>
+/// Records are immutable. The wire-format reader / writer in <see cref="DnsMessage"/>
+/// dispatches on <see cref="Type"/> to instantiate the right concrete type, so consumers can
+/// pattern-match (<c>switch</c> expressions) against the known shapes.
 /// </para>
 /// </remarks>
-public class DnsRecord
+public abstract class DnsRecord
 {
     /// <summary>
-    /// Initializes a new <see cref="DnsRecord"/>.
+    /// Initializes shared properties on a derived record.
     /// </summary>
-    /// <param name="name">The owner name.</param>
-    /// <param name="type">The record type.</param>
-    /// <param name="class">The DNS class (almost always <see cref="DnsClass.IN"/>).</param>
-    /// <param name="timeToLive">The TTL in seconds.</param>
-    /// <param name="data">The wire-format RDATA bytes.</param>
-    public DnsRecord(
-        DnsName name,
-        DnsRecordType type,
-        DnsClass @class,
-        uint timeToLive,
-        ReadOnlyMemory<byte> data)
+    protected DnsRecord(DnsName name, DnsRecordType type, DnsClass @class, uint timeToLive)
     {
         Name = name;
         Type = type;
         Class = @class;
         TimeToLive = timeToLive;
-        Data = data;
     }
 
     /// <summary>The owner name (the name the record describes).</summary>
@@ -51,6 +46,15 @@ public class DnsRecord
     /// <summary>The time-to-live in seconds.</summary>
     public uint TimeToLive { get; }
 
-    /// <summary>The wire-format RDATA bytes. Strongly-typed accessors land in PR 2.</summary>
-    public ReadOnlyMemory<byte> Data { get; }
+    /// <summary>
+    /// Writes the RDATA portion of this record to <paramref name="writer"/>. Called by
+    /// <see cref="DnsMessage"/> after the common header (name + type + class + TTL +
+    /// RDLENGTH placeholder) has been emitted.
+    /// </summary>
+    /// <remarks>
+    /// Implementations write only the type-specific RDATA bytes. The framing (RDLENGTH
+    /// patch-up) is handled by the message-level serializer to keep record code focused on
+    /// the protocol-specific content.
+    /// </remarks>
+    internal abstract void WriteRData(ref DnsWireWriter writer);
 }

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsTransport.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/DnsTransport.cs
@@ -12,6 +12,13 @@ namespace Assimalign.Cohesion.Dns;
 /// </summary>
 /// <remarks>
 /// <para>
+/// One <see cref="DnsTransport"/> binds to one <see cref="Endpoint"/>. Resolvers that need to
+/// fail over between multiple upstreams hold a list of transports rather than a single
+/// transport with N endpoints — this matches the
+/// <c>Assimalign.Cohesion.Transports</c> family's <c>ClientTransport</c> shape and lets
+/// stream-based subclasses (TCP, DoT, DoQ) pool connections against a fixed remote.
+/// </para>
+/// <para>
 /// The transport works in terms of raw byte buffers; serialization and parsing live in the
 /// wire-format layer of <c>Assimalign.Cohesion.Dns</c>. This split keeps the transport
 /// implementation small and lets the resolver decide message-level concerns like EDNS
@@ -28,17 +35,20 @@ public abstract class DnsTransport : IDisposable, IAsyncDisposable
     private bool _disposed;
 
     /// <summary>
-    /// Sends <paramref name="request"/> to <paramref name="endpoint"/> and returns the
-    /// response payload. The returned <see cref="ReadOnlyMemory{Byte}"/> may share storage
-    /// with a pooled buffer owned by the transport; callers <strong>MUST NOT</strong> retain
-    /// it beyond the lifetime of the awaited task without copying.
+    /// The upstream server bound to this transport. Set at construction; immutable.
     /// </summary>
-    /// <param name="endpoint">The upstream server to query.</param>
+    public abstract EndPoint Endpoint { get; }
+
+    /// <summary>
+    /// Sends <paramref name="request"/> to <see cref="Endpoint"/> and returns the response
+    /// payload. The returned <see cref="ReadOnlyMemory{Byte}"/> may share storage with a
+    /// pooled buffer owned by the transport; callers <strong>MUST NOT</strong> retain it
+    /// beyond the lifetime of the awaited task without copying.
+    /// </summary>
     /// <param name="request">The serialized DNS request bytes (just the DNS message; no
     /// length-prefix for stream-based transports &#8211; the transport supplies framing).</param>
     /// <param name="cancellationToken">Cancels the in-flight exchange.</param>
     public abstract Task<ReadOnlyMemory<byte>> ExchangeAsync(
-        EndPoint endpoint,
         ReadOnlyMemory<byte> request,
         CancellationToken cancellationToken = default);
 

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsClientSubnetOption.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsClientSubnetOption.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// The EDNS Client-Subnet (ECS) option &#8211; RFC 7871. Carries a partial client address so
+/// authoritative servers can tailor answers geographically without seeing the full IP.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire layout of the option payload:
+/// </para>
+/// <pre>
+///  0   1   2   3   4   5   6   7
+/// +---+---+---+---+---+---+---+---+
+/// |          FAMILY               |  (2 octets: 1 = IPv4, 2 = IPv6)
+/// +---+---+---+---+---+---+---+---+
+/// |   SOURCE-NETMASK              |  (1 octet)
+/// +---+---+---+---+---+---+---+---+
+/// |    SCOPE-NETMASK              |  (1 octet; 0 in queries)
+/// +---+---+---+---+---+---+---+---+
+/// |  ADDRESS  (CEIL(SOURCE/8) bytes)  |
+/// +---+---+---+---+---+---+---+---+
+/// </pre>
+/// </remarks>
+public sealed class DnsEdnsClientSubnetOption : DnsEdnsOption
+{
+    /// <summary>
+    /// Initializes a new <c>edns-client-subnet</c> option.
+    /// </summary>
+    /// <param name="address">The address whose prefix is shared with the upstream.</param>
+    /// <param name="sourcePrefixLength">Number of significant bits in <paramref name="address"/>.</param>
+    /// <param name="scopePrefixLength">Number of significant bits the responder considered.
+    /// Typically 0 in queries and populated by the responder in answers.</param>
+    public DnsEdnsClientSubnetOption(IPAddress address, byte sourcePrefixLength, byte scopePrefixLength = 0)
+        : base(DnsEdnsOptionCode.ClientSubnet)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        int maxBits = address.AddressFamily == AddressFamily.InterNetwork ? 32 : 128;
+        if (sourcePrefixLength > maxBits || scopePrefixLength > maxBits)
+        {
+            throw new ArgumentException(
+                $"ECS prefix length must be 0..{maxBits} for {address.AddressFamily}.");
+        }
+        Address = address;
+        SourcePrefixLength = sourcePrefixLength;
+        ScopePrefixLength = scopePrefixLength;
+    }
+
+    /// <summary>The (truncated) client address.</summary>
+    public IPAddress Address { get; }
+
+    /// <summary>Source prefix length in bits.</summary>
+    public byte SourcePrefixLength { get; }
+
+    /// <summary>Scope prefix length in bits, set by responders.</summary>
+    public byte ScopePrefixLength { get; }
+
+    /// <summary>The numeric family code (1 = IPv4, 2 = IPv6).</summary>
+    public ushort Family => Address.AddressFamily == AddressFamily.InterNetwork ? (ushort)1 : (ushort)2;
+
+    /// <inheritdoc />
+    internal override void WritePayload(ref DnsWireWriter writer)
+    {
+        writer.WriteUInt16(Family);
+        writer.WriteUInt8(SourcePrefixLength);
+        writer.WriteUInt8(ScopePrefixLength);
+
+        // Address bytes — only ceil(prefix/8) of them per RFC 7871.
+        int addrSize = Address.AddressFamily == AddressFamily.InterNetwork ? 4 : 16;
+        Span<byte> addrBuffer = stackalloc byte[16];
+        if (!Address.TryWriteBytes(addrBuffer, out int written) || written != addrSize)
+        {
+            DnsException.ThrowMalformed("failed to serialize ECS address");
+        }
+        int bytesToWrite = (SourcePrefixLength + 7) / 8;
+        writer.WriteBytes(addrBuffer.Slice(0, bytesToWrite));
+    }
+
+    internal static DnsEdnsClientSubnetOption ReadPayload(ref DnsWireReader reader, int payloadLength)
+    {
+        if (payloadLength < 4)
+        {
+            DnsException.ThrowMalformed("ECS option payload must be at least 4 octets");
+        }
+
+        int start = reader.Position;
+        ushort family = reader.ReadUInt16();
+        byte source = reader.ReadUInt8();
+        byte scope = reader.ReadUInt8();
+
+        int addrBytes = payloadLength - 4;
+        int expectedFullSize = family == 1 ? 4 : 16;
+        if (addrBytes > expectedFullSize)
+        {
+            DnsException.ThrowMalformed(
+                $"ECS option carries {addrBytes} address octets but family {family} only allows {expectedFullSize}");
+        }
+
+        Span<byte> addressBuffer = stackalloc byte[16];
+        addressBuffer.Clear();
+        ReadOnlySpan<byte> bytes = reader.ReadBytes(addrBytes);
+        bytes.CopyTo(addressBuffer);
+
+        IPAddress address = family switch
+        {
+            1 => new IPAddress(addressBuffer.Slice(0, 4)),
+            2 => new IPAddress(addressBuffer.Slice(0, 16)),
+            _ => throw NotSupportedFamily(family),
+        };
+
+        int consumed = reader.Position - start;
+        if (consumed != payloadLength)
+        {
+            DnsException.ThrowMalformed(
+                $"ECS option: declared length {payloadLength} but consumed {consumed} octets");
+        }
+
+        return new DnsEdnsClientSubnetOption(address, source, scope);
+
+        static Exception NotSupportedFamily(ushort family)
+        {
+            DnsException.ThrowMalformed($"ECS option uses unsupported family code {family}");
+            return null!; // unreachable
+        }
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsCookieOption.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsCookieOption.cs
@@ -1,0 +1,75 @@
+using System;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// The EDNS Cookie option &#8211; RFC 7873. Carries a lightweight transaction binding to
+/// defend against off-path spoofing and reflection-style attacks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The option is exactly 8 octets in queries (the 64-bit Client Cookie) and 16&#8211;40
+/// octets in responses (Client Cookie + 8&#8211;32 octet Server Cookie). Cohesion
+/// represents both halves with separate byte arrays so callers can manage them explicitly.
+/// </para>
+/// </remarks>
+public sealed class DnsEdnsCookieOption : DnsEdnsOption
+{
+    private readonly byte[] _clientCookie;
+    private readonly byte[]? _serverCookie;
+
+    /// <summary>
+    /// Initializes a new EDNS Cookie option.
+    /// </summary>
+    /// <param name="clientCookie">Exactly 8 octets supplied by the client.</param>
+    /// <param name="serverCookie">8&#8211;32 octets supplied by the server in responses; null
+    /// or empty for query-side cookies.</param>
+    public DnsEdnsCookieOption(ReadOnlySpan<byte> clientCookie, ReadOnlySpan<byte> serverCookie = default)
+        : base(DnsEdnsOptionCode.Cookie)
+    {
+        if (clientCookie.Length != 8)
+        {
+            throw new ArgumentException("Client cookie must be exactly 8 octets.", nameof(clientCookie));
+        }
+        if (serverCookie.Length != 0 && (serverCookie.Length < 8 || serverCookie.Length > 32))
+        {
+            throw new ArgumentException("Server cookie, when present, must be 8..32 octets.", nameof(serverCookie));
+        }
+        _clientCookie = clientCookie.ToArray();
+        _serverCookie = serverCookie.Length == 0 ? null : serverCookie.ToArray();
+    }
+
+    /// <summary>The 8-octet Client Cookie.</summary>
+    public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+
+    /// <summary>The Server Cookie, or an empty span when only a Client Cookie is present.</summary>
+    public ReadOnlySpan<byte> ServerCookie => _serverCookie ?? Array.Empty<byte>();
+
+    /// <summary>True when this cookie carries a Server Cookie.</summary>
+    public bool HasServerCookie => _serverCookie is not null;
+
+    /// <inheritdoc />
+    internal override void WritePayload(ref DnsWireWriter writer)
+    {
+        writer.WriteBytes(_clientCookie);
+        if (_serverCookie is not null)
+        {
+            writer.WriteBytes(_serverCookie);
+        }
+    }
+
+    internal static DnsEdnsCookieOption ReadPayload(ref DnsWireReader reader, int payloadLength)
+    {
+        if (payloadLength != 8 && (payloadLength < 16 || payloadLength > 40))
+        {
+            DnsException.ThrowMalformed(
+                $"Cookie option payload must be 8 (client only) or 16..40 (client+server) octets; got {payloadLength}");
+        }
+        ReadOnlySpan<byte> client = reader.ReadBytes(8);
+        ReadOnlySpan<byte> server = payloadLength == 8
+            ? default
+            : reader.ReadBytes(payloadLength - 8);
+        return new DnsEdnsCookieOption(client, server);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsExtendedErrorOption.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsExtendedErrorOption.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// The EDNS Extended-DNS-Error option (EDE) &#8211; RFC 8914. Carries a structured
+/// info-code plus an optional UTF-8 text explanation, allowing responders to surface
+/// validation, blocking, or rate-limiting reasons that the four-bit RCODE can't represent.
+/// </summary>
+public sealed class DnsEdnsExtendedErrorOption : DnsEdnsOption
+{
+    /// <summary>
+    /// Initializes a new EDE option.
+    /// </summary>
+    /// <param name="infoCode">The IANA-assigned info code (RFC 8914 §4 + the EDE registry).</param>
+    /// <param name="extraText">Optional UTF-8 explanatory text.</param>
+    public DnsEdnsExtendedErrorOption(ushort infoCode, string? extraText = null)
+        : base(DnsEdnsOptionCode.ExtendedError)
+    {
+        InfoCode = infoCode;
+        ExtraText = extraText;
+    }
+
+    /// <summary>The numeric info code.</summary>
+    public ushort InfoCode { get; }
+
+    /// <summary>The UTF-8 explanatory text; null when omitted.</summary>
+    public string? ExtraText { get; }
+
+    /// <inheritdoc />
+    internal override void WritePayload(ref DnsWireWriter writer)
+    {
+        writer.WriteUInt16(InfoCode);
+        if (!string.IsNullOrEmpty(ExtraText))
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(ExtraText);
+            writer.WriteBytes(bytes);
+        }
+    }
+
+    internal static DnsEdnsExtendedErrorOption ReadPayload(ref DnsWireReader reader, int payloadLength)
+    {
+        if (payloadLength < 2)
+        {
+            DnsException.ThrowMalformed(
+                $"Extended-DNS-Error option requires at least 2 octets (info code); got {payloadLength}");
+        }
+        ushort infoCode = reader.ReadUInt16();
+        string? extra = null;
+        if (payloadLength > 2)
+        {
+            ReadOnlySpan<byte> bytes = reader.ReadBytes(payloadLength - 2);
+            extra = Encoding.UTF8.GetString(bytes);
+        }
+        return new DnsEdnsExtendedErrorOption(infoCode, extra);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsFlags.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsFlags.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Boolean flag bits carried in the 16-bit flags field of the EDNS OPT pseudo-record
+/// (RFC 6891 &#167; 6.1.3). Currently only the DO bit is defined; the rest are reserved for
+/// future extension.
+/// </summary>
+[Flags]
+public enum DnsEdnsFlags : ushort
+{
+    /// <summary>No flags set.</summary>
+    None = 0,
+
+    /// <summary>DO &#8211; DNSSEC OK (RFC 3225). Set in queries that ask the responder to
+    /// include DNSSEC RRs in the answer.</summary>
+    DnssecOk = 1 << 15,
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsOption.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsOption.cs
@@ -1,0 +1,37 @@
+using System;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Base class for an EDNS option carried inside a <see cref="DnsOptRecord"/>'s RDATA
+/// (RFC 6891 &#167; 6.1.2). Each option has a 16-bit code and a length-prefixed payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Derived types expose strongly-typed properties for the well-known options
+/// (<see cref="DnsEdnsClientSubnetOption"/>, <see cref="DnsEdnsExtendedErrorOption"/>,
+/// <see cref="DnsEdnsCookieOption"/>, ...). Any option whose code isn't recognized parses
+/// as <see cref="DnsEdnsUnknownOption"/> preserving the opaque bytes so the OPT record can
+/// round-trip without loss &#8211; required by RFC 6891 &#167; 4 for forward-compatibility.
+/// </para>
+/// </remarks>
+public abstract class DnsEdnsOption
+{
+    /// <summary>
+    /// Initializes shared properties on a derived option.
+    /// </summary>
+    protected DnsEdnsOption(DnsEdnsOptionCode code)
+    {
+        Code = code;
+    }
+
+    /// <summary>The IANA-assigned option code.</summary>
+    public DnsEdnsOptionCode Code { get; }
+
+    /// <summary>
+    /// Writes the option's payload (the bytes that follow the 4-octet option-code +
+    /// option-length header). Implementations write only the type-specific payload.
+    /// </summary>
+    internal abstract void WritePayload(ref DnsWireWriter writer);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsOptionCode.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsOptionCode.cs
@@ -1,0 +1,54 @@
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// EDNS option codes. Values are assigned by IANA in the
+/// <see href="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11">
+/// DNS Parameters &#8211; EDNS0 Option Codes</see> registry.
+/// </summary>
+public enum DnsEdnsOptionCode : ushort
+{
+    /// <summary>NSID (RFC 5001) &#8211; opaque DNS server identifier returned with responses.</summary>
+    Nsid = 3,
+
+    /// <summary>DAU (RFC 6975) &#8211; DNSSEC algorithm understood by the client.</summary>
+    DnssecAlgorithmUnderstood = 5,
+
+    /// <summary>DHU (RFC 6975) &#8211; DS hash algorithm understood by the client.</summary>
+    DsHashUnderstood = 6,
+
+    /// <summary>N3U (RFC 6975) &#8211; NSEC3 hash algorithm understood by the client.</summary>
+    Nsec3HashUnderstood = 7,
+
+    /// <summary>Client subnet (RFC 7871) &#8211; ECS for geo-tailored answers.</summary>
+    ClientSubnet = 8,
+
+    /// <summary>Expire (RFC 7314) &#8211; zone-expire metadata for AXFR/IXFR responses.</summary>
+    Expire = 9,
+
+    /// <summary>Cookie (RFC 7873) &#8211; lightweight transaction binding.</summary>
+    Cookie = 10,
+
+    /// <summary>Edns-Tcp-Keepalive (RFC 7828).</summary>
+    TcpKeepalive = 11,
+
+    /// <summary>Padding (RFC 7830).</summary>
+    Padding = 12,
+
+    /// <summary>Chain query (RFC 7901).</summary>
+    Chain = 13,
+
+    /// <summary>Key tag (RFC 8145).</summary>
+    KeyTag = 14,
+
+    /// <summary>Extended DNS error (RFC 8914).</summary>
+    ExtendedError = 15,
+
+    /// <summary>Client tag (draft).</summary>
+    ClientTag = 16,
+
+    /// <summary>Server tag (draft).</summary>
+    ServerTag = 17,
+
+    /// <summary>Report channel (RFC 9567).</summary>
+    ReportChannel = 18,
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsUnknownOption.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Edns/DnsEdnsUnknownOption.cs
@@ -1,0 +1,29 @@
+using System;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// An EDNS option whose <see cref="DnsEdnsOption.Code"/> isn't recognized by this library.
+/// Preserves the opaque payload bytes so the OPT record round-trips per RFC 6891 &#167; 4.
+/// </summary>
+public sealed class DnsEdnsUnknownOption : DnsEdnsOption
+{
+    private readonly byte[] _payload;
+
+    /// <summary>
+    /// Initializes a new <see cref="DnsEdnsUnknownOption"/>.
+    /// </summary>
+    public DnsEdnsUnknownOption(DnsEdnsOptionCode code, ReadOnlySpan<byte> payload)
+        : base(code)
+    {
+        _payload = payload.ToArray();
+    }
+
+    /// <summary>The opaque payload bytes preserved from the wire.</summary>
+    public ReadOnlySpan<byte> Payload => _payload;
+
+    /// <inheritdoc />
+    internal override void WritePayload(ref DnsWireWriter writer)
+        => writer.WriteBytes(_payload);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsNameDecoder.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsNameDecoder.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Text;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Decodes a wire-format DNS name back to its dotted presentation form, handling RFC 1035
+/// &#167; 4.1.4 compression pointers along the way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A wire-format name is a sequence of labels. Each label starts with a length octet:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>00xxxxxx</c> (0&#8211;63): a literal label of <c>x</c> octets.</description></item>
+///   <item><description><c>11xxxxxx xxxxxxxx</c>: a 14-bit pointer to an earlier offset in the message.</description></item>
+///   <item><description><c>10</c> and <c>01</c> prefixes are reserved and reject as malformed.</description></item>
+///   <item><description><c>00000000</c> (length 0): the root label terminates the name.</description></item>
+/// </list>
+/// <para>
+/// The decoder caps pointer follow-ups to defend against compression loops, caps the total
+/// reassembled name at RFC 1035's 255-octet limit, and rejects forward pointers (every
+/// compression pointer MUST refer to an earlier offset).
+/// </para>
+/// </remarks>
+internal static class DnsNameDecoder
+{
+    /// <summary>Maximum number of compression pointers any one name may follow. Defensive
+    /// upper bound that comfortably exceeds anything seen in practice.</summary>
+    private const int MaxPointerHops = 32;
+
+    /// <summary>
+    /// Reads a name from <paramref name="reader"/>, following compression pointers into
+    /// <paramref name="message"/>. The cursor on <paramref name="reader"/> advances to the
+    /// octet immediately after the name's last byte (or the pointer that terminated it).
+    /// </summary>
+    public static DnsName Read(ref DnsWireReader reader, ReadOnlySpan<byte> message)
+    {
+        StringBuilder builder = new();
+        int hops = 0;
+        int totalLength = 0;
+
+        // We need to track whether we've followed a pointer. Once we follow one, advances
+        // on the SECONDARY reader don't move the primary cursor — but the primary cursor must
+        // sit immediately past the two-octet pointer that started the indirect chain.
+        DnsWireReader cursor = reader;
+        int? returnTo = null;
+
+        while (true)
+        {
+            byte length = cursor.ReadUInt8();
+
+            if (length == 0)
+            {
+                // Root label terminator.
+                if (returnTo is null)
+                {
+                    reader.Seek(cursor.Position);
+                }
+                else
+                {
+                    reader.Seek(returnTo.Value);
+                }
+
+                if (builder.Length == 0)
+                {
+                    return DnsName.Root;
+                }
+                return new DnsName(builder.ToString());
+            }
+
+            int kind = length & 0xC0;
+            if (kind == 0x00)
+            {
+                // Literal label.
+                if (length > 63)
+                {
+                    DnsException.ThrowMalformed($"label length {length} exceeds the RFC 1035 limit of 63 octets");
+                }
+
+                ReadOnlySpan<byte> labelBytes = cursor.ReadBytes(length);
+                if (builder.Length > 0)
+                {
+                    builder.Append('.');
+                    totalLength++;
+                }
+                AppendLabel(builder, labelBytes);
+                totalLength += labelBytes.Length;
+                if (totalLength > 253)
+                {
+                    DnsException.ThrowMalformed(
+                        $"reassembled name exceeds the RFC 1035 limit of 253 presentation characters");
+                }
+            }
+            else if (kind == 0xC0)
+            {
+                // Compression pointer. 14-bit offset into the message.
+                byte low = cursor.ReadUInt8();
+                int pointer = ((length & 0x3F) << 8) | low;
+
+                if (returnTo is null)
+                {
+                    // First pointer encountered — the primary reader stops here.
+                    returnTo = cursor.Position;
+                }
+
+                if (pointer >= reader.Length)
+                {
+                    DnsException.ThrowMalformed($"compression pointer {pointer} falls outside the message (length {reader.Length})");
+                }
+
+                // RFC 1035 doesn't strictly require backward pointers, but every compliant
+                // encoder produces them and accepting forward pointers would expose us to
+                // straightforward DoS via loops. Reject them.
+                int sourceOffset = returnTo.Value - 2;
+                if (pointer >= sourceOffset)
+                {
+                    DnsException.ThrowMalformed(
+                        $"compression pointer at offset {sourceOffset} targets non-prior offset {pointer}");
+                }
+
+                hops++;
+                if (hops > MaxPointerHops)
+                {
+                    DnsException.ThrowMalformed($"compression pointer chain exceeds {MaxPointerHops} hops");
+                }
+
+                cursor = new DnsWireReader(message, pointer);
+            }
+            else
+            {
+                DnsException.ThrowMalformed(
+                    $"label length octet 0x{length:X2} uses reserved bit pattern (top two bits 01 or 10)");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Appends a single label's bytes to <paramref name="builder"/>, escaping non-ASCII or
+    /// special characters per RFC 1035 §5.1 presentation-form rules.
+    /// </summary>
+    private static void AppendLabel(StringBuilder builder, ReadOnlySpan<byte> labelBytes)
+    {
+        foreach (byte b in labelBytes)
+        {
+            // ASCII letters / digits / hyphen / underscore pass through verbatim (the common
+            // case). Other ASCII and any 8-bit byte get backslash-escaped.
+            if ((b >= 'a' && b <= 'z') ||
+                (b >= 'A' && b <= 'Z') ||
+                (b >= '0' && b <= '9') ||
+                b == '-' || b == '_')
+            {
+                builder.Append((char)b);
+            }
+            else if (b == '.' || b == '\\')
+            {
+                builder.Append('\\').Append((char)b);
+            }
+            else if (b is >= 0x21 and <= 0x7E)
+            {
+                builder.Append((char)b);
+            }
+            else
+            {
+                // Non-printable / 8-bit byte → \DDD numeric escape.
+                builder.Append('\\');
+                builder.Append((char)('0' + (b / 100)));
+                builder.Append((char)('0' + ((b / 10) % 10)));
+                builder.Append((char)('0' + (b % 10)));
+            }
+        }
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsNameEncoder.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsNameEncoder.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Text;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Encodes a <see cref="DnsName"/> into wire format, optionally compressing suffixes that
+/// have already appeared in the current message (RFC 1035 &#167; 4.1.4).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The encoder walks the name's labels from the apex back to the leaf. For each suffix it
+/// either emits a 14-bit pointer into <see cref="DnsWireWriter.LabelOffsets"/> when an
+/// earlier occurrence is recorded, or emits the literal label(s) followed by the root
+/// terminator. New suffixes are recorded so subsequent names in the same message can
+/// reference them.
+/// </para>
+/// <para>
+/// Records that the wire format requires to skip compression (notably the RRSIG signing
+/// process) call the no-compress entry point so the canonical form is reproducible.
+/// </para>
+/// </remarks>
+internal static class DnsNameEncoder
+{
+    /// <summary>
+    /// Writes <paramref name="name"/> in wire format using compression where possible.
+    /// </summary>
+    public static void Write(ref DnsWireWriter writer, DnsName name)
+        => WriteCore(ref writer, name, compress: true);
+
+    /// <summary>
+    /// Writes <paramref name="name"/> in wire format without consulting the compression
+    /// table. Used for canonical-form serialization (DNSSEC, future feature) where
+    /// compression is forbidden.
+    /// </summary>
+    public static void WriteUncompressed(ref DnsWireWriter writer, DnsName name)
+        => WriteCore(ref writer, name, compress: false);
+
+    private static void WriteCore(ref DnsWireWriter writer, DnsName name, bool compress)
+    {
+        string[] labels = name.GetLabels();
+
+        // Root name is just the zero terminator.
+        if (labels.Length == 0)
+        {
+            writer.WriteUInt8(0);
+            return;
+        }
+
+        // Walk labels from leaf to root, building lowercase suffixes for the compression
+        // table. We emit labels in their original case but key the table by lowercase to
+        // match RFC 1035 §2.3.3 case-insensitive equality.
+        for (int i = 0; i < labels.Length; i++)
+        {
+            string label = labels[i];
+            byte[] labelBytes = Encoding.ASCII.GetBytes(label);
+            if (labelBytes.Length > 63)
+            {
+                DnsException.ThrowMalformed(
+                    $"label '{label}' exceeds the RFC 1035 limit of 63 octets in wire form");
+            }
+
+            string suffixKey = BuildSuffixKey(labels, i);
+
+            // Compression: if this suffix already appears in the message and the offset fits
+            // in 14 bits, emit a pointer and stop.
+            if (compress && writer.LabelOffsets.TryGetValue(suffixKey, out int existingOffset))
+            {
+                if (existingOffset < 0x4000)
+                {
+                    writer.WriteUInt16((ushort)(0xC000 | existingOffset));
+                    return;
+                }
+            }
+
+            // Record THIS suffix's offset before writing, so a later name can point to it.
+            if (compress && writer.Position < 0x4000)
+            {
+                writer.LabelOffsets[suffixKey] = writer.Position;
+            }
+
+            writer.WriteUInt8((byte)labelBytes.Length);
+            writer.WriteBytes(labelBytes);
+        }
+
+        // Root terminator.
+        writer.WriteUInt8(0);
+    }
+
+    /// <summary>
+    /// Builds the lowercase dotted suffix starting at <paramref name="startIndex"/>. Used as
+    /// the compression-table key so equivalent suffixes match regardless of case.
+    /// </summary>
+    private static string BuildSuffixKey(string[] labels, int startIndex)
+    {
+        if (startIndex == labels.Length - 1)
+        {
+            return labels[startIndex].ToLowerInvariant();
+        }
+
+        StringBuilder builder = new();
+        for (int i = startIndex; i < labels.Length; i++)
+        {
+            if (i > startIndex)
+            {
+                builder.Append('.');
+            }
+            builder.Append(labels[i].ToLowerInvariant());
+        }
+        return builder.ToString();
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsWireReader.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsWireReader.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Buffers.Binary;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Forward-only big-endian reader over a DNS wire-format buffer. The DNS protocol uses
+/// network byte order (big-endian) for every multi-octet field; this wrapper centralizes the
+/// byte-order conversion and bounds-checking so the parsers can stay readable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DnsWireReader"/> is a <see langword="ref struct"/> so it can wrap a stack-only
+/// <see cref="ReadOnlySpan{Byte}"/> without allocation. Each <c>Read*</c> call advances
+/// <see cref="Position"/>; on insufficient buffer the reader throws
+/// <see cref="DnsException"/> with <see cref="DnsErrorCode.Malformed"/> so caller code does
+/// not need to repeat the check.
+/// </para>
+/// <para>
+/// The reader does not own the buffer &#8211; it never mutates it &#8211; so several readers
+/// may view the same message in parallel (used by the name decoder when following
+/// compression pointers).
+/// </para>
+/// </remarks>
+internal ref struct DnsWireReader
+{
+    private readonly ReadOnlySpan<byte> _buffer;
+    private int _position;
+
+    public DnsWireReader(ReadOnlySpan<byte> buffer)
+    {
+        _buffer = buffer;
+        _position = 0;
+    }
+
+    public DnsWireReader(ReadOnlySpan<byte> buffer, int position)
+    {
+        _buffer = buffer;
+        _position = position;
+    }
+
+    /// <summary>Current zero-based offset into the buffer.</summary>
+    public int Position => _position;
+
+    /// <summary>Total length of the underlying buffer.</summary>
+    public int Length => _buffer.Length;
+
+    /// <summary>Octets remaining between the cursor and the end of the buffer.</summary>
+    public int Remaining => _buffer.Length - _position;
+
+    /// <summary>Raw view of the buffer; never mutated.</summary>
+    public ReadOnlySpan<byte> Buffer => _buffer;
+
+    /// <summary>
+    /// Reads one octet and advances the cursor.
+    /// </summary>
+    public byte ReadUInt8()
+    {
+        EnsureAvailable(1);
+        return _buffer[_position++];
+    }
+
+    /// <summary>
+    /// Reads a big-endian 16-bit unsigned integer and advances the cursor.
+    /// </summary>
+    public ushort ReadUInt16()
+    {
+        EnsureAvailable(2);
+        ushort value = BinaryPrimitives.ReadUInt16BigEndian(_buffer.Slice(_position, 2));
+        _position += 2;
+        return value;
+    }
+
+    /// <summary>
+    /// Reads a big-endian 32-bit unsigned integer and advances the cursor.
+    /// </summary>
+    public uint ReadUInt32()
+    {
+        EnsureAvailable(4);
+        uint value = BinaryPrimitives.ReadUInt32BigEndian(_buffer.Slice(_position, 4));
+        _position += 4;
+        return value;
+    }
+
+    /// <summary>
+    /// Returns a sub-span of <paramref name="length"/> octets starting at the current cursor
+    /// and advances the cursor.
+    /// </summary>
+    public ReadOnlySpan<byte> ReadBytes(int length)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        }
+        EnsureAvailable(length);
+        ReadOnlySpan<byte> slice = _buffer.Slice(_position, length);
+        _position += length;
+        return slice;
+    }
+
+    /// <summary>
+    /// Peeks the next octet without advancing the cursor.
+    /// </summary>
+    public byte PeekUInt8()
+    {
+        EnsureAvailable(1);
+        return _buffer[_position];
+    }
+
+    /// <summary>
+    /// Peeks the next big-endian 16-bit unsigned integer without advancing the cursor.
+    /// </summary>
+    public ushort PeekUInt16()
+    {
+        EnsureAvailable(2);
+        return BinaryPrimitives.ReadUInt16BigEndian(_buffer.Slice(_position, 2));
+    }
+
+    /// <summary>
+    /// Repositions the cursor to <paramref name="offset"/>. Used by the name decoder when
+    /// following compression pointers.
+    /// </summary>
+    /// <exception cref="DnsException">Offset falls outside the buffer.</exception>
+    public void Seek(int offset)
+    {
+        if ((uint)offset > (uint)_buffer.Length)
+        {
+            DnsException.ThrowMalformed($"wire offset {offset} is outside the buffer (length {_buffer.Length})");
+        }
+        _position = offset;
+    }
+
+    /// <summary>
+    /// Throws <see cref="DnsException"/> with <see cref="DnsErrorCode.Malformed"/> when fewer
+    /// than <paramref name="count"/> octets remain.
+    /// </summary>
+    private void EnsureAvailable(int count)
+    {
+        if (_buffer.Length - _position < count)
+        {
+            DnsException.ThrowMalformed(
+                $"wire buffer underrun: needed {count} octets at offset {_position} but only {_buffer.Length - _position} remain");
+        }
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsWireWriter.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Internal/DnsWireWriter.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Forward-only big-endian writer over a DNS wire-format buffer. Mirrors
+/// <see cref="DnsWireReader"/>: centralises byte-order conversion and bounds checking so the
+/// serializers stay readable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DnsWireWriter"/> is a <see langword="ref struct"/> so it can wrap a stack-only
+/// <see cref="Span{Byte}"/> without allocation. Insufficient buffer is signalled with
+/// <see cref="DnsException"/> &#8211; the writer never grows the buffer, leaving allocation
+/// strategy to the caller (typically a rented pool buffer sized to RFC 6891 EDNS payload
+/// limits).
+/// </para>
+/// <para>
+/// The writer also maintains a name-compression table (<see cref="LabelOffsets"/>) used by
+/// the name encoder to deduplicate suffixes per RFC 1035 &#167; 4.1.4.
+/// </para>
+/// </remarks>
+internal ref struct DnsWireWriter
+{
+    private readonly Span<byte> _buffer;
+    private int _position;
+
+    public DnsWireWriter(Span<byte> buffer)
+    {
+        _buffer = buffer;
+        _position = 0;
+    }
+
+    /// <summary>Current zero-based offset into the buffer.</summary>
+    public int Position => _position;
+
+    /// <summary>Total length of the underlying buffer.</summary>
+    public int Length => _buffer.Length;
+
+    /// <summary>Octets remaining between the cursor and the end of the buffer.</summary>
+    public int Remaining => _buffer.Length - _position;
+
+    /// <summary>
+    /// Per-message name-compression table. Maps the dotted lowercase suffix to its first
+    /// occurrence offset. Reset between messages by the caller (writers are short-lived so
+    /// this is rarely an issue).
+    /// </summary>
+    public Dictionary<string, int> LabelOffsets { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Writes one octet.
+    /// </summary>
+    public void WriteUInt8(byte value)
+    {
+        EnsureCapacity(1);
+        _buffer[_position++] = value;
+    }
+
+    /// <summary>
+    /// Writes a 16-bit unsigned integer in big-endian.
+    /// </summary>
+    public void WriteUInt16(ushort value)
+    {
+        EnsureCapacity(2);
+        BinaryPrimitives.WriteUInt16BigEndian(_buffer.Slice(_position, 2), value);
+        _position += 2;
+    }
+
+    /// <summary>
+    /// Writes a 32-bit unsigned integer in big-endian.
+    /// </summary>
+    public void WriteUInt32(uint value)
+    {
+        EnsureCapacity(4);
+        BinaryPrimitives.WriteUInt32BigEndian(_buffer.Slice(_position, 4), value);
+        _position += 4;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="bytes"/> directly to the buffer. The parameter is
+    /// <see langword="scoped"/> so callers can pass <c>stackalloc</c>-backed spans without
+    /// triggering escape-analysis errors on this <see langword="ref struct"/>.
+    /// </summary>
+    public void WriteBytes(scoped ReadOnlySpan<byte> bytes)
+    {
+        EnsureCapacity(bytes.Length);
+        bytes.CopyTo(_buffer.Slice(_position, bytes.Length));
+        _position += bytes.Length;
+    }
+
+    /// <summary>
+    /// Reserves <paramref name="length"/> octets at the current cursor and returns a mutable
+    /// span into them. The cursor advances past the reservation. Used by record writers to
+    /// patch a 16-bit RDLENGTH after writing the RDATA itself.
+    /// </summary>
+    public Span<byte> Reserve(int length)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        }
+        EnsureCapacity(length);
+        Span<byte> slice = _buffer.Slice(_position, length);
+        _position += length;
+        return slice;
+    }
+
+    /// <summary>
+    /// Patches a 16-bit big-endian unsigned integer at <paramref name="offset"/> without
+    /// moving the cursor.
+    /// </summary>
+    public void PatchUInt16(int offset, ushort value)
+    {
+        if (offset < 0 || offset + 2 > _buffer.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        }
+        BinaryPrimitives.WriteUInt16BigEndian(_buffer.Slice(offset, 2), value);
+    }
+
+    /// <summary>
+    /// Returns the slice of the buffer written so far.
+    /// </summary>
+    public ReadOnlySpan<byte> WrittenSpan => _buffer.Slice(0, _position);
+
+    /// <summary>
+    /// Direct, mutable access to the underlying buffer. Used by the name encoder when
+    /// emitting raw label bytes.
+    /// </summary>
+    public Span<byte> Buffer => _buffer;
+
+    private void EnsureCapacity(int count)
+    {
+        if (_buffer.Length - _position < count)
+        {
+            DnsException.ThrowMalformed(
+                $"wire buffer overrun: tried to write {count} octets at offset {_position} but only {_buffer.Length - _position} remain");
+        }
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsARecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsARecord.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// An IPv4 host-address (<c>A</c>) record &#8211; RFC 1035 &#167; 3.4.1. The RDATA is exactly
+/// four octets of network-order IPv4 address.
+/// </summary>
+public sealed class DnsARecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>A</c> record.
+    /// </summary>
+    /// <param name="name">The owner name.</param>
+    /// <param name="address">The IPv4 address. Must be an
+    /// <see cref="System.Net.Sockets.AddressFamily.InterNetwork"/> address.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsARecord(DnsName name, IPAddress address, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.A, @class, timeToLive)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        if (address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        {
+            throw new ArgumentException("A records require an IPv4 (AddressFamily.InterNetwork) address.", nameof(address));
+        }
+        Address = address;
+    }
+
+    /// <summary>The IPv4 address recorded in this entry.</summary>
+    public IPAddress Address { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        if (!Address.TryWriteBytes(bytes, out int written) || written != 4)
+        {
+            DnsException.ThrowMalformed("failed to serialize IPv4 address into 4 octets");
+        }
+        writer.WriteBytes(bytes);
+    }
+
+    internal static DnsARecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        ushort rdLength)
+    {
+        if (rdLength != 4)
+        {
+            DnsException.ThrowMalformed($"A record RDATA length must be 4 octets; got {rdLength}");
+        }
+        ReadOnlySpan<byte> bytes = reader.ReadBytes(4);
+        return new DnsARecord(name, new IPAddress(bytes), ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsAaaaRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsAaaaRecord.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// An IPv6 host-address (<c>AAAA</c>) record &#8211; RFC 3596. The RDATA is exactly 16 octets
+/// of network-order IPv6 address.
+/// </summary>
+public sealed class DnsAaaaRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>AAAA</c> record.
+    /// </summary>
+    /// <param name="name">The owner name.</param>
+    /// <param name="address">The IPv6 address. Must be an
+    /// <see cref="System.Net.Sockets.AddressFamily.InterNetworkV6"/> address.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsAaaaRecord(DnsName name, IPAddress address, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.AAAA, @class, timeToLive)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        if (address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6)
+        {
+            throw new ArgumentException("AAAA records require an IPv6 (AddressFamily.InterNetworkV6) address.", nameof(address));
+        }
+        Address = address;
+    }
+
+    /// <summary>The IPv6 address recorded in this entry.</summary>
+    public IPAddress Address { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        if (!Address.TryWriteBytes(bytes, out int written) || written != 16)
+        {
+            DnsException.ThrowMalformed("failed to serialize IPv6 address into 16 octets");
+        }
+        writer.WriteBytes(bytes);
+    }
+
+    internal static DnsAaaaRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        ushort rdLength)
+    {
+        if (rdLength != 16)
+        {
+            DnsException.ThrowMalformed($"AAAA record RDATA length must be 16 octets; got {rdLength}");
+        }
+        ReadOnlySpan<byte> bytes = reader.ReadBytes(16);
+        return new DnsAaaaRecord(name, new IPAddress(bytes), ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsCnameRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsCnameRecord.cs
@@ -1,0 +1,58 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A canonical-name (<c>CNAME</c>) record &#8211; RFC 1035 &#167; 3.3.1. The RDATA is a
+/// single domain name; subject to compression.
+/// </summary>
+public sealed class DnsCnameRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>CNAME</c> record.
+    /// </summary>
+    /// <param name="name">The owner name (the alias).</param>
+    /// <param name="canonicalName">The canonical name the alias resolves to.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsCnameRecord(DnsName name, DnsName canonicalName, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.CNAME, @class, timeToLive)
+    {
+        CanonicalName = canonicalName;
+    }
+
+    /// <summary>The canonical name pointed to by this alias.</summary>
+    public DnsName CanonicalName { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+        => DnsNameEncoder.Write(ref writer, CanonicalName);
+
+    internal static DnsCnameRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        DnsName target = DnsNameDecoder.Read(ref reader, message);
+        EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsCnameRecord));
+        return new DnsCnameRecord(name, target, ttl, @class);
+    }
+
+    internal static void EnsureFullyConsumed(
+        DnsWireReader reader,
+        int rdataStart,
+        ushort rdLength,
+        string recordTypeName)
+    {
+        int consumed = reader.Position - rdataStart;
+        if (consumed != rdLength)
+        {
+            DnsException.ThrowMalformed(
+                $"{recordTypeName} RDATA: declared length {rdLength} but consumed {consumed} octets");
+        }
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsMxRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsMxRecord.cs
@@ -1,0 +1,59 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A mail-exchange (<c>MX</c>) record &#8211; RFC 1035 &#167; 3.3.9. The RDATA is a
+/// 16-bit preference followed by a domain name; the name is subject to compression.
+/// Receivers select the MX with the lowest preference value (smaller = higher priority).
+/// </summary>
+public sealed class DnsMxRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>MX</c> record.
+    /// </summary>
+    /// <param name="name">The owner name (the domain whose mail this MX serves).</param>
+    /// <param name="preference">Preference value; lower wins.</param>
+    /// <param name="exchange">The host that handles mail for the owner.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsMxRecord(
+        DnsName name,
+        ushort preference,
+        DnsName exchange,
+        uint timeToLive,
+        DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.MX, @class, timeToLive)
+    {
+        Preference = preference;
+        Exchange = exchange;
+    }
+
+    /// <summary>Preference value &#8211; lower numbers are tried first.</summary>
+    public ushort Preference { get; }
+
+    /// <summary>The host that accepts mail for the owner.</summary>
+    public DnsName Exchange { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        writer.WriteUInt16(Preference);
+        DnsNameEncoder.Write(ref writer, Exchange);
+    }
+
+    internal static DnsMxRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        ushort preference = reader.ReadUInt16();
+        DnsName exchange = DnsNameDecoder.Read(ref reader, message);
+        DnsCnameRecord.EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsMxRecord));
+        return new DnsMxRecord(name, preference, exchange, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsNsRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsNsRecord.cs
@@ -1,0 +1,45 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// An authoritative-name-server (<c>NS</c>) record &#8211; RFC 1035 &#167; 3.3.11. The RDATA
+/// is a single domain name pointing at the authoritative server for the zone; subject to
+/// compression.
+/// </summary>
+public sealed class DnsNsRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>NS</c> record.
+    /// </summary>
+    /// <param name="name">The owner name (the zone).</param>
+    /// <param name="nameServer">The authoritative name server for the zone.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsNsRecord(DnsName name, DnsName nameServer, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.NS, @class, timeToLive)
+    {
+        NameServer = nameServer;
+    }
+
+    /// <summary>The authoritative name server for the owner zone.</summary>
+    public DnsName NameServer { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+        => DnsNameEncoder.Write(ref writer, NameServer);
+
+    internal static DnsNsRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        DnsName target = DnsNameDecoder.Read(ref reader, message);
+        DnsCnameRecord.EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsNsRecord));
+        return new DnsNsRecord(name, target, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsOptRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsOptRecord.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// The EDNS OPT pseudo-record (RFC 6891 &#167; 6). Appears in the additional section of a
+/// message to negotiate payload size, surface extended RCODEs, and carry typed options
+/// (ECS, Cookie, Extended-DNS-Error, &#8230;).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The OPT record repurposes the fields of a regular resource record:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>NAME</c> &#8211; must be the root (<c>.</c>).</description></item>
+///   <item><description><c>CLASS</c> &#8211; reinterpreted as the <em>requestor's UDP payload size</em>.</description></item>
+///   <item><description><c>TTL</c> &#8211; reinterpreted as a packed
+///   (extended-RCODE &#171; 24 | version &#171; 16 | flags) word.</description></item>
+///   <item><description><c>RDATA</c> &#8211; a sequence of (option-code, option-length, option-data) triples.</description></item>
+/// </list>
+/// <para>
+/// Cohesion exposes those fields through typed properties (<see cref="UdpPayloadSize"/>,
+/// <see cref="ExtendedRCodeHigh"/>, <see cref="Version"/>, <see cref="Flags"/>) but stores
+/// them in the packed form expected by the wire writer.
+/// </para>
+/// </remarks>
+public sealed class DnsOptRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new OPT pseudo-record.
+    /// </summary>
+    /// <param name="udpPayloadSize">Maximum UDP payload size the requestor can reassemble
+    /// (RFC 6891 §6.2.3). 512 is the legacy minimum; modern resolvers typically advertise
+    /// 1232 to stay under typical Ethernet MTU.</param>
+    /// <param name="extendedRCodeHigh">Upper 8 bits of the extended 12-bit RCODE. The low
+    /// 4 bits stay in the header.</param>
+    /// <param name="version">EDNS version. Always 0 in current deployments.</param>
+    /// <param name="flags">EDNS flag bits (DO).</param>
+    /// <param name="options">The typed options carried in the RDATA.</param>
+    public DnsOptRecord(
+        ushort udpPayloadSize,
+        byte extendedRCodeHigh,
+        byte version,
+        DnsEdnsFlags flags,
+        IReadOnlyList<DnsEdnsOption> options)
+        : base(DnsName.Root, DnsRecordType.OPT, (DnsClass)udpPayloadSize, PackTtl(extendedRCodeHigh, version, flags))
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        UdpPayloadSize = udpPayloadSize;
+        ExtendedRCodeHigh = extendedRCodeHigh;
+        Version = version;
+        Flags = flags;
+        Options = options;
+    }
+
+    /// <summary>
+    /// Convenience constructor for an OPT record with no options.
+    /// </summary>
+    public DnsOptRecord(ushort udpPayloadSize, DnsEdnsFlags flags = DnsEdnsFlags.None)
+        : this(udpPayloadSize, 0, 0, flags, Array.Empty<DnsEdnsOption>())
+    {
+    }
+
+    /// <summary>Maximum UDP payload size advertised by the requestor.</summary>
+    public ushort UdpPayloadSize { get; }
+
+    /// <summary>Upper 8 bits of the extended 12-bit RCODE.</summary>
+    public byte ExtendedRCodeHigh { get; }
+
+    /// <summary>EDNS version (always 0 in current deployments).</summary>
+    public byte Version { get; }
+
+    /// <summary>EDNS flag bits.</summary>
+    public DnsEdnsFlags Flags { get; }
+
+    /// <summary>Typed options carried in the RDATA.</summary>
+    public IReadOnlyList<DnsEdnsOption> Options { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        foreach (DnsEdnsOption option in Options)
+        {
+            writer.WriteUInt16((ushort)option.Code);
+            int lengthOffset = writer.Position;
+            writer.WriteUInt16(0); // placeholder for option-length
+            int payloadStart = writer.Position;
+            option.WritePayload(ref writer);
+            int payloadLength = writer.Position - payloadStart;
+            if (payloadLength > ushort.MaxValue)
+            {
+                DnsException.ThrowMalformed(
+                    $"EDNS option {option.Code} payload exceeds 65535 octets ({payloadLength})");
+            }
+            writer.PatchUInt16(lengthOffset, (ushort)payloadLength);
+        }
+    }
+
+    internal static DnsOptRecord ReadRData(
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        ushort rdLength)
+    {
+        ushort udpPayloadSize = (ushort)@class;
+        byte extendedRCodeHigh = (byte)((ttl >> 24) & 0xFF);
+        byte version = (byte)((ttl >> 16) & 0xFF);
+        DnsEdnsFlags flags = (DnsEdnsFlags)(ttl & 0xFFFF);
+
+        var options = new List<DnsEdnsOption>();
+        int rdataStart = reader.Position;
+        while (reader.Position - rdataStart < rdLength)
+        {
+            DnsEdnsOptionCode code = (DnsEdnsOptionCode)reader.ReadUInt16();
+            ushort optionLength = reader.ReadUInt16();
+            int optionStart = reader.Position;
+
+            DnsEdnsOption option = code switch
+            {
+                DnsEdnsOptionCode.ClientSubnet => DnsEdnsClientSubnetOption.ReadPayload(ref reader, optionLength),
+                DnsEdnsOptionCode.Cookie => DnsEdnsCookieOption.ReadPayload(ref reader, optionLength),
+                DnsEdnsOptionCode.ExtendedError => DnsEdnsExtendedErrorOption.ReadPayload(ref reader, optionLength),
+                _ => new DnsEdnsUnknownOption(code, reader.ReadBytes(optionLength)),
+            };
+
+            int consumed = reader.Position - optionStart;
+            if (consumed != optionLength)
+            {
+                DnsException.ThrowMalformed(
+                    $"EDNS option {code}: declared length {optionLength} but consumed {consumed} octets");
+            }
+            options.Add(option);
+        }
+
+        if (reader.Position - rdataStart != rdLength)
+        {
+            DnsException.ThrowMalformed("OPT record RDATA length mismatch");
+        }
+
+        return new DnsOptRecord(udpPayloadSize, extendedRCodeHigh, version, flags, options);
+    }
+
+    private static uint PackTtl(byte extendedRCodeHigh, byte version, DnsEdnsFlags flags)
+        => ((uint)extendedRCodeHigh << 24) | ((uint)version << 16) | (ushort)flags;
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsPtrRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsPtrRecord.cs
@@ -1,0 +1,45 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A pointer (<c>PTR</c>) record &#8211; RFC 1035 &#167; 3.3.12. Used for reverse DNS
+/// lookups (e.g. <c>1.2.3.4.in-addr.arpa PTR host.example.com</c>). The RDATA is a single
+/// domain name; subject to compression.
+/// </summary>
+public sealed class DnsPtrRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>PTR</c> record.
+    /// </summary>
+    /// <param name="name">The owner name (typically a reverse-mapped address).</param>
+    /// <param name="pointerName">The name the owner points at.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsPtrRecord(DnsName name, DnsName pointerName, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.PTR, @class, timeToLive)
+    {
+        PointerName = pointerName;
+    }
+
+    /// <summary>The name this record points at.</summary>
+    public DnsName PointerName { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+        => DnsNameEncoder.Write(ref writer, PointerName);
+
+    internal static DnsPtrRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        DnsName target = DnsNameDecoder.Read(ref reader, message);
+        DnsCnameRecord.EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsPtrRecord));
+        return new DnsPtrRecord(name, target, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsSoaRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsSoaRecord.cs
@@ -1,0 +1,103 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A start-of-authority (<c>SOA</c>) record &#8211; RFC 1035 &#167; 3.3.13. Exactly one
+/// instance exists at the apex of every zone, carrying the primary nameserver, the contact
+/// mailbox, the zone serial, and four timers controlling zone-transfer cadence.
+/// </summary>
+/// <remarks>
+/// The RDATA layout is:
+/// <list type="number">
+///   <item><description><c>MNAME</c> &#8211; primary master name server (subject to
+///   compression).</description></item>
+///   <item><description><c>RNAME</c> &#8211; responsible-person mailbox, with the local part
+///   represented as a label (e.g. <c>hostmaster.example.com</c> stands for
+///   <c>hostmaster@example.com</c>). Subject to compression.</description></item>
+///   <item><description><c>SERIAL</c>, <c>REFRESH</c>, <c>RETRY</c>, <c>EXPIRE</c>,
+///   <c>MINIMUM</c> &#8211; five 32-bit unsigned integers.</description></item>
+/// </list>
+/// </remarks>
+public sealed class DnsSoaRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>SOA</c> record.
+    /// </summary>
+    public DnsSoaRecord(
+        DnsName name,
+        DnsName primaryNameServer,
+        DnsName responsibleMailbox,
+        uint serial,
+        uint refreshInterval,
+        uint retryInterval,
+        uint expireLimit,
+        uint minimumTtl,
+        uint timeToLive,
+        DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.SOA, @class, timeToLive)
+    {
+        PrimaryNameServer = primaryNameServer;
+        ResponsibleMailbox = responsibleMailbox;
+        Serial = serial;
+        RefreshInterval = refreshInterval;
+        RetryInterval = retryInterval;
+        ExpireLimit = expireLimit;
+        MinimumTtl = minimumTtl;
+    }
+
+    /// <summary>Primary master name server for the zone.</summary>
+    public DnsName PrimaryNameServer { get; }
+
+    /// <summary>Responsible-person mailbox in DNS label form.</summary>
+    public DnsName ResponsibleMailbox { get; }
+
+    /// <summary>Zone serial; bumped on every committed change.</summary>
+    public uint Serial { get; }
+
+    /// <summary>Seconds between zone-refresh checks by secondaries.</summary>
+    public uint RefreshInterval { get; }
+
+    /// <summary>Seconds before a secondary retries after a failed refresh.</summary>
+    public uint RetryInterval { get; }
+
+    /// <summary>Seconds after which a secondary should consider the zone authoritative
+    /// data stale and stop serving it.</summary>
+    public uint ExpireLimit { get; }
+
+    /// <summary>Minimum TTL for records returned from this zone (RFC 2308 reinterprets this
+    /// as the negative-caching TTL).</summary>
+    public uint MinimumTtl { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        DnsNameEncoder.Write(ref writer, PrimaryNameServer);
+        DnsNameEncoder.Write(ref writer, ResponsibleMailbox);
+        writer.WriteUInt32(Serial);
+        writer.WriteUInt32(RefreshInterval);
+        writer.WriteUInt32(RetryInterval);
+        writer.WriteUInt32(ExpireLimit);
+        writer.WriteUInt32(MinimumTtl);
+    }
+
+    internal static DnsSoaRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        DnsName mname = DnsNameDecoder.Read(ref reader, message);
+        DnsName rname = DnsNameDecoder.Read(ref reader, message);
+        uint serial = reader.ReadUInt32();
+        uint refresh = reader.ReadUInt32();
+        uint retry = reader.ReadUInt32();
+        uint expire = reader.ReadUInt32();
+        uint minimum = reader.ReadUInt32();
+        DnsCnameRecord.EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsSoaRecord));
+        return new DnsSoaRecord(name, mname, rname, serial, refresh, retry, expire, minimum, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsSrvRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsSrvRecord.cs
@@ -1,0 +1,71 @@
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A service-locator (<c>SRV</c>) record &#8211; RFC 2782. Carries
+/// (priority, weight, port, target) for a named service. The target name is NOT subject to
+/// compression per RFC 2782 §4 (but many implementations compress it anyway; the decoder
+/// accepts compressed names and the encoder emits uncompressed names to stay strict).
+/// </summary>
+public sealed class DnsSrvRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>SRV</c> record.
+    /// </summary>
+    public DnsSrvRecord(
+        DnsName name,
+        ushort priority,
+        ushort weight,
+        ushort port,
+        DnsName target,
+        uint timeToLive,
+        DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.SRV, @class, timeToLive)
+    {
+        Priority = priority;
+        Weight = weight;
+        Port = port;
+        Target = target;
+    }
+
+    /// <summary>Lower priorities are tried first (smaller wins).</summary>
+    public ushort Priority { get; }
+
+    /// <summary>Relative weight for load-balancing across equal-priority records.</summary>
+    public ushort Weight { get; }
+
+    /// <summary>The TCP/UDP port the service runs on.</summary>
+    public ushort Port { get; }
+
+    /// <summary>The host that provides the service.</summary>
+    public DnsName Target { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        writer.WriteUInt16(Priority);
+        writer.WriteUInt16(Weight);
+        writer.WriteUInt16(Port);
+        // RFC 2782 §4 forbids compression of the SRV target. Use the uncompressed encoder so
+        // signed / canonical-form records produce reproducible bytes.
+        DnsNameEncoder.WriteUncompressed(ref writer, Target);
+    }
+
+    internal static DnsSrvRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        System.ReadOnlySpan<byte> message,
+        int rdataStart,
+        ushort rdLength)
+    {
+        ushort priority = reader.ReadUInt16();
+        ushort weight = reader.ReadUInt16();
+        ushort port = reader.ReadUInt16();
+        DnsName target = DnsNameDecoder.Read(ref reader, message);
+        DnsCnameRecord.EnsureFullyConsumed(reader, rdataStart, rdLength, nameof(DnsSrvRecord));
+        return new DnsSrvRecord(name, priority, weight, port, target, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsTxtRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsTxtRecord.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A text (<c>TXT</c>) record &#8211; RFC 1035 &#167; 3.3.14. The RDATA is a sequence of one
+/// or more length-prefixed character strings (each &#8804; 255 octets). Used for arbitrary
+/// text data: SPF, DKIM, domain-ownership verification, and anything else.
+/// </summary>
+public sealed class DnsTxtRecord : DnsRecord
+{
+    /// <summary>
+    /// Initializes a new <c>TXT</c> record with one or more strings.
+    /// </summary>
+    /// <param name="name">The owner name.</param>
+    /// <param name="strings">The text strings. Each must be 0&#8211;255 octets in UTF-8.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="class">The DNS class. Defaults to <see cref="DnsClass.IN"/>.</param>
+    public DnsTxtRecord(
+        DnsName name,
+        IReadOnlyList<string> strings,
+        uint timeToLive,
+        DnsClass @class = DnsClass.IN)
+        : base(name, DnsRecordType.TXT, @class, timeToLive)
+    {
+        ArgumentNullException.ThrowIfNull(strings);
+        if (strings.Count == 0)
+        {
+            throw new ArgumentException("TXT record must carry at least one string.", nameof(strings));
+        }
+
+        foreach (var s in strings)
+        {
+            if (s is null)
+            {
+                throw new ArgumentException("TXT record strings cannot be null.", nameof(strings));
+            }
+            int byteCount = Encoding.UTF8.GetByteCount(s);
+            if (byteCount > 255)
+            {
+                throw new ArgumentException(
+                    $"TXT record string exceeds the RFC 1035 limit of 255 octets (got {byteCount}).",
+                    nameof(strings));
+            }
+        }
+        Strings = strings;
+    }
+
+    /// <summary>
+    /// Convenience constructor for the common single-string case.
+    /// </summary>
+    public DnsTxtRecord(DnsName name, string text, uint timeToLive, DnsClass @class = DnsClass.IN)
+        : this(name, new[] { text }, timeToLive, @class)
+    {
+    }
+
+    /// <summary>The strings carried in the RDATA, in their declared order.</summary>
+    public IReadOnlyList<string> Strings { get; }
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+    {
+        foreach (var s in Strings)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(s);
+            writer.WriteUInt8((byte)bytes.Length);
+            writer.WriteBytes(bytes);
+        }
+    }
+
+    internal static DnsTxtRecord ReadRData(
+        DnsName name,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        ushort rdLength)
+    {
+        var strings = new List<string>();
+        int rdataStart = reader.Position;
+        while (reader.Position - rdataStart < rdLength)
+        {
+            byte length = reader.ReadUInt8();
+            ReadOnlySpan<byte> bytes = reader.ReadBytes(length);
+            strings.Add(Encoding.UTF8.GetString(bytes));
+        }
+        int consumed = reader.Position - rdataStart;
+        if (consumed != rdLength)
+        {
+            DnsException.ThrowMalformed(
+                $"TXT RDATA: declared length {rdLength} but consumed {consumed} octets");
+        }
+        if (strings.Count == 0)
+        {
+            DnsException.ThrowMalformed("TXT record must contain at least one string");
+        }
+        return new DnsTxtRecord(name, strings, ttl, @class);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsUnknownRecord.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/src/Records/DnsUnknownRecord.cs
@@ -1,0 +1,66 @@
+using System;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A resource record whose <see cref="DnsRecord.Type"/> isn't recognized by this library.
+/// Preserves the opaque RDATA bytes so the message can round-trip unchanged.
+/// </summary>
+/// <remarks>
+/// <para>
+/// RFC 3597 (handling of unknown DNS resource record types) is explicit that resolvers and
+/// authorities MUST preserve unknown RR types byte-for-byte: future protocol additions
+/// would otherwise be impossible without rolling out new code everywhere first. This record
+/// satisfies that requirement and is the default fall-through in the wire-format dispatcher.
+/// </para>
+/// <para>
+/// Compression in RDATA is not allowed for unknown types per RFC 3597 §4, so the bytes are
+/// emitted verbatim on the wire. The decoder copies the RDATA into a fresh array so the
+/// record doesn't pin the source message buffer.
+/// </para>
+/// </remarks>
+public sealed class DnsUnknownRecord : DnsRecord
+{
+    private readonly byte[] _data;
+
+    /// <summary>
+    /// Initializes a new <see cref="DnsUnknownRecord"/>.
+    /// </summary>
+    /// <param name="name">The owner name.</param>
+    /// <param name="type">The (unknown-to-us) record type code.</param>
+    /// <param name="class">The DNS class.</param>
+    /// <param name="timeToLive">The TTL in seconds.</param>
+    /// <param name="data">The opaque RDATA bytes.</param>
+    public DnsUnknownRecord(
+        DnsName name,
+        DnsRecordType type,
+        DnsClass @class,
+        uint timeToLive,
+        ReadOnlySpan<byte> data)
+        : base(name, type, @class, timeToLive)
+    {
+        _data = data.ToArray();
+    }
+
+    /// <summary>
+    /// The opaque RDATA bytes preserved from the wire.
+    /// </summary>
+    public ReadOnlySpan<byte> Data => _data;
+
+    /// <inheritdoc />
+    internal override void WriteRData(ref DnsWireWriter writer)
+        => writer.WriteBytes(_data);
+
+    internal static DnsUnknownRecord ReadRData(
+        DnsName name,
+        DnsRecordType type,
+        DnsClass @class,
+        uint ttl,
+        ref DnsWireReader reader,
+        ushort rdLength)
+    {
+        ReadOnlySpan<byte> bytes = reader.ReadBytes(rdLength);
+        return new DnsUnknownRecord(name, type, @class, ttl, bytes);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsEdnsTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsEdnsTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Net;
+using Assimalign.Cohesion.Dns;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// Round-trip and malformed-input coverage for the EDNS OPT pseudo-record and its options
+/// (RFC 6891, RFC 7871 ECS, RFC 7873 Cookie, RFC 8914 Extended-DNS-Error).
+/// </summary>
+public class DnsEdnsTests
+{
+    private static byte[] WriteToArray(DnsMessage message)
+    {
+        byte[] buffer = new byte[4096];
+        int written = message.WriteTo(buffer);
+        return buffer.AsSpan(0, written).ToArray();
+    }
+
+    private static DnsMessage BuildWithOpt(DnsOptRecord opt)
+    {
+        var header = new DnsHeader(
+            id: 0x1111,
+            flags: DnsHeaderFlags.RecursionDesired,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NoError,
+            questionCount: 1,
+            answerCount: 0,
+            authorityCount: 0,
+            additionalCount: 1);
+        return new DnsMessage(
+            header,
+            new[] { new DnsQuestion("example.com", DnsRecordType.A) },
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>(),
+            new DnsRecord[] { opt });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: empty OPT round-trips with payload size + DO bit")]
+    public void EmptyOpt_RoundTrip()
+    {
+        var opt = new DnsOptRecord(udpPayloadSize: 1232, flags: DnsEdnsFlags.DnssecOk);
+        var message = BuildWithOpt(opt);
+
+        byte[] bytes = WriteToArray(message);
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedOpt = parsed.Edns;
+
+        Assert.NotNull(parsedOpt);
+        Assert.Equal((ushort)1232, parsedOpt!.UdpPayloadSize);
+        Assert.Equal(DnsEdnsFlags.DnssecOk, parsedOpt.Flags);
+        Assert.Empty(parsedOpt.Options);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: ECS option round-trips IPv4 prefix")]
+    public void EcsOption_IPv4_RoundTrip()
+    {
+        var ecs = new DnsEdnsClientSubnetOption(IPAddress.Parse("192.0.2.0"), sourcePrefixLength: 24);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { ecs });
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedOpt = parsed.Edns!;
+        var parsedEcs = Assert.IsType<DnsEdnsClientSubnetOption>(parsedOpt.Options[0]);
+        Assert.Equal(IPAddress.Parse("192.0.2.0"), parsedEcs.Address);
+        Assert.Equal((byte)24, parsedEcs.SourcePrefixLength);
+        Assert.Equal((byte)0, parsedEcs.ScopePrefixLength);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: ECS option round-trips IPv6 prefix")]
+    public void EcsOption_IPv6_RoundTrip()
+    {
+        var ecs = new DnsEdnsClientSubnetOption(IPAddress.Parse("2001:db8::"), sourcePrefixLength: 48, scopePrefixLength: 56);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { ecs });
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedEcs = Assert.IsType<DnsEdnsClientSubnetOption>(parsed.Edns!.Options[0]);
+        Assert.Equal(IPAddress.Parse("2001:db8::"), parsedEcs.Address);
+        Assert.Equal((byte)48, parsedEcs.SourcePrefixLength);
+        Assert.Equal((byte)56, parsedEcs.ScopePrefixLength);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: Cookie option (client-only) round-trips")]
+    public void CookieOption_ClientOnly_RoundTrip()
+    {
+        var clientCookie = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+        var cookie = new DnsEdnsCookieOption(clientCookie);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { cookie });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedCookie = Assert.IsType<DnsEdnsCookieOption>(parsed.Edns!.Options[0]);
+
+        Assert.False(parsedCookie.HasServerCookie);
+        Assert.True(clientCookie.AsSpan().SequenceEqual(parsedCookie.ClientCookie));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: Cookie option (client + server) round-trips")]
+    public void CookieOption_ClientServer_RoundTrip()
+    {
+        var clientCookie = new byte[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var serverCookie = new byte[16] { 0xaa, 0xbb, 0xcc, 0xdd, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        var cookie = new DnsEdnsCookieOption(clientCookie, serverCookie);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { cookie });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedCookie = Assert.IsType<DnsEdnsCookieOption>(parsed.Edns!.Options[0]);
+
+        Assert.True(parsedCookie.HasServerCookie);
+        Assert.True(clientCookie.AsSpan().SequenceEqual(parsedCookie.ClientCookie));
+        Assert.True(serverCookie.AsSpan().SequenceEqual(parsedCookie.ServerCookie));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: Extended-DNS-Error round-trips info-code + text")]
+    public void ExtendedError_RoundTrip()
+    {
+        var ede = new DnsEdnsExtendedErrorOption(infoCode: 6 /* DNSSEC bogus */, extraText: "signature expired");
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { ede });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedEde = Assert.IsType<DnsEdnsExtendedErrorOption>(parsed.Edns!.Options[0]);
+
+        Assert.Equal((ushort)6, parsedEde.InfoCode);
+        Assert.Equal("signature expired", parsedEde.ExtraText);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: unknown option code preserves payload bytes")]
+    public void UnknownOption_PreservesPayload()
+    {
+        var payload = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+        var unknown = new DnsEdnsUnknownOption((DnsEdnsOptionCode)999, payload);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { unknown });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+        var parsedUnknown = Assert.IsType<DnsEdnsUnknownOption>(parsed.Edns!.Options[0]);
+
+        Assert.Equal((DnsEdnsOptionCode)999, parsedUnknown.Code);
+        Assert.True(payload.AsSpan().SequenceEqual(parsedUnknown.Payload));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: multi-option OPT preserves ordering")]
+    public void MultipleOptions_OrderPreserved()
+    {
+        var ecs = new DnsEdnsClientSubnetOption(IPAddress.Parse("192.0.2.0"), 24);
+        var cookie = new DnsEdnsCookieOption(new byte[8] { 9, 8, 7, 6, 5, 4, 3, 2 });
+        var ede = new DnsEdnsExtendedErrorOption(15);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { ecs, cookie, ede });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+        var options = parsed.Edns!.Options;
+
+        Assert.Equal(3, options.Count);
+        Assert.IsType<DnsEdnsClientSubnetOption>(options[0]);
+        Assert.IsType<DnsEdnsCookieOption>(options[1]);
+        Assert.IsType<DnsEdnsExtendedErrorOption>(options[2]);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: extended-rcode high byte round-trips")]
+    public void ExtendedRCodeHigh_RoundTrip()
+    {
+        var opt = new DnsOptRecord(udpPayloadSize: 1232, extendedRCodeHigh: 0x10, version: 0, flags: DnsEdnsFlags.None,
+            options: Array.Empty<DnsEdnsOption>());
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var parsed = DnsMessage.Parse(bytes);
+
+        Assert.Equal((byte)0x10, parsed.Edns!.ExtendedRCodeHigh);
+        Assert.Equal((byte)0, parsed.Edns.Version);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - EDNS: malformed ECS family rejected")]
+    public void EcsMalformed_BadFamily_Rejected()
+    {
+        // Build a hand-crafted OPT carrying an ECS option with family=3 (invalid).
+        // We construct it via the wire writer-level path: easier to just check the
+        // ReadPayload directly by constructing the message bytes manually.
+        // Use the Unknown option to embed the bad bytes, then ensure parsing dispatches
+        // through ECS by setting the option code to ClientSubnet.
+        byte[] badEcsPayload = new byte[] { 0x00, 0x03 /* bad family */, 0x18 /* source=24 */, 0x00, 0xC0, 0x00, 0x02 };
+        var unknown = new DnsEdnsUnknownOption(DnsEdnsOptionCode.ClientSubnet, badEcsPayload);
+        var opt = new DnsOptRecord(1232, 0, 0, DnsEdnsFlags.None, new DnsEdnsOption[] { unknown });
+
+        byte[] bytes = WriteToArray(BuildWithOpt(opt));
+        var ex = Assert.Throws<DnsException>(() => DnsMessage.Parse(bytes));
+        Assert.Equal(DnsErrorCode.Malformed, ex.Code);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsHeaderTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsHeaderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using Assimalign.Cohesion.Dns;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// Covers the 12-octet DNS header wire format (RFC 1035 §4.1.1) round-trip + the field-
+/// packing rules (OPCODE in bits 11-14, RCODE in the low 4 bits, AD/CD in bits 4-5).
+/// </summary>
+public class DnsHeaderTests
+{
+    [Fact(DisplayName = "Cohesion Test [Dns] - Header: round-trip preserves every field")]
+    public void RoundTrip_Identity()
+    {
+        var header = new DnsHeader(
+            id: 0xBEEF,
+            flags: DnsHeaderFlags.Response | DnsHeaderFlags.RecursionDesired | DnsHeaderFlags.RecursionAvailable,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NoError,
+            questionCount: 1,
+            answerCount: 2,
+            authorityCount: 3,
+            additionalCount: 4);
+
+        Span<byte> buffer = stackalloc byte[DnsHeader.WireSize];
+        header.WriteTo(buffer);
+
+        var parsed = DnsHeader.Parse(buffer);
+        Assert.Equal(header, parsed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Header: OPCODE occupies bits 11-14")]
+    public void OpCode_BitPosition()
+    {
+        var header = new DnsHeader(
+            id: 0,
+            flags: DnsHeaderFlags.None,
+            opCode: DnsOpCode.Update, // 5
+            responseCode: DnsResponseCode.NoError,
+            0, 0, 0, 0);
+
+        Span<byte> buffer = stackalloc byte[DnsHeader.WireSize];
+        header.WriteTo(buffer);
+
+        // Second 16-bit word (bytes 2-3): the OPCODE (5) sits in bits 11-14
+        // => 0b0010_1000_0000_0000 = 0x2800
+        Assert.Equal(0x28, buffer[2]);
+        Assert.Equal(0x00, buffer[3]);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Header: RCODE occupies the low 4 bits")]
+    public void RCode_BitPosition()
+    {
+        var header = new DnsHeader(
+            id: 0,
+            flags: DnsHeaderFlags.None,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NXDomain, // 3
+            0, 0, 0, 0);
+
+        Span<byte> buffer = stackalloc byte[DnsHeader.WireSize];
+        header.WriteTo(buffer);
+
+        Assert.Equal(0x00, buffer[2]);
+        Assert.Equal(0x03, buffer[3]);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Header: DNSSEC AD + CD bits round-trip")]
+    public void DnssecFlags_RoundTrip()
+    {
+        var header = new DnsHeader(
+            id: 0x1234,
+            flags: DnsHeaderFlags.AuthenticData | DnsHeaderFlags.CheckingDisabled,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NoError,
+            0, 0, 0, 0);
+
+        Span<byte> buffer = stackalloc byte[DnsHeader.WireSize];
+        header.WriteTo(buffer);
+
+        var parsed = DnsHeader.Parse(buffer);
+        Assert.True(parsed.Flags.HasFlag(DnsHeaderFlags.AuthenticData));
+        Assert.True(parsed.Flags.HasFlag(DnsHeaderFlags.CheckingDisabled));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Header: under-sized buffer throws Malformed")]
+    public void TooShortBuffer_Throws()
+    {
+        Span<byte> buffer = stackalloc byte[11];
+        // Have to copy out since Span can't be captured in lambdas. Use array to test.
+        var arr = new byte[11];
+        var ex = Assert.Throws<DnsException>(() => DnsHeader.Parse(arr));
+        Assert.Equal(DnsErrorCode.Malformed, ex.Code);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsMessageTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns/tests/DnsMessageTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Assimalign.Cohesion.Dns;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// Round-trip + golden-corpus tests for <see cref="DnsMessage"/>. Builds messages with each
+/// supported record family, serializes, parses, and verifies field-by-field equality.
+/// Includes name-compression coverage and unknown-RR preservation per RFC 3597.
+/// </summary>
+public class DnsMessageTests
+{
+    private static byte[] WriteToArray(DnsMessage message)
+    {
+        byte[] buffer = new byte[4096];
+        int written = message.WriteTo(buffer);
+        return buffer.AsSpan(0, written).ToArray();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: query round-trips through wire format")]
+    public void Query_RoundTrip()
+    {
+        var question = new DnsQuestion("www.example.com", DnsRecordType.A);
+        var original = new DnsMessage(0x1234, question);
+
+        byte[] bytes = WriteToArray(original);
+        var parsed = DnsMessage.Parse(bytes);
+
+        Assert.Equal(0x1234, parsed.Header.Id);
+        Assert.True(parsed.Header.Flags.HasFlag(DnsHeaderFlags.RecursionDesired));
+        Assert.Single(parsed.Questions);
+        Assert.Equal(new DnsName("www.example.com"), parsed.Questions[0].Name);
+        Assert.Equal(DnsRecordType.A, parsed.Questions[0].Type);
+        Assert.Equal(DnsClass.IN, parsed.Questions[0].Class);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: A record round-trips")]
+    public void ARecord_RoundTrip()
+    {
+        var header = new DnsHeader(0x4242, DnsHeaderFlags.Response, DnsOpCode.Query, DnsResponseCode.NoError, 1, 1, 0, 0);
+        var question = new DnsQuestion("example.com", DnsRecordType.A);
+        var record = new DnsARecord("example.com", IPAddress.Parse("93.184.216.34"), timeToLive: 3600);
+        var original = new DnsMessage(header, new[] { question }, new DnsRecord[] { record },
+            Array.Empty<DnsRecord>(), Array.Empty<DnsRecord>());
+
+        byte[] bytes = WriteToArray(original);
+        var parsed = DnsMessage.Parse(bytes);
+
+        var answer = Assert.IsType<DnsARecord>(parsed.Answers[0]);
+        Assert.Equal(IPAddress.Parse("93.184.216.34"), answer.Address);
+        Assert.Equal(3600u, answer.TimeToLive);
+        Assert.Equal(new DnsName("example.com"), answer.Name);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: AAAA record round-trips")]
+    public void AaaaRecord_RoundTrip()
+    {
+        var record = new DnsAaaaRecord("example.com", IPAddress.Parse("2606:2800:220:1:248:1893:25c8:1946"), 3600);
+        var original = BuildSingleAnswer(record);
+
+        byte[] bytes = WriteToArray(original);
+        var parsed = DnsMessage.Parse(bytes);
+
+        var answer = Assert.IsType<DnsAaaaRecord>(parsed.Answers[0]);
+        Assert.Equal(IPAddress.Parse("2606:2800:220:1:248:1893:25c8:1946"), answer.Address);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: CNAME / NS / PTR with shared suffix compress")]
+    public void NameCompression_Active()
+    {
+        // Three answers under the same example.com suffix; expect compression to fire.
+        var answers = new DnsRecord[]
+        {
+            new DnsCnameRecord("alias.example.com", "canonical.example.com", 60),
+            new DnsNsRecord("example.com", "ns1.example.com", 60),
+            new DnsPtrRecord("ptr.example.com", "host.example.com", 60),
+        };
+        var original = BuildAnswers(answers);
+
+        byte[] bytes = WriteToArray(original);
+        var parsed = DnsMessage.Parse(bytes);
+
+        Assert.Equal(3, parsed.Answers.Count);
+
+        var cname = Assert.IsType<DnsCnameRecord>(parsed.Answers[0]);
+        Assert.Equal(new DnsName("canonical.example.com"), cname.CanonicalName);
+
+        var ns = Assert.IsType<DnsNsRecord>(parsed.Answers[1]);
+        Assert.Equal(new DnsName("ns1.example.com"), ns.NameServer);
+
+        var ptr = Assert.IsType<DnsPtrRecord>(parsed.Answers[2]);
+        Assert.Equal(new DnsName("host.example.com"), ptr.PointerName);
+
+        // The serialized output should be meaningfully smaller than the uncompressed lower
+        // bound (12-byte header + 0 questions + 3 records each carrying 4 distinct names
+        // would be much larger). Verify by an upper bound.
+        Assert.True(bytes.Length < 200, $"compressed message should be <200 bytes; got {bytes.Length}");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: MX record carries preference + exchange")]
+    public void MxRecord_RoundTrip()
+    {
+        var record = new DnsMxRecord("example.com", preference: 10, exchange: "mail.example.com", 3600);
+        byte[] bytes = WriteToArray(BuildSingleAnswer(record));
+
+        var parsed = DnsMessage.Parse(bytes);
+        var mx = Assert.IsType<DnsMxRecord>(parsed.Answers[0]);
+        Assert.Equal((ushort)10, mx.Preference);
+        Assert.Equal(new DnsName("mail.example.com"), mx.Exchange);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: TXT record preserves multi-string layout")]
+    public void TxtRecord_MultiString_RoundTrip()
+    {
+        var record = new DnsTxtRecord("example.com",
+            new[] { "v=spf1", "include:_spf.example.org", "-all" },
+            timeToLive: 3600);
+        byte[] bytes = WriteToArray(BuildSingleAnswer(record));
+
+        var parsed = DnsMessage.Parse(bytes);
+        var txt = Assert.IsType<DnsTxtRecord>(parsed.Answers[0]);
+        Assert.Equal(3, txt.Strings.Count);
+        Assert.Equal("v=spf1", txt.Strings[0]);
+        Assert.Equal("include:_spf.example.org", txt.Strings[1]);
+        Assert.Equal("-all", txt.Strings[2]);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: SOA record round-trips all 7 fields")]
+    public void SoaRecord_RoundTrip()
+    {
+        var record = new DnsSoaRecord(
+            name: "example.com",
+            primaryNameServer: "ns1.example.com",
+            responsibleMailbox: "hostmaster.example.com",
+            serial: 2024_05_14_01u,
+            refreshInterval: 7200,
+            retryInterval: 3600,
+            expireLimit: 1_209_600,
+            minimumTtl: 300,
+            timeToLive: 86400);
+
+        byte[] bytes = WriteToArray(BuildSingleAnswer(record));
+        var parsed = DnsMessage.Parse(bytes);
+        var soa = Assert.IsType<DnsSoaRecord>(parsed.Answers[0]);
+
+        Assert.Equal(new DnsName("ns1.example.com"), soa.PrimaryNameServer);
+        Assert.Equal(new DnsName("hostmaster.example.com"), soa.ResponsibleMailbox);
+        Assert.Equal(2024_05_14_01u, soa.Serial);
+        Assert.Equal(7200u, soa.RefreshInterval);
+        Assert.Equal(3600u, soa.RetryInterval);
+        Assert.Equal(1_209_600u, soa.ExpireLimit);
+        Assert.Equal(300u, soa.MinimumTtl);
+        Assert.Equal(86400u, soa.TimeToLive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: SRV record round-trips")]
+    public void SrvRecord_RoundTrip()
+    {
+        var record = new DnsSrvRecord("_xmpp-server._tcp.example.com",
+            priority: 5, weight: 10, port: 5269, target: "xmpp.example.com", timeToLive: 86400);
+        byte[] bytes = WriteToArray(BuildSingleAnswer(record));
+
+        var parsed = DnsMessage.Parse(bytes);
+        var srv = Assert.IsType<DnsSrvRecord>(parsed.Answers[0]);
+        Assert.Equal((ushort)5, srv.Priority);
+        Assert.Equal((ushort)10, srv.Weight);
+        Assert.Equal((ushort)5269, srv.Port);
+        Assert.Equal(new DnsName("xmpp.example.com"), srv.Target);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: unknown RR type preserves bytes verbatim")]
+    public void UnknownRecord_RoundTrip()
+    {
+        // RFC 3597: every implementation MUST preserve unknown types byte-for-byte.
+        // Use a code that's not in DnsRecordType (62 = CSYNC, not enumerated).
+        var unknownType = (DnsRecordType)62;
+        var rdata = new byte[] { 0x01, 0x02, 0x03, 0x04, 0xDE, 0xAD, 0xBE, 0xEF };
+        var record = new DnsUnknownRecord("example.com", unknownType, DnsClass.IN, 3600, rdata);
+
+        byte[] bytes = WriteToArray(BuildSingleAnswer(record));
+        var parsed = DnsMessage.Parse(bytes);
+        var unknown = Assert.IsType<DnsUnknownRecord>(parsed.Answers[0]);
+
+        Assert.Equal(unknownType, unknown.Type);
+        Assert.True(rdata.AsSpan().SequenceEqual(unknown.Data));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: Parse rejects truncated header")]
+    public void ParseTruncated_Throws()
+    {
+        var ex = Assert.Throws<DnsException>(() => DnsMessage.Parse(new byte[5]));
+        Assert.Equal(DnsErrorCode.Malformed, ex.Code);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Dns] - Message: Parse rejects malformed name (reserved label kind)")]
+    public void ParseReservedLabelKind_Throws()
+    {
+        // Build a valid header with QDCOUNT=1, then a label with the reserved bit pattern 0x80
+        // (top two bits 10).
+        byte[] bytes = new byte[14];
+        // Header: id=0, flags=0, qd=1, an=0, ns=0, ar=0
+        bytes[5] = 0x01;
+        // Question: label with reserved length octet (top bits 10)
+        bytes[12] = 0x80;
+
+        var ex = Assert.Throws<DnsException>(() => DnsMessage.Parse(bytes));
+        Assert.Equal(DnsErrorCode.Malformed, ex.Code);
+    }
+
+    // ----- helpers -----
+
+    private static DnsMessage BuildSingleAnswer(DnsRecord record)
+    {
+        var header = new DnsHeader(
+            id: 0x4242,
+            flags: DnsHeaderFlags.Response | DnsHeaderFlags.RecursionDesired | DnsHeaderFlags.RecursionAvailable,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NoError,
+            questionCount: 0,
+            answerCount: 1,
+            authorityCount: 0,
+            additionalCount: 0);
+        return new DnsMessage(header, Array.Empty<DnsQuestion>(), new[] { record },
+            Array.Empty<DnsRecord>(), Array.Empty<DnsRecord>());
+    }
+
+    private static DnsMessage BuildAnswers(IReadOnlyList<DnsRecord> records)
+    {
+        var header = new DnsHeader(
+            id: 0x4242,
+            flags: DnsHeaderFlags.Response,
+            opCode: DnsOpCode.Query,
+            responseCode: DnsResponseCode.NoError,
+            questionCount: 0,
+            answerCount: (ushort)records.Count,
+            authorityCount: 0,
+            additionalCount: 0);
+        return new DnsMessage(header, Array.Empty<DnsQuestion>(), records,
+            Array.Empty<DnsRecord>(), Array.Empty<DnsRecord>());
+    }
+}


### PR DESCRIPTION
## Summary

Second of three PRs for the **L01.01.08 DNS** epic. Folds:

- **Feature 03** DNS packets, names, resource-record wire fidelity
  - `.03.01` (629) Validate DNS header, section counts, name compression
  - `.03.02` (630) Normalize RR modeling + canonical serialization + unknown-RR preservation
  - `.03.03` (631) Build packet + RR golden corpora plus RFC conformance tests
- **Feature 04** Normalize EDNS + protocol extension handling
  - `.04.01` (633) Implement EDNS negotiation, OPT record handling, payload-size fallback
  - `.04.02` (634) Model EDNS options generically (ECS, extended errors, cookies, unknown)
  - `.04.03` (635) Build EDNS round-trip + downgrade + malformed-input compliance tests

PR 3 (last of the three) covers Features `.05` (transport stack) + `.06` (resolver + cache).

## Transports library decision

PR 2 doesn't introduce concrete transports, but the public `DnsTransport` shape was adjusted to align with `Assimalign.Cohesion.Transports`'s `ClientTransport`:

```diff
-public abstract Task<ReadOnlyMemory<byte>> ExchangeAsync(
-    EndPoint endpoint, ReadOnlyMemory<byte> request, CancellationToken ct);
+public abstract EndPoint Endpoint { get; }
+public abstract Task<ReadOnlyMemory<byte>> ExchangeAsync(
+    ReadOnlyMemory<byte> request, CancellationToken ct);
```

One transport binds to one upstream at construction. PR 3 will introduce thin `UdpDnsTransport` / `TcpDnsTransport` / `QuicDnsTransport` adapters over `UdpClientTransport` / `TcpClientTransport` / `QuicClientTransport`. DoT will likely need a small `TlsClientTransport` addition in the Transports library; DoH is better served by `HttpClient` than by the raw-transport layer.

## Wire format (Feature 03)

| Type | Role |
|------|------|
| `DnsHeader` (struct, 12-octet `WireSize`) | RFC 1035 §4.1.1 header with field-level `Parse` / `WriteTo`. |
| `DnsHeaderFlags` (`[Flags]`) | QR / AA / TC / RD / RA / AD / CD. |
| `DnsRecord` (abstract base) | Closed-extension; unknown wire types round-trip via `DnsUnknownRecord`. |
| `DnsARecord` / `DnsAaaaRecord` | RFC 1035 §3.4.1 + RFC 3596. |
| `DnsCnameRecord` / `DnsNsRecord` / `DnsPtrRecord` | Single-name RDATA. |
| `DnsMxRecord` | 16-bit preference + name. |
| `DnsTxtRecord` | Multi-string RDATA. |
| `DnsSoaRecord` | Two names + 5 × uint32 timers. |
| `DnsSrvRecord` | priority / weight / port / target (target uncompressed per RFC 2782 §4). |
| `DnsUnknownRecord` | Opaque RDATA preservation per RFC 3597. |
| `DnsMessage` | Full 4-section message with `Parse(ReadOnlySpan<byte>)` + `WriteTo(Span<byte>)` / `TryWriteTo(Span<byte>, out int)`. Section counts derived from collection sizes on write. |

### Name compression
- Encode: shared per-message suffix table on `DnsWireWriter`; emits 14-bit pointers when offset fits.
- Decode: handles pointers with chain depth ≤ 32, rejects forward pointers, caps reassembled name at 253 chars.

### Internal helpers (`src/Internal/`)
- `DnsWireReader` / `DnsWireWriter` — `ref struct` wrappers over `Span<byte>`, centralized big-endian + bounds checks.
- `DnsNameDecoder` / `DnsNameEncoder` — RFC 1035 §4.1.4 encode/decode.

## EDNS (Feature 04)

| Type | Role |
|------|------|
| `DnsOptRecord` | RFC 6891 OPT pseudo-record. Re-purposes `Class` as UDP payload size, `TTL` as `(extended-RCODE-high, version, flags)`. Exposes typed properties. |
| `DnsEdnsFlags` | `DnssecOk` (DO bit, RFC 3225). |
| `DnsEdnsOption` (abstract) | Closed-extension; unknown codes via `DnsEdnsUnknownOption`. |
| `DnsEdnsClientSubnetOption` | RFC 7871 ECS, IPv4 + IPv6. |
| `DnsEdnsCookieOption` | RFC 7873 client/server cookies. |
| `DnsEdnsExtendedErrorOption` | RFC 8914 info code + optional UTF-8 text. |
| `DnsEdnsOptionCode` | IANA-assigned codes with RFC citations. |

`DnsMessage.Edns` convenience getter scans the additional section for the OPT record.

## Tests (58 total, all passing locally Debug + Release; was 32)

| Suite | Tests |
|-------|------:|
| `DnsExceptionTests` (PR 1) | 10 |
| `DnsNameTests` (PR 1) | 12 |
| `DnsQuestionTests` (PR 1) | 3 |
| `DnsClientLifecycleTests` (PR 1) | 6 |
| **`DnsHeaderTests` (new)** | 5 |
| **`DnsMessageTests` (new)** | 12 |
| **`DnsEdnsTests` (new)** | 10 |

## Net change
- 32 files changed, +2,909 / −71
- 24 new source files (wire helpers + record family + EDNS + tests)
- 4 modified (DnsMessage rewrite, DnsRecord → abstract, DnsTransport shape, docs)

## Test plan

- [x] `dotnet build` clean Debug + Release (0 errors, 0 library-code warnings; AOT analyzer happy)
- [x] `dotnet test` Dns suite (58/58 pass locally)
- [ ] CI green across ubuntu / windows / macos × 2 packages (6 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)