### PR TITLE
feat(dns.client): UDP + TCP transports + DoT/DoH/DoQ placeholders (L01.01.08 PR3)

### DIFF
--- a/.github/workflows/library-dns.yml
+++ b/.github/workflows/library-dns.yml
@@ -21,6 +21,9 @@ jobs:
         projects: [
             "Assimalign.Cohesion.Dns",
             "Assimalign.Cohesion.Dns.Client",
+            "Assimalign.Cohesion.Dns.Client.Dot",
+            "Assimalign.Cohesion.Dns.Client.Doh",
+            "Assimalign.Cohesion.Dns.Client.Doq",
           ]
     steps:
       - uses: actions/checkout@v4

--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -636,6 +636,36 @@
 	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/">
 		<Project Path="libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/Assimalign.Cohesion.Dns.Client.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/README.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/OVERVIEW.md" />
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/src/">
+		<Project Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/src/Assimalign.Cohesion.Dns.Client.Dot.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/README.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/OVERVIEW.md" />
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/src/">
+		<Project Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/src/Assimalign.Cohesion.Dns.Client.Doh.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/README.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/">
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/OVERVIEW.md" />
+		<File Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/src/">
+		<Project Path="libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/src/Assimalign.Cohesion.Dns.Client.Doq.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/libraries/FileSystem/">
 		<File Path="libraries/FileSystem/Directory.Build.props" />
 		<File Path="libraries/FileSystem/Directory.Build.targets" />

--- a/frameworks/Assimalign.Cohesion.App.props
+++ b/frameworks/Assimalign.Cohesion.App.props
@@ -79,6 +79,9 @@
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.ApplicationModel" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Dns" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Dns.Client" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Dns.Client.Dot" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Dns.Client.Doh" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Dns.Client.Doq" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.FileSystem.Aggregate" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.FileSystem.IsolatedStorage" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.ObjectMapping" />

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/README.md
@@ -1,0 +1,16 @@
+# Assimalign.Cohesion.Dns.Client.Doh
+
+DNS-over-HTTPS (DoH) transport for the Cohesion DNS family — RFC 8484.
+
+**Placeholder package.** No implementation ships in this build. The
+package is scaffolded so the family layout is in place when the
+implementation lands; the public surface contract lives in
+`docs/REQUIREMENTS.md`.
+
+DoH carries DNS messages over HTTP/2 (or HTTP/3) with
+`Content-Type: application/dns-message`. The implementation will
+build on `Assimalign.Cohesion.Http.ClientFactory` so consumers can
+plug their existing `HttpClient` pipeline (auth, retries, proxies)
+into the DoH transport without modification.
+
+See `docs/REQUIREMENTS.md` for the full implementation contract.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/OVERVIEW.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/OVERVIEW.md
@@ -1,0 +1,57 @@
+# Assimalign.Cohesion.Dns.Client.Doh
+
+## Summary
+
+DNS-over-HTTPS (DoH) transport for the Cohesion DNS family.
+Implements RFC 8484 ("DNS Queries over HTTPS (DoH)") on top of the
+wire format defined in `Assimalign.Cohesion.Dns`.
+
+## Status
+
+**Placeholder.** No code in this package today; only the csproj and
+docs exist so the family layout is stable. Implementation deferred
+until `Assimalign.Cohesion.Http.ClientFactory` matures &mdash; the DoH
+transport is designed as a thin adapter on top of the Cohesion HTTP
+client factory, and standing it up before that surface is finalized
+would only bake in churn.
+
+See `docs/REQUIREMENTS.md` for the implementation contract &mdash;
+public surface, expected dependencies, test plan, and open design
+questions. PR-3 (the resolver + UDP/TCP transports PR) creates this
+placeholder so callers can pin a reference to a stable assembly name
+ahead of the eventual implementation.
+
+## Why a separate package
+
+DoH layers DNS messages over HTTP/2 (or HTTP/3) with
+`Content-Type: application/dns-message`. That means the transport
+pulls in the entire HTTP client stack &mdash; auth handlers, retry
+policies, proxy resolution, HTTP/2 multiplexing &mdash; that pure
+UDP/TCP DNS users have no use for. Keeping DoH in its own package:
+
+- Lets users opt out of the HTTP dependency surface when they only
+  need UDP/TCP/DoT.
+- Mirrors the family layout of the FileSystem packages (one
+  provider per package).
+- Lets the DoH transport integrate cleanly with whatever
+  authentication, retries, and observability the host has already
+  configured on its `HttpClient` pipeline &mdash; just hand the
+  transport an `IHttpClientFactory` and a logical-name string.
+
+## When implementation lands
+
+The implementing PR will:
+
+1. Add a single `DohDnsTransport : DnsTransport` type plus its
+   options bag.
+2. Wire it to `Assimalign.Cohesion.Http.ClientFactory` for
+   `HttpClient` resolution.
+3. Register a factory-style extension method (`AddDohDnsTransport`)
+   for the resolver builder.
+4. Add the assembly to the CI matrix in
+   `.github/workflows/library-dns.yml`.
+5. Add the assembly to `frameworks/Assimalign.Cohesion.App.props`
+   under the active block.
+6. Replace this OVERVIEW with the post-implementation version
+   (status, public surface, etc.) and either freeze
+   `REQUIREMENTS.md` or fold it into the DESIGN doc.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/REQUIREMENTS.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/docs/REQUIREMENTS.md
@@ -1,0 +1,191 @@
+# Assimalign.Cohesion.Dns.Client.Doh &mdash; Implementation requirements
+
+> **Status: deferred.** This package ships as an empty placeholder
+> until `Assimalign.Cohesion.Http.ClientFactory` is feature-complete.
+> This document is the contract the implementing PR must satisfy.
+
+## Standards
+
+Primary: **[RFC 8484](https://www.rfc-editor.org/rfc/rfc8484)** &mdash;
+"DNS Queries over HTTPS (DoH)".
+
+Supplementary:
+- **RFC 7540 / RFC 9113** &mdash; HTTP/2 (the default DoH binding).
+- **RFC 9114** &mdash; HTTP/3 (optional, encouraged if the host
+  `HttpClient` negotiates it).
+- **RFC 8467** &mdash; padding for encrypted DNS (recommended for
+  DoH, optional behind a transport flag).
+
+## Public surface contract
+
+The implementing PR MUST deliver:
+
+```csharp
+namespace Assimalign.Cohesion.Dns;
+
+public sealed class DohDnsTransport : DnsTransport
+{
+    public DohDnsTransport(DohDnsTransportOptions options);
+
+    public override EndPoint Endpoint { get; }
+        // Surfaced as a DnsHttpEndPoint wrapping the Uri so the
+        // DnsTransport base contract holds without forcing callers
+        // to think about IP/Port for a URL-addressed transport.
+
+    public override Task<ReadOnlyMemory<byte>> ExchangeAsync(
+        ReadOnlyMemory<byte> request,
+        CancellationToken cancellationToken = default);
+
+    protected override ValueTask DisposeAsyncCore();
+}
+
+public sealed class DohDnsTransportOptions
+{
+    // Required. RFC 8484 §3 URI template; query parameter handling
+    // applies only when Method = HttpMethod.Get.
+    public Uri Endpoint { get; set; }
+
+    // Required. Resolves an HttpClient by logical name from the
+    // Cohesion HTTP client factory. The host configures auth,
+    // retries, proxies, HTTP/3 negotiation, etc. on that named
+    // client &mdash; DoH itself only takes the resulting pipeline.
+    public IHttpClientFactory HttpClientFactory { get; set; }
+    public string HttpClientName { get; set; } = "DnsDoh";
+
+    // GET (RFC 8484 §4.1.1, base64url-encoded ?dns= parameter, more
+    // cacheable) vs POST (§4.1.2, application/dns-message body).
+    // POST is the default for size headroom and cacheability
+    // neutrality at the transport layer.
+    public HttpMethod Method { get; set; } = HttpMethod.Post;
+
+    public TimeSpan QueryTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    // RFC 8467 padding. Off by default to keep wire size minimal;
+    // turn on when running over a network where size-correlated
+    // traffic analysis matters.
+    public bool PadRequests { get; set; }
+}
+```
+
+The `Endpoint` property exposed as `EndPoint` requires either a
+small `DnsHttpEndPoint : EndPoint` shim or a documented decision
+that DoH returns `Endpoint = null` for the base contract and the
+URL lives only on the options. Recommend the shim.
+
+Plus a factory-builder extension on whatever shape the resolver
+builder ends up with:
+
+```csharp
+public static IDnsResolverBuilder AddDohDnsTransport(
+    this IDnsResolverBuilder builder,
+    Action<DohDnsTransportOptions> configure);
+```
+
+## Behavior
+
+The transport MUST:
+
+1. Resolve an `HttpClient` from `HttpClientFactory` keyed by
+   `HttpClientName` for every exchange. The factory is responsible
+   for lifecycle &mdash; do **not** cache the `HttpClient` in
+   `DohDnsTransport` (Cohesion's factory may rotate handlers).
+2. Build the request per the configured `Method`:
+   - **POST**: `Content-Type: application/dns-message`, body = the
+     raw DNS wire message.
+   - **GET**: append `?dns=<base64url(message)>`. Strip any
+     pre-existing `?dns=` segment from `Endpoint.Query` before
+     appending.
+3. Set `Accept: application/dns-message`.
+4. Set `Cache-Control: no-cache` for queries the caller has marked
+   transient (see resolver design); otherwise let the response
+   `Cache-Control` flow through to the DNS cache TTL adjustment
+   logic.
+5. Validate the response:
+   - HTTP status 200 &rarr; parse body as DNS wire.
+   - HTTP status 4xx / 5xx &rarr; `DnsException` with
+     `DnsErrorCode.Transport` (carry the status code in the
+     exception data).
+   - Any `Content-Type` other than `application/dns-message`
+     &rarr; `DnsErrorCode.Malformed`.
+6. Honour the cancellation token at every async wait.
+7. Apply RFC 8467 padding when `PadRequests = true`. Pad to the
+   nearest 128-octet boundary using the EDNS Padding option
+   (option code 12, RFC 7830) and let the host pipeline pad the
+   response on its own.
+8. Map every failure to `DnsException`:
+   - HTTP error status &rarr; `DnsErrorCode.Transport`
+   - Wrong content type / empty body &rarr; `DnsErrorCode.Malformed`
+   - Timeout &rarr; `DnsErrorCode.Timeout`
+   - TLS handshake failure &rarr; `DnsErrorCode.Transport`
+     (the host `HttpClient` raised it; we just wrap)
+
+## Dependencies
+
+The package MUST depend on:
+
+- `Assimalign.Cohesion.Dns.Client` (for the `DnsTransport` base and
+  the resolver-builder integration).
+- `Assimalign.Cohesion.Http.ClientFactory` (for
+  `IHttpClientFactory` &mdash; this is the entire reason the DoH
+  package is separate from `Dns.Client`).
+
+The package MUST NOT depend on `Microsoft.Extensions.Http`. The
+Cohesion HTTP client factory is the contract surface; consumers
+who want `Microsoft.Extensions.Http` semantics can adapt via the
+factory.
+
+## Test plan
+
+1. **Round-trip against a real DoH resolver**
+   (`https://cloudflare-dns.com/dns-query`,
+   `https://dns.google/dns-query`): opt-in integration test, gated
+   on a `DnsLiveTests=true` env var. Tests both GET and POST.
+2. **Stub `HttpMessageHandler` returns a canned 200 response**:
+   asserts request `Method`, `Content-Type`, `Accept`, and body
+   bytes match the expected query encoding for both GET and POST
+   modes.
+3. **Server returns 4xx &rarr; `DnsErrorCode.Transport`**.
+4. **Server returns 200 + wrong content type &rarr;
+   `DnsErrorCode.Malformed`**.
+5. **Server returns 200 + truncated body &rarr;
+   `DnsErrorCode.Malformed`** (the resolver should not retry over
+   TCP &mdash; DoH already runs on a reliable transport).
+6. **Cancellation mid-request**: asserts
+   `OperationCanceledException` (not `DnsException`).
+7. **RFC 8467 padding**: when `PadRequests = true`, asserts the
+   serialized request includes an OPT record with a Padding option
+   bringing the total to a 128-octet multiple.
+8. **AOT analyzer clean** under
+   `<IsAotCompatible>true</IsAotCompatible>`.
+
+## Open questions for the implementer
+
+- **Endpoint surfacing**: introduce `DnsHttpEndPoint : EndPoint`
+  for the base-class `Endpoint` property, or accept that DoH
+  doesn't fit the IP/Port mental model and document the override
+  semantics. Recommendation: introduce the shim &mdash; it keeps
+  `DnsTransport` symmetric across all four transports.
+- **HTTP/3 negotiation**: leave entirely to the host
+  `HttpClient` (it'll negotiate via ALPN) or expose a transport
+  option that forces `HttpVersion = 3.0`? Default to letting the
+  host pipeline decide.
+- **Response caching**: DoH responses carry HTTP `Cache-Control`
+  headers; the DNS layer carries TTL. RFC 8484 §5.1 says the lower
+  of the two wins. Decide alongside the resolver cache design
+  (Story L01.01.08.06.01).
+- **Padding strategy**: RFC 8467 recommends padding strategies
+  (block-length 128). The first implementation should ship with
+  the recommended strategy and expose a hook for callers who want
+  to override it.
+
+## Non-goals
+
+- Acting as a DoH *server*. Server-side resolution lives under the
+  future `Assimalign.Cohesion.Dns.Authority` package (Feature
+  `.07` of the L01.01.08 epic, currently deferred).
+- Bringing its own HTTP stack. The transport composes on top of
+  whatever pipeline `IHttpClientFactory` resolves &mdash; auth,
+  retries, proxy resolution, telemetry are the host's
+  responsibility.
+- Implementing JSON-flavored DoH (Cloudflare/Google's
+  `application/dns-json` extension). RFC 8484 wire format only.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/src/Assimalign.Cohesion.Dns.Client.Doh.csproj
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doh/src/Assimalign.Cohesion.Dns.Client.Doh.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Dns</RootNamespace>
+		<Description>DNS-over-HTTPS (DoH, RFC 8484) transport for the Cohesion DNS family. Placeholder package — implementation deferred until Assimalign.Cohesion.Http.ClientFactory matures; see docs/REQUIREMENTS.md for the implementation contract.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Dns.Client" />
+	</ItemGroup>
+</Project>

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/README.md
@@ -1,0 +1,18 @@
+# Assimalign.Cohesion.Dns.Client.Doq
+
+DNS-over-QUIC (DoQ) transport for the Cohesion DNS family — RFC 9250.
+
+**Placeholder package.** No implementation ships in this build. The
+package is scaffolded so the family layout is in place when the
+implementation lands; the public surface contract lives in
+`docs/REQUIREMENTS.md`.
+
+DoQ carries DNS messages over QUIC streams using the same two-octet
+length-prefix framing as DNS-over-TCP (RFC 1035 §4.2.2), with one
+DNS exchange per QUIC stream. The implementation will build on
+`Assimalign.Cohesion.Transports.QuicClientTransport` once that
+surface is feature-complete, so connection lifecycle, 0-RTT, and
+congestion control reuse the shared transport story rather than
+being reimplemented here.
+
+See `docs/REQUIREMENTS.md` for the full implementation contract.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/OVERVIEW.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/OVERVIEW.md
@@ -1,0 +1,58 @@
+# Assimalign.Cohesion.Dns.Client.Doq
+
+## Summary
+
+DNS-over-QUIC (DoQ) transport for the Cohesion DNS family.
+Implements RFC 9250 ("DNS over Dedicated QUIC Connections") on top
+of the wire format defined in `Assimalign.Cohesion.Dns`.
+
+## Status
+
+**Placeholder.** No code in this package today; only the csproj and
+docs exist so the family layout is stable. Implementation deferred
+until `Assimalign.Cohesion.Transports` ships a QUIC client transport
+and the broader Cohesion HTTP / TLS story has matured enough to
+share certificate / authentication plumbing across DoT, DoH, and
+DoQ.
+
+See `docs/REQUIREMENTS.md` for the implementation contract &mdash;
+public surface, expected dependencies, test plan, and open design
+questions. PR-3 (the resolver + UDP/TCP transports PR) creates this
+placeholder so callers can pin a reference to a stable assembly name
+ahead of the eventual implementation.
+
+## Why a separate package
+
+DoQ requires a QUIC stack &mdash; in practice
+`System.Net.Quic`, which on .NET 10 is still platform-gated (needs a
+working MsQuic on Windows / Linux, unsupported on macOS today). That
+runtime cost has no business being paid by users of plain UDP DNS.
+Keeping DoQ as its own package:
+
+- Lets users opt out of the QUIC dependency surface entirely
+  (including the conditional `System.Net.Quic` reference).
+- Mirrors the family layout of the FileSystem packages (one
+  provider per package).
+- Makes the platform-availability story explicit in the
+  documentation rather than a runtime surprise.
+
+## When implementation lands
+
+The implementing PR will:
+
+1. Add a single `DoqDnsTransport : DnsTransport` type plus its
+   options bag.
+2. Compose on top of
+   `Assimalign.Cohesion.Transports.QuicClientTransport` for the
+   QUIC connection / stream lifecycle.
+3. Register a factory-style extension method (`AddDoqDnsTransport`)
+   for the resolver builder.
+4. Add the assembly to the CI matrix in
+   `.github/workflows/library-dns.yml`. Runs only on
+   ubuntu-latest + windows-latest until macOS gets a working QUIC
+   stack.
+5. Add the assembly to `frameworks/Assimalign.Cohesion.App.props`
+   under the active block.
+6. Replace this OVERVIEW with the post-implementation version
+   (status, public surface, etc.) and either freeze
+   `REQUIREMENTS.md` or fold it into the DESIGN doc.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/REQUIREMENTS.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/docs/REQUIREMENTS.md
@@ -1,0 +1,183 @@
+# Assimalign.Cohesion.Dns.Client.Doq &mdash; Implementation requirements
+
+> **Status: deferred.** This package ships as an empty placeholder
+> until `Assimalign.Cohesion.Transports` ships a usable QUIC client
+> transport. This document is the contract the implementing PR
+> must satisfy.
+
+## Standards
+
+Primary: **[RFC 9250](https://www.rfc-editor.org/rfc/rfc9250)** &mdash;
+"DNS over Dedicated QUIC Connections".
+
+Supplementary:
+- **RFC 9000** &mdash; QUIC v1 (the underlying transport).
+- **RFC 9001** &mdash; TLS 1.3 binding for QUIC.
+- **RFC 1035 §4.2.2** &mdash; the two-octet length prefix carries
+  over to DoQ; one DNS exchange per QUIC stream.
+- **RFC 8467** &mdash; padding for encrypted DNS (recommended for
+  DoQ as for DoT/DoH).
+
+## Public surface contract
+
+The implementing PR MUST deliver:
+
+```csharp
+namespace Assimalign.Cohesion.Dns;
+
+public sealed class DoqDnsTransport : DnsTransport
+{
+    public DoqDnsTransport(DoqDnsTransportOptions options);
+
+    public override EndPoint Endpoint { get; }
+
+    public override Task<ReadOnlyMemory<byte>> ExchangeAsync(
+        ReadOnlyMemory<byte> request,
+        CancellationToken cancellationToken = default);
+
+    protected override ValueTask DisposeAsyncCore();
+}
+
+public sealed class DoqDnsTransportOptions
+{
+    public EndPoint Endpoint { get; set; }              // required, defaults to port 853
+    public string Host { get; set; }                    // SNI + cert hostname check
+    public TimeSpan ConnectTimeout { get; set; }        // default 5s
+    public TimeSpan QueryTimeout { get; set; }          // default 5s
+
+    // QUIC IdleTimeout (RFC 9000 §10.1). Connection closes when
+    // idle for this duration. Default 30s, matching the DoT idle
+    // close in the Cohesion DoT options.
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    // Authentication profile, identical semantics to the DoT
+    // package (RFC 8310). DoQ inherits DoT's authentication model
+    // per RFC 9250 §4.
+    public DoqAuthenticationProfile AuthenticationProfile { get; set; }
+        // Strict (default) | Opportunistic | Tofu
+    public X509Certificate2Collection? PinnedCertificates { get; set; }
+    public SslClientAuthenticationOptions? SslOptions { get; set; }
+
+    // RFC 8467 padding (off by default; see RFC 9250 §8).
+    public bool PadRequests { get; set; }
+
+    // RFC 9250 §5.5.4 ALPN. MUST be "doq" per IANA registration.
+    // Exposed for future-proofing; default is correct and most
+    // callers should leave it alone.
+    public string Alpn { get; set; } = "doq";
+}
+```
+
+Plus a factory-builder extension on whatever shape the resolver
+builder ends up with:
+
+```csharp
+public static IDnsResolverBuilder AddDoqDnsTransport(
+    this IDnsResolverBuilder builder,
+    Action<DoqDnsTransportOptions> configure);
+```
+
+## Behavior
+
+The transport MUST:
+
+1. Open a QUIC connection to `Endpoint` (default port 853 per
+   RFC 9250 §4.1.1) with `ConnectTimeout`. ALPN MUST be `doq` per
+   the IANA registration referenced in RFC 9250 §5.5.4.
+2. Validate the server certificate per `AuthenticationProfile`,
+   matching the DoT semantics (Strict / Opportunistic / Tofu).
+3. Open one bidirectional QUIC stream per DNS exchange (RFC 9250
+   §4.2). The client MUST NOT reuse a stream &mdash; opening more
+   streams is cheap with QUIC, and reusing them breaks per-stream
+   flow control.
+4. Use the RFC 1035 §4.2.2 two-octet length prefix on every
+   message. The Message ID MUST be 0 per RFC 9250 §4.2.1 because
+   QUIC streams already provide correlation.
+5. Reuse the underlying QUIC *connection* for subsequent exchanges
+   until `IdleTimeout` elapses, then close gracefully with
+   transport error code `DOQ_NO_ERROR` (0).
+6. Honour the cancellation token at every async wait.
+7. Apply RFC 8467 padding when `PadRequests = true`, padding to a
+   468-octet block size per RFC 8467 §4.1 ("recommended block
+   sizes for DoT/DoQ").
+8. Map every failure to `DnsException`:
+   - QUIC handshake failure &rarr; `DnsErrorCode.Transport`
+   - Hostname-mismatch &rarr; `DnsErrorCode.Spoofed`
+   - Stream reset with a `DOQ_*` error code &rarr;
+     `DnsErrorCode.Transport` (carry the DoQ error code in the
+     exception data)
+   - Timeout &rarr; `DnsErrorCode.Timeout`
+   - Non-zero Message ID in response &rarr;
+     `DnsErrorCode.Malformed` (RFC 9250 §4.2.1)
+
+## Dependencies
+
+The package MUST depend on:
+
+- `Assimalign.Cohesion.Dns.Client` (for the `DnsTransport` base and
+  the resolver-builder integration).
+- `Assimalign.Cohesion.Transports` &mdash; specifically the QUIC
+  client transport. When that surface isn't available, the
+  implementer MUST escalate rather than vendoring a QUIC client
+  inside the DoQ package.
+
+The package MUST guard `System.Net.Quic` usage behind
+`QuicConnection.IsSupported` and surface a clear
+`PlatformNotSupportedException` (or a `DnsException` with
+`DnsErrorCode.Transport` and an inner `PlatformNotSupportedException`)
+when constructed on a platform without QUIC support.
+
+## Test plan
+
+1. **Round-trip against a real DoQ resolver** (AdGuard
+   `94.140.14.140:853`, NextDNS, etc.): opt-in integration test,
+   gated on a `DnsLiveTests=true` env var, additionally skipped
+   on `!QuicConnection.IsSupported`.
+2. **Hostname-mismatch surfaces `DnsErrorCode.Spoofed`**: loopback
+   QUIC listener with a self-signed cert whose CN doesn't match
+   `Host`.
+3. **Strict-profile chain failure surfaces
+   `DnsErrorCode.Transport`**: self-signed cert + system trust
+   validation.
+4. **Message ID MUST be zero on the wire**: stub QUIC server
+   inspects the framed request and asserts the first two RDATA
+   bytes (after the length prefix) are `0x00 0x00`.
+5. **Non-zero Message ID in response surfaces
+   `DnsErrorCode.Malformed`**: stub server returns a response with
+   ID = 0x1234.
+6. **Cancellation mid-handshake**: asserts
+   `OperationCanceledException` (not `DnsException`).
+7. **AOT analyzer clean** under
+   `<IsAotCompatible>true</IsAotCompatible>` &mdash; verify
+   `System.Net.Quic` cooperates with AOT on the supported runtimes.
+8. **Platform gate**: on macOS-latest (where QUIC isn't supported
+   on .NET 10 today), construction MUST raise
+   `PlatformNotSupportedException` rather than failing with a
+   misleading error.
+
+## Open questions for the implementer
+
+- **Connection pooling**: one QUIC connection per `DoqDnsTransport`
+  instance, or a pool keyed by `(Host, Endpoint)`? Match whatever
+  shape `Assimalign.Cohesion.Transports.QuicClientTransport` adopts.
+- **0-RTT data**: RFC 9250 §4.4 forbids 0-RTT for the first DNS
+  query in a session. Defer 0-RTT entirely to a follow-up story.
+- **Stream concurrency limit**: QUIC connections have a
+  configurable bidirectional-stream limit. The implementing PR
+  should pick a sensible default (RFC 9250 §4.2 suggests 100) and
+  expose it on the options bag.
+- **CI matrix scope**: macOS QUIC support is unreliable on .NET 10
+  &mdash; document the platform skip in
+  `docs/COMPATIBILITY.md` once the implementation lands.
+
+## Non-goals
+
+- Acting as a DoQ *server*. Server-side resolution lives under the
+  future `Assimalign.Cohesion.Dns.Authority` package (Feature
+  `.07` of the L01.01.08 epic, currently deferred).
+- Implementing QUIC itself. The package consumes
+  `System.Net.Quic` (via `Assimalign.Cohesion.Transports`) and
+  does not own the cipher selection, congestion control, or
+  certificate handling beyond the authentication profile.
+- Zero-RTT data exchange. RFC 9250 §4.4 calls 0-RTT out
+  explicitly; revisit only if a real workload demands it.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/src/Assimalign.Cohesion.Dns.Client.Doq.csproj
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Doq/src/Assimalign.Cohesion.Dns.Client.Doq.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Dns</RootNamespace>
+		<Description>DNS-over-QUIC (DoQ, RFC 9250) transport for the Cohesion DNS family. Placeholder package — implementation deferred until Assimalign.Cohesion.Transports ships a QUIC client transport; see docs/REQUIREMENTS.md for the implementation contract.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Dns.Client" />
+	</ItemGroup>
+</Project>

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/README.md
@@ -1,0 +1,14 @@
+# Assimalign.Cohesion.Dns.Client.Dot
+
+DNS-over-TLS (DoT) transport for the Cohesion DNS family — RFC 7858.
+
+**Placeholder package.** No implementation ships in this build. The
+package is scaffolded so the family layout is in place when the
+implementation lands; the public surface contract lives in
+`docs/REQUIREMENTS.md`.
+
+The placeholder still depends on `Assimalign.Cohesion.Dns.Client` so
+consumers can pin their references now without waiting for the
+implementation PR.
+
+See `docs/REQUIREMENTS.md` for the full implementation contract.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/OVERVIEW.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/OVERVIEW.md
@@ -1,0 +1,48 @@
+# Assimalign.Cohesion.Dns.Client.Dot
+
+## Summary
+
+DNS-over-TLS (DoT) transport for the Cohesion DNS family. Implements
+RFC 7858 ("Specification for DNS over Transport Layer Security
+(TLS)") on top of the wire format defined in
+`Assimalign.Cohesion.Dns`.
+
+## Status
+
+**Placeholder.** No code in this package today; only the csproj and
+docs exist so the family layout is stable. Implementation deferred
+until the broader Cohesion HTTP / TLS story matures.
+
+See `docs/REQUIREMENTS.md` for the implementation contract — public
+surface, expected dependencies, test plan, and open design
+questions. PR-3 (the resolver + UDP/TCP transports PR) creates this
+placeholder so callers can pin a reference to a stable assembly name
+ahead of the eventual implementation.
+
+## Why a separate package
+
+DoT shares the wire format of regular DNS-over-TCP (RFC 1035 §4.2.2
+two-octet length-prefix framing) but adds a TLS layer between the
+TCP socket and the framing. Keeping it as a separate package:
+
+- Lets users opt out of the TLS dependency surface when they only
+  need UDP/TCP.
+- Mirrors the family layout of the FileSystem packages
+  (one provider per package).
+- Makes the runtime / AOT cost of TLS explicit.
+
+## When implementation lands
+
+The implementing PR will:
+
+1. Add a single `DotDnsTransport : DnsTransport` type plus its
+   options bag.
+2. Register a factory-style extension method
+   (`AddDotDnsTransport`) for the resolver builder.
+3. Add the assembly to the CI matrix in
+   `.github/workflows/library-dns.yml`.
+4. Add the assembly to `frameworks/Assimalign.Cohesion.App.props`
+   under the active block.
+5. Replace this OVERVIEW with the post-implementation version (status,
+   public surface, etc.) and either freeze `REQUIREMENTS.md` or fold
+   it into the DESIGN doc.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/REQUIREMENTS.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/docs/REQUIREMENTS.md
@@ -1,0 +1,149 @@
+# Assimalign.Cohesion.Dns.Client.Dot &mdash; Implementation requirements
+
+> **Status: deferred.** This package ships as an empty placeholder
+> until the broader Cohesion HTTP / TLS story matures. This document
+> is the contract the implementing PR must satisfy.
+
+## Standards
+
+Primary: **[RFC 7858](https://www.rfc-editor.org/rfc/rfc7858)** &mdash;
+"Specification for DNS over Transport Layer Security (TLS)".
+
+Supplementary:
+- **RFC 1035 §4.2.2** &mdash; DNS over TCP framing (the two-octet
+  length-prefix carries over to DoT verbatim).
+- **RFC 8310** &mdash; usage profiles + authentication models for DoT
+  (Opportunistic, Out-of-band, DANE-authenticated).
+- **RFC 7766** &mdash; DNS transport over TCP requirements (idle
+  timeouts, EDNS keep-alive interactions).
+
+## Public surface contract
+
+The implementing PR MUST deliver:
+
+```csharp
+namespace Assimalign.Cohesion.Dns;
+
+public sealed class DotDnsTransport : DnsTransport
+{
+    public DotDnsTransport(DotDnsTransportOptions options);
+
+    public override EndPoint Endpoint { get; }
+
+    public override Task<ReadOnlyMemory<byte>> ExchangeAsync(
+        ReadOnlyMemory<byte> request,
+        CancellationToken cancellationToken = default);
+
+    protected override ValueTask DisposeAsyncCore();
+}
+
+public sealed class DotDnsTransportOptions
+{
+    public EndPoint Endpoint { get; set; }              // required, defaults to port 853
+    public string Host { get; set; }                    // SNI + cert hostname check
+    public TimeSpan ConnectTimeout { get; set; }        // default 5s
+    public TimeSpan QueryTimeout { get; set; }          // default 5s
+    public TimeSpan IdleTimeout { get; set; }           // RFC 7766 idle-close; default 30s
+
+    // Authentication profile (RFC 8310).
+    public DotAuthenticationProfile AuthenticationProfile { get; set; }
+        // Strict (default) | Opportunistic | Tofu
+    public X509Certificate2Collection? PinnedCertificates { get; set; }
+    public SslClientAuthenticationOptions? SslOptions { get; set; }
+}
+```
+
+Plus a factory-builder extension on whatever shape the resolver
+builder ends up with:
+
+```csharp
+public static IDnsResolverBuilder AddDotDnsTransport(
+    this IDnsResolverBuilder builder,
+    Action<DotDnsTransportOptions> configure);
+```
+
+## Behavior
+
+The transport MUST:
+
+1. Open a TCP connection to `Endpoint` (default port 853) with
+   `ConnectTimeout`.
+2. Perform a TLS handshake using `SslOptions` (or sensible defaults)
+   and validate the server certificate per `AuthenticationProfile`:
+   - `Strict`: hostname matches `Host`, chain validates against the
+     system trust store. Any failure surfaces as
+     `DnsException` with `DnsErrorCode.Transport`.
+   - `Opportunistic`: hostname check still applies but a chain
+     failure downgrades to encrypted-but-unauthenticated (logs a
+     warning rather than throwing). Implementer must surface the
+     downgrade through telemetry.
+   - `Tofu` (trust-on-first-use): pin the server's
+     SubjectPublicKeyInfo after first successful handshake and
+     reject subsequent mismatches.
+3. Reuse the connection for subsequent `ExchangeAsync` calls until
+   `IdleTimeout` elapses, then close gracefully.
+4. Use the RFC 1035 §4.2.2 two-octet length prefix for every message.
+5. Honour the cancellation token at every async wait.
+6. Map every failure to `DnsException`:
+   - TLS handshake failure → `DnsErrorCode.Transport`
+   - Hostname-mismatch → `DnsErrorCode.Spoofed`
+   - Timeout → `DnsErrorCode.Timeout`
+   - Truncated response (impossible in TCP framing but worth
+     defending against) → `DnsErrorCode.Malformed`
+
+## Dependencies
+
+The package MUST depend on:
+
+- `Assimalign.Cohesion.Dns.Client` (for `DnsTransport` base + resolver
+  builder integration).
+- Either:
+  - `Assimalign.Cohesion.Transports` with a new `IStreamTransform`
+    middleware shape that supports TLS wrapping, **or**
+  - Direct use of `System.Net.Sockets.TcpClient` +
+    `System.Net.Security.SslStream` (the simpler path; preferred
+    unless the Transports extension lands first).
+
+The package MUST NOT depend on `Assimalign.Cohesion.Http` &mdash; DoT
+runs directly over TLS, not HTTP.
+
+## Test plan
+
+1. **Round-trip against a real DoT resolver** (1.1.1.1 / 9.9.9.9):
+   opt-in integration test, gated on a `DnsLiveTests=true` env var.
+2. **Hostname-mismatch surfaces `DnsErrorCode.Spoofed`**: use a
+   loopback TLS listener with a self-signed cert whose CN doesn't
+   match the configured `Host`.
+3. **Strict-profile chain failure surfaces `DnsErrorCode.Transport`**:
+   self-signed cert + system trust validation.
+4. **Connection idle-close round-trips**: send a query, idle past
+   `IdleTimeout`, send a second query &mdash; the second open must
+   succeed against a re-established connection.
+5. **Cancellation mid-handshake**: assert
+   `OperationCanceledException` (not `DnsException`) so callers see
+   the cancellation cause directly per the standard pattern.
+6. **AOT analyzer clean** under
+   `<IsAotCompatible>true</IsAotCompatible>`.
+
+## Open questions for the implementer
+
+- **Connection pooling**: one connection per `DotDnsTransport`
+  instance, or a pool keyed by `(Host, Endpoint)`? Match whatever
+  shape `Assimalign.Cohesion.Transports.TcpClientTransport` adopts
+  for keep-alive.
+- **EDNS keep-alive (RFC 7828)** integration: should the transport
+  ride the resolver's EDNS-option list, or does it manage its own
+  RFC 7828 OPT exchange? Decide alongside the resolver
+  implementation.
+- **TLS 1.3 0-RTT**: out of scope for the first implementation; defer
+  to a follow-up story if performance demands it.
+
+## Non-goals
+
+- Acting as a DoT *server*. Server-side authoritative resolution
+  lives under the future `Assimalign.Cohesion.Dns.Authority` package
+  (Feature `.07` of the L01.01.08 epic, currently deferred).
+- Implementing TLS itself. The package consumes `SslStream` (or its
+  Transports-library equivalent) and does not own the cipher
+  selection or certificate handling beyond the authentication
+  profile.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/src/Assimalign.Cohesion.Dns.Client.Dot.csproj
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client.Dot/src/Assimalign.Cohesion.Dns.Client.Dot.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Dns</RootNamespace>
+		<Description>DNS-over-TLS (DoT, RFC 7858) transport for the Cohesion DNS family. Placeholder package — implementation deferred until the broader Cohesion HTTP / TLS story matures; see docs/REQUIREMENTS.md for the implementation contract.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Dns.Client" />
+	</ItemGroup>
+</Project>

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
@@ -4,9 +4,73 @@ Resolving DNS client for Cohesion. Provides recursive DNS resolution,
 caching, and pluggable UDP / TCP / DoT / DoH / DoQ transports on top
 of the `Assimalign.Cohesion.Dns` contracts.
 
-Scaffolded at the opening of the L01.01.08 epic; implementation lands
-in PRs 3 (transports + resolver). See
-[`../Assimalign.Cohesion.Dns/docs/OVERVIEW.md`](../Assimalign.Cohesion.Dns/docs/OVERVIEW.md)
-for the public contracts and
-[`../Assimalign.Cohesion.Dns/docs/PROVENANCE.md`](../Assimalign.Cohesion.Dns/docs/PROVENANCE.md)
-for the clean-room rules that apply to this area.
+## What ships today
+
+| Surface | Status |
+|---------|--------|
+| `UdpDnsTransport` &mdash; RFC 1035 §4.2.1 UDP transport | Shipping |
+| `TcpDnsTransport` &mdash; RFC 1035 §4.2.2 length-prefix TCP transport, RFC 7766 connection reuse | Shipping |
+| `DotDnsTransport`, `DohDnsTransport`, `DoqDnsTransport` | Placeholder packages (see `Assimalign.Cohesion.Dns.Client.{Dot,Doh,Doq}`) |
+| Recursive resolver + cache | Deferred to a follow-up PR |
+
+## Transport contract
+
+Both `UdpDnsTransport` and `TcpDnsTransport` derive from
+`Assimalign.Cohesion.Dns.DnsTransport`. Each instance binds to one
+remote endpoint and exposes a single `ExchangeAsync` method:
+
+```csharp
+var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+{
+    EndPoint     = new IPEndPoint(IPAddress.Parse("1.1.1.1"), 53),
+    QueryTimeout = TimeSpan.FromSeconds(2),
+});
+
+byte[] request = /* serialized DnsMessage */;
+ReadOnlyMemory<byte> response = await transport.ExchangeAsync(request);
+DnsMessage parsed = DnsMessage.Parse(response.Span);
+```
+
+The transport works in terms of raw byte buffers; serialization and
+parsing live in `Assimalign.Cohesion.Dns`. This split keeps the
+transport implementation small and lets the resolver decide
+message-level concerns like EDNS payload size or DNSSEC bits without
+involving the network layer.
+
+## Connection reuse + retry semantics
+
+`TcpDnsTransport` follows RFC 7766: one TCP connection per transport
+instance, reused across exchanges. Connection lifecycle:
+
+- **Idle close**: connections older than `IdleTimeout` (default 30s)
+  are recycled before the next exchange.
+- **Stale recovery**: if a reused connection fails mid-exchange (RST,
+  EOF), the transport opens a fresh connection and retries the
+  exchange once. This is safe because DNS queries are idempotent.
+  Fresh connections that fail are not retried &mdash; the failure
+  surfaces to the caller as `DnsException(Transport)`.
+- **External cancellation** propagates as
+  `OperationCanceledException`; internal timeout surfaces as
+  `DnsException(Timeout)`.
+
+## Implementation note: raw sockets vs Cohesion.Transports
+
+Both transports use `System.Net.Sockets.Socket` directly rather than
+building on `Assimalign.Cohesion.Transports.{Udp,Tcp}ClientTransport`.
+The Transports library models bidirectional, pipe-backed flows with
+pluggable middleware &mdash; the right model for streaming protocols
+and servers, gratuitous machinery for one-shot DNS request/response.
+
+The design notes on each transport class spell this out. If the
+Transports library later grows a request/response shape we can
+revisit; the public surface here doesn't change.
+
+## See also
+
+- [`Assimalign.Cohesion.Dns`](../Assimalign.Cohesion.Dns/docs/OVERVIEW.md) &mdash;
+  wire format contracts and the `DnsTransport` abstract base.
+- [`Assimalign.Cohesion.Dns/docs/PROVENANCE.md`](../Assimalign.Cohesion.Dns/docs/PROVENANCE.md) &mdash;
+  the clean-room rules that govern every package in this epic.
+- `Assimalign.Cohesion.Dns.Client.{Dot,Doh,Doq}` &mdash; placeholder
+  packages with full implementation contracts in their
+  `docs/REQUIREMENTS.md`.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Assimalign.Cohesion.Dns.Client.csproj
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Assimalign.Cohesion.Dns.Client.csproj
@@ -6,4 +6,7 @@
 	<ItemGroup>
 		<CohesionProjectReference Include="Assimalign.Cohesion.Dns" />
 	</ItemGroup>
+	<ItemGroup>
+		<InternalsVisibleTo Include="Assimalign.Cohesion.Dns.Client.Tests" />
+	</ItemGroup>
 </Project>

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/TcpDnsTransport.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/TcpDnsTransport.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// DNS-over-TCP transport. Frames DNS messages with the two-octet length prefix mandated by
+/// RFC 1035 &#167; 4.2.2 and reuses the connection across exchanges per RFC 7766.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One <see cref="TcpDnsTransport"/> instance owns one TCP connection at a time. The connection
+/// is opened lazily on the first <see cref="ExchangeAsync"/> call and recycled when:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="TcpDnsTransportOptions.IdleTimeout"/> elapses with no
+///   in-flight exchange (the next exchange opens a fresh connection).</description></item>
+///   <item><description>Any I/O on the connection fails &#8211; the next exchange opens a fresh
+///   connection. The current exchange surfaces the failure as <see cref="DnsException"/>.</description></item>
+///   <item><description>The transport is disposed.</description></item>
+/// </list>
+/// <para>
+/// Concurrent exchanges on the same transport are serialized; RFC 7766 &#167; 6.2.1.1 pipelining
+/// is a future optimization gated on resolver-side ID-correlation work.
+/// </para>
+/// <para>
+/// <strong>Implementation note.</strong> The transport uses <see cref="Socket"/> directly. The
+/// Cohesion.Transports library's <c>TcpClientTransport</c> is connection-pipe-pipeline shaped,
+/// which is the right model for streaming protocols but adds layers for a request/response
+/// transport that needs precise control over the two-octet framing and per-exchange recycle
+/// semantics. Re-evaluate once Cohesion.Transports grows a request/response shape.
+/// </para>
+/// </remarks>
+public sealed class TcpDnsTransport : DnsTransport
+{
+    private readonly TcpDnsTransportOptions _options;
+    private readonly SemaphoreSlim _exchangeLock;
+
+    private Socket? _socket;
+    private DateTime _lastActivityUtc;
+
+    /// <summary>
+    /// Creates a new TCP DNS transport bound to <paramref name="options"/>.<c>EndPoint</c>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="options"/>.<c>EndPoint</c> is <see langword="null"/>
+    /// or a timeout is non-positive.</exception>
+    public TcpDnsTransport(TcpDnsTransportOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.EndPoint is null)
+        {
+            throw new ArgumentException(
+                $"{nameof(TcpDnsTransportOptions)}.{nameof(TcpDnsTransportOptions.EndPoint)} is required.",
+                nameof(options));
+        }
+        if (options.ConnectTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"{nameof(TcpDnsTransportOptions)}.{nameof(TcpDnsTransportOptions.ConnectTimeout)} must be positive.",
+                nameof(options));
+        }
+        if (options.QueryTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"{nameof(TcpDnsTransportOptions)}.{nameof(TcpDnsTransportOptions.QueryTimeout)} must be positive.",
+                nameof(options));
+        }
+        if (options.IdleTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"{nameof(TcpDnsTransportOptions)}.{nameof(TcpDnsTransportOptions.IdleTimeout)} must be positive.",
+                nameof(options));
+        }
+
+        _options = options;
+        _exchangeLock = new SemaphoreSlim(1, 1);
+    }
+
+    /// <inheritdoc />
+    public override EndPoint Endpoint => _options.EndPoint!;
+
+    /// <inheritdoc />
+    public override async Task<ReadOnlyMemory<byte>> ExchangeAsync(
+        ReadOnlyMemory<byte> request,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (request.IsEmpty)
+        {
+            throw new ArgumentException("DNS request must be non-empty.", nameof(request));
+        }
+        if (request.Length > ushort.MaxValue)
+        {
+            throw new ArgumentException(
+                $"DNS request size {request.Length} exceeds the TCP framing limit (65535 octets).",
+                nameof(request));
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_options.QueryTimeout);
+
+        try
+        {
+            await _exchangeLock.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (TimedOut(timeoutCts, cancellationToken))
+        {
+            DnsException.ThrowTimeout($"TCP exchange queue for {Endpoint}");
+            throw; // unreachable
+        }
+
+        try
+        {
+            // Recycle the connection if it went idle past IdleTimeout. The check happens
+            // under the exchange lock so we can't race with another exchange opening.
+            if (_socket is not null && DateTime.UtcNow - _lastActivityUtc > _options.IdleTimeout)
+            {
+                CloseConnection();
+            }
+
+            // One retry budget: if we're reusing a possibly-stale connection and the I/O
+            // fails, reopen and try once more. RFC 7766 §6.2.3 — servers MAY close idle
+            // connections; clients SHOULD treat that as recoverable for idempotent queries
+            // (which all DNS queries are).
+            bool reusedConnection = _socket is not null;
+            bool retried = false;
+
+            while (true)
+            {
+                if (_socket is null)
+                {
+                    await ConnectAsync(timeoutCts, cancellationToken).ConfigureAwait(false);
+                }
+
+                try
+                {
+                    await WriteFramedAsync(request, timeoutCts.Token).ConfigureAwait(false);
+                    ReadOnlyMemory<byte> response = await ReadFramedAsync(timeoutCts.Token).ConfigureAwait(false);
+                    _lastActivityUtc = DateTime.UtcNow;
+                    return response;
+                }
+                catch (OperationCanceledException) when (TimedOut(timeoutCts, cancellationToken))
+                {
+                    CloseConnection();
+                    DnsException.ThrowTimeout($"TCP exchange with {Endpoint}");
+                    throw; // unreachable
+                }
+                catch (DnsException ex) when (ex.Code == DnsErrorCode.Transport && reusedConnection && !retried)
+                {
+                    // Stale-connection retry: close and try once more on a fresh socket.
+                    CloseConnection();
+                    reusedConnection = false;
+                    retried = true;
+                    continue;
+                }
+                catch (SocketException ex) when (reusedConnection && !retried)
+                {
+                    CloseConnection();
+                    reusedConnection = false;
+                    retried = true;
+                    _ = ex; // discard; we'll retry
+                    continue;
+                }
+                catch (SocketException ex)
+                {
+                    CloseConnection();
+                    DnsException.ThrowTransport($"TCP I/O with {Endpoint}: {ex.SocketErrorCode}", ex);
+                    throw; // unreachable
+                }
+                catch
+                {
+                    CloseConnection();
+                    throw;
+                }
+            }
+        }
+        finally
+        {
+            _exchangeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeCore()
+    {
+        CloseConnection();
+        _exchangeLock.Dispose();
+    }
+
+    private async Task ConnectAsync(CancellationTokenSource exchangeTimeoutCts, CancellationToken externalToken)
+    {
+        AddressFamily family = _options.EndPoint switch
+        {
+            IPEndPoint ip => ip.AddressFamily,
+            DnsEndPoint dns => dns.AddressFamily,
+            _ => AddressFamily.InterNetwork,
+        };
+
+        var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true,
+        };
+
+        using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(exchangeTimeoutCts.Token);
+        connectCts.CancelAfter(_options.ConnectTimeout);
+
+        try
+        {
+            await socket.ConnectAsync(_options.EndPoint!, connectCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (externalToken.IsCancellationRequested)
+        {
+            socket.Dispose();
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            socket.Dispose();
+            DnsException.ThrowTimeout($"TCP connect to {Endpoint}");
+        }
+        catch (SocketException ex)
+        {
+            socket.Dispose();
+            DnsException.ThrowTransport($"TCP connect to {Endpoint}: {ex.SocketErrorCode}", ex);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+
+        _socket = socket;
+        _lastActivityUtc = DateTime.UtcNow;
+    }
+
+    private async Task WriteFramedAsync(ReadOnlyMemory<byte> request, CancellationToken cancellationToken)
+    {
+        // RFC 1035 §4.2.2: two-octet length prefix, network byte order, followed by the message.
+        // Compose the prefix + message in one buffer to keep the send to a single syscall.
+        int totalLength = request.Length + 2;
+        byte[] framed = new byte[totalLength];
+        BinaryPrimitives.WriteUInt16BigEndian(framed.AsSpan(0, 2), (ushort)request.Length);
+        request.CopyTo(framed.AsMemory(2));
+
+        int sent = 0;
+        while (sent < totalLength)
+        {
+            int n = await _socket!
+                .SendAsync(framed.AsMemory(sent, totalLength - sent), SocketFlags.None, cancellationToken)
+                .ConfigureAwait(false);
+            if (n == 0)
+            {
+                DnsException.ThrowTransport($"TCP send to {Endpoint}: socket closed mid-write");
+            }
+            sent += n;
+        }
+    }
+
+    private async Task<ReadOnlyMemory<byte>> ReadFramedAsync(CancellationToken cancellationToken)
+    {
+        byte[] lengthBuffer = new byte[2];
+        await ReadExactAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+        ushort length = BinaryPrimitives.ReadUInt16BigEndian(lengthBuffer);
+
+        if (length == 0)
+        {
+            DnsException.ThrowMalformed($"TCP response from {Endpoint} declared zero-length message");
+        }
+
+        byte[] message = new byte[length];
+        await ReadExactAsync(message, cancellationToken).ConfigureAwait(false);
+        return message;
+    }
+
+    private async Task ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        int received = 0;
+        while (received < buffer.Length)
+        {
+            int n = await _socket!
+                .ReceiveAsync(buffer[received..], SocketFlags.None, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (n == 0)
+            {
+                DnsException.ThrowTransport($"TCP receive from {Endpoint}: connection closed before {buffer.Length} octets read");
+            }
+            received += n;
+        }
+    }
+
+    private void CloseConnection()
+    {
+        Socket? s = _socket;
+        if (s is null)
+        {
+            return;
+        }
+        _socket = null;
+        try
+        {
+            s.Shutdown(SocketShutdown.Both);
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        s.Dispose();
+    }
+
+    private static bool TimedOut(CancellationTokenSource timeoutCts, CancellationToken externalToken)
+        => timeoutCts.IsCancellationRequested && !externalToken.IsCancellationRequested;
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/TcpDnsTransportOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/TcpDnsTransportOptions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Configuration for <see cref="TcpDnsTransport"/>.
+/// </summary>
+public sealed class TcpDnsTransportOptions
+{
+    /// <summary>
+    /// The remote name server. Required.
+    /// </summary>
+    public EndPoint? EndPoint { get; set; }
+
+    /// <summary>
+    /// TCP connect timeout. Defaults to 5 seconds.
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Per-exchange timeout (covers send + receive of one exchange). Defaults to 5 seconds.
+    /// </summary>
+    public TimeSpan QueryTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// How long an idle TCP connection is held open before being recycled. RFC 7766 &#167; 6.2.3
+    /// recommends a finite idle close so servers can reclaim resources. Defaults to 30 seconds.
+    /// </summary>
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/UdpDnsTransport.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/UdpDnsTransport.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Buffers;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// DNS-over-UDP transport. One datagram out, one datagram in. Implements RFC 1035 &#167; 4.2.1
+/// against a single fixed upstream <see cref="DnsTransport.Endpoint"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The transport opens one connected UDP socket per <see cref="UdpDnsTransport"/> instance and
+/// reuses it across exchanges &#8211; this keeps the local source port stable and avoids the
+/// kernel cost of bind/connect per query, which matters when a resolver issues thousands of
+/// queries per second. Each exchange uses its own receive buffer so concurrent
+/// <see cref="ExchangeAsync"/> calls on the same transport instance don't trample each other's
+/// datagrams; correlation by DNS message ID happens at the resolver layer, not here.
+/// </para>
+/// <para>
+/// Truncated responses (TC bit set in the response header) are surfaced to the caller as-is.
+/// The resolver layer is responsible for noticing TC and retrying over TCP per RFC 5966.
+/// </para>
+/// <para>
+/// <strong>Implementation note.</strong> The transport uses <see cref="Socket"/> directly rather
+/// than building on <c>Assimalign.Cohesion.Transports.UdpClientTransport</c>. The Transports
+/// library models bidirectional pipe-backed flows with pluggable middleware &#8211; great for
+/// long-lived server / streaming connections, gratuitous for one-shot DNS request/response. If
+/// the Transports library grows a request/response shape we can revisit; the public surface
+/// here doesn't change either way.
+/// </para>
+/// </remarks>
+public sealed class UdpDnsTransport : DnsTransport
+{
+    private readonly UdpDnsTransportOptions _options;
+    private readonly Socket _socket;
+    private readonly SemaphoreSlim _exchangeLock;
+
+    /// <summary>
+    /// Creates a new UDP DNS transport bound to <paramref name="options"/>.<c>EndPoint</c>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="options"/>.<c>EndPoint</c> is <see langword="null"/>.</exception>
+    public UdpDnsTransport(UdpDnsTransportOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.EndPoint is null)
+        {
+            throw new ArgumentException(
+                $"{nameof(UdpDnsTransportOptions)}.{nameof(UdpDnsTransportOptions.EndPoint)} is required.",
+                nameof(options));
+        }
+        if (options.QueryTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"{nameof(UdpDnsTransportOptions)}.{nameof(UdpDnsTransportOptions.QueryTimeout)} must be positive.",
+                nameof(options));
+        }
+        if (options.MaxResponseSize <= 0 || options.MaxResponseSize > 65_535)
+        {
+            throw new ArgumentException(
+                $"{nameof(UdpDnsTransportOptions)}.{nameof(UdpDnsTransportOptions.MaxResponseSize)} must be in [1, 65535].",
+                nameof(options));
+        }
+
+        _options = options;
+
+        AddressFamily family = options.EndPoint switch
+        {
+            IPEndPoint ip => ip.AddressFamily,
+            DnsEndPoint dns => dns.AddressFamily,
+            _ => AddressFamily.InterNetwork,
+        };
+
+        _socket = new Socket(family, SocketType.Dgram, ProtocolType.Udp);
+        // Serialize sends so two concurrent exchanges don't have their datagrams interleaved on
+        // the socket's send queue. We hold the lock only for the brief window of the actual
+        // send + receive; in practice resolvers run one exchange per transport anyway.
+        _exchangeLock = new SemaphoreSlim(1, 1);
+    }
+
+    /// <inheritdoc />
+    public override EndPoint Endpoint => _options.EndPoint!;
+
+    /// <inheritdoc />
+    public override async Task<ReadOnlyMemory<byte>> ExchangeAsync(
+        ReadOnlyMemory<byte> request,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (request.IsEmpty)
+        {
+            throw new ArgumentException("DNS request must be non-empty.", nameof(request));
+        }
+
+        // RFC 1035 §4.2.1: UDP messages are limited to 512 octets without EDNS. We accept the
+        // EDNS-advertised payload size here; the resolver enforces the lower bound when it
+        // composes the message.
+        if (request.Length > _options.MaxResponseSize)
+        {
+            // Not strictly a transport failure — the message is just too big for UDP. Surface
+            // it as Transport so the caller falls back to TCP.
+            DnsException.ThrowTransport(
+                $"UDP request size {request.Length} exceeds the configured MaxResponseSize {_options.MaxResponseSize}");
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_options.QueryTimeout);
+
+        await _exchangeLock.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        try
+        {
+            try
+            {
+                await _socket.SendToAsync(
+                    request,
+                    SocketFlags.None,
+                    _options.EndPoint!,
+                    timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                DnsException.ThrowTimeout($"UDP send to {Endpoint}");
+            }
+            catch (SocketException ex)
+            {
+                DnsException.ThrowTransport($"UDP send to {Endpoint}: {ex.SocketErrorCode}", ex);
+            }
+
+            // Allocate a per-exchange buffer so concurrent exchanges don't share storage. The
+            // returned ReadOnlyMemory<byte> aliases this buffer; we never recycle it.
+            byte[] buffer = new byte[_options.MaxResponseSize];
+
+            try
+            {
+                SocketReceiveFromResult result = await _socket
+                    .ReceiveFromAsync(buffer, SocketFlags.None, _options.EndPoint!, timeoutCts.Token)
+                    .ConfigureAwait(false);
+
+                return buffer.AsMemory(0, result.ReceivedBytes);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                DnsException.ThrowTimeout($"UDP receive from {Endpoint}");
+                throw; // unreachable; satisfies the analyzer
+            }
+            catch (SocketException ex)
+            {
+                DnsException.ThrowTransport($"UDP receive from {Endpoint}: {ex.SocketErrorCode}", ex);
+                throw; // unreachable
+            }
+        }
+        finally
+        {
+            _exchangeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeCore()
+    {
+        _exchangeLock.Dispose();
+        _socket.Dispose();
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/UdpDnsTransportOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/UdpDnsTransportOptions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Configuration for <see cref="UdpDnsTransport"/>.
+/// </summary>
+public sealed class UdpDnsTransportOptions
+{
+    /// <summary>
+    /// The remote name server. Required.
+    /// </summary>
+    public EndPoint? EndPoint { get; set; }
+
+    /// <summary>
+    /// Per-exchange timeout. Defaults to 5 seconds, matching the recommended
+    /// stub-resolver default in RFC 1123 &#167; 6.1.3.3.
+    /// </summary>
+    public TimeSpan QueryTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Maximum response size the transport is willing to receive. Defaults to 4096 octets,
+    /// matching the EDNS payload size most resolvers advertise. Anything larger comes back
+    /// over TCP per RFC 5966 / 7766.
+    /// </summary>
+    public int MaxResponseSize { get; set; } = 4096;
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TcpDnsTransportTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TcpDnsTransportTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Buffers.Binary;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+public sealed class TcpDnsTransportTests
+{
+    [Fact]
+    public async Task ExchangeAsync_RoundTripsAgainstLoopbackServer()
+    {
+        await using var server = new LoopbackTcpDnsServer();
+        server.OnRequest(req =>
+        {
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            ConnectTimeout = TimeSpan.FromSeconds(1),
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        byte[] request = LoopbackUdpDnsServer.BuildMinimalResponse(0xABCD);
+        ReadOnlyMemory<byte> response = await transport.ExchangeAsync(request);
+
+        Assert.Equal(12, response.Length);
+        Assert.Equal(0xABCD, BinaryPrimitives.ReadUInt16BigEndian(response.Span[..2]));
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_ReusesConnectionWhenServerHoldsIt()
+    {
+        await using var server = new LoopbackTcpDnsServer
+        {
+            HoldConnection = true,
+        };
+        server.OnRequest(req =>
+        {
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            IdleTimeout = TimeSpan.FromSeconds(10),
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        for (int i = 0; i < 3; i++)
+        {
+            byte[] req = LoopbackUdpDnsServer.BuildMinimalResponse((ushort)(0x1000 + i));
+            var resp = await transport.ExchangeAsync(req);
+            Assert.Equal(0x1000 + i, BinaryPrimitives.ReadUInt16BigEndian(resp.Span[..2]));
+        }
+
+        // Give the server's accept loop time to record any extra connections (it should only
+        // have one).
+        await Task.Delay(50);
+        Assert.Equal(1, server.AcceptedConnections);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_ReopensAfterIdleTimeout()
+    {
+        await using var server = new LoopbackTcpDnsServer
+        {
+            HoldConnection = true,
+        };
+        server.OnRequest(req =>
+        {
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            IdleTimeout = TimeSpan.FromMilliseconds(100),
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        byte[] req1 = LoopbackUdpDnsServer.BuildMinimalResponse(0x0001);
+        _ = await transport.ExchangeAsync(req1);
+
+        await Task.Delay(250); // idle past 100ms
+
+        byte[] req2 = LoopbackUdpDnsServer.BuildMinimalResponse(0x0002);
+        _ = await transport.ExchangeAsync(req2);
+
+        await Task.Delay(50);
+        Assert.Equal(2, server.AcceptedConnections);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_ReopensAfterPriorFailure()
+    {
+        // Server drops the connection after the first exchange. Next exchange should reopen.
+        await using var server = new LoopbackTcpDnsServer
+        {
+            HoldConnection = false, // closes after one exchange
+        };
+        server.OnRequest(req =>
+        {
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            IdleTimeout = TimeSpan.FromSeconds(30),
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        _ = await transport.ExchangeAsync(LoopbackUdpDnsServer.BuildMinimalResponse(0xAAAA));
+        _ = await transport.ExchangeAsync(LoopbackUdpDnsServer.BuildMinimalResponse(0xBBBB));
+
+        await Task.Delay(50);
+        Assert.Equal(2, server.AcceptedConnections);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_TimesOutWhenServerStaysSilent()
+    {
+        await using var server = new LoopbackTcpDnsServer();
+        server.OnRequest(_ => Array.Empty<byte>()); // drop: read but don't respond
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromMilliseconds(200),
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => transport.ExchangeAsync(LoopbackUdpDnsServer.BuildMinimalResponse(0xDEAD)));
+        // The server drops by closing the socket after reading the request, so we surface as
+        // Transport (closed before declared bytes read). If the timeout wins first we surface
+        // as Timeout. Either is acceptable.
+        Assert.True(
+            ex.Code is DnsErrorCode.Transport or DnsErrorCode.Timeout,
+            $"Expected Transport or Timeout, got {ex.Code}");
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_TimesOutOnUnreachableEndpoint()
+    {
+        // 192.0.2.0/24 (TEST-NET-1, RFC 5737) is documentation-only address space — no host
+        // there to receive a connect.
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = new IPEndPoint(IPAddress.Parse("192.0.2.1"), 53),
+            ConnectTimeout = TimeSpan.FromMilliseconds(200),
+            QueryTimeout = TimeSpan.FromSeconds(5),
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => transport.ExchangeAsync(LoopbackUdpDnsServer.BuildMinimalResponse(0)));
+        // Either the connect times out (Timeout) or the kernel rejects the route (Transport).
+        Assert.True(
+            ex.Code is DnsErrorCode.Timeout or DnsErrorCode.Transport,
+            $"Expected Timeout or Transport, got {ex.Code}");
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_PropagatesExternalCancellation()
+    {
+        await using var server = new LoopbackTcpDnsServer
+        {
+            // Server reads the request but hangs on the response so the client's receive
+            // blocks until cancellation fires.
+            HoldConnection = true,
+        };
+        server.OnRequest(_ => Array.Empty<byte>());
+
+        using var transport = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => transport.ExchangeAsync(LoopbackUdpDnsServer.BuildMinimalResponse(0), cts.Token));
+    }
+
+    [Fact]
+    public void Constructor_RequiresEndPoint()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new TcpDnsTransport(new TcpDnsTransportOptions()));
+    }
+
+    [Fact]
+    public void Constructor_RequiresPositiveTimeouts()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new TcpDnsTransport(new TcpDnsTransportOptions
+            {
+                EndPoint = new IPEndPoint(IPAddress.Loopback, 53),
+                ConnectTimeout = TimeSpan.Zero,
+            }));
+
+        Assert.Throws<ArgumentException>(
+            () => new TcpDnsTransport(new TcpDnsTransportOptions
+            {
+                EndPoint = new IPEndPoint(IPAddress.Loopback, 53),
+                QueryTimeout = TimeSpan.Zero,
+            }));
+
+        Assert.Throws<ArgumentException>(
+            () => new TcpDnsTransport(new TcpDnsTransportOptions
+            {
+                EndPoint = new IPEndPoint(IPAddress.Loopback, 53),
+                IdleTimeout = TimeSpan.Zero,
+            }));
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackTcpDnsServer.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackTcpDnsServer.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// A loopback TCP "DNS" server that frames responses with the two-octet RFC 1035 &#167; 4.2.2
+/// length prefix. Used to exercise <see cref="TcpDnsTransport"/>.
+/// </summary>
+internal sealed class LoopbackTcpDnsServer : IAsyncDisposable
+{
+    private readonly Socket _listener;
+    private readonly CancellationTokenSource _shutdownCts;
+    private readonly Task _loop;
+
+    private Func<byte[], byte[]> _responder = _ => Array.Empty<byte>();
+    private bool _holdConnection;
+
+    public LoopbackTcpDnsServer()
+    {
+        _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        _listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        _listener.Listen(8);
+        EndPoint = (IPEndPoint)_listener.LocalEndPoint!;
+        _shutdownCts = new CancellationTokenSource();
+        _loop = Task.Run(() => AcceptLoopAsync(_shutdownCts.Token));
+    }
+
+    public IPEndPoint EndPoint { get; }
+
+    public int AcceptedConnections { get; private set; }
+
+    /// <summary>
+    /// Sets the per-request responder. Returns empty to drop (server stays silent after the
+    /// request, simulating a hung peer).
+    /// </summary>
+    public void OnRequest(Func<byte[], byte[]> responder)
+    {
+        _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+    }
+
+    /// <summary>
+    /// When set, the server keeps the connection open after responding so the next exchange
+    /// reuses it.
+    /// </summary>
+    public bool HoldConnection
+    {
+        get => _holdConnection;
+        set => _holdConnection = value;
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            Socket conn;
+            try
+            {
+                conn = await _listener.AcceptAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+            catch (SocketException)
+            {
+                return;
+            }
+
+            AcceptedConnections++;
+            _ = Task.Run(() => HandleConnectionAsync(conn, cancellationToken));
+        }
+    }
+
+    private async Task HandleConnectionAsync(Socket conn, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                byte[] lengthBuf = new byte[2];
+                if (!await ReadExactAsync(conn, lengthBuf, cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                ushort len = BinaryPrimitives.ReadUInt16BigEndian(lengthBuf);
+                byte[] msg = new byte[len];
+                if (!await ReadExactAsync(conn, msg, cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                byte[] response = _responder(msg);
+                if (response.Length == 0)
+                {
+                    if (_holdConnection)
+                    {
+                        // Hang: keep the connection open without responding so the client's
+                        // receive blocks indefinitely (used for cancellation tests).
+                        try
+                        {
+                            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                        return;
+                    }
+                    // Drop: close the socket without responding.
+                    return;
+                }
+
+                byte[] framed = new byte[response.Length + 2];
+                BinaryPrimitives.WriteUInt16BigEndian(framed.AsSpan(0, 2), (ushort)response.Length);
+                response.CopyTo(framed.AsSpan(2));
+
+                await conn.SendAsync(framed, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+
+                if (!_holdConnection)
+                {
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        finally
+        {
+            try
+            {
+                conn.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+            }
+            conn.Dispose();
+        }
+    }
+
+    private static async Task<bool> ReadExactAsync(Socket conn, Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n;
+            try
+            {
+                n = await conn.ReceiveAsync(buffer[read..], SocketFlags.None, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                return false;
+            }
+            if (n == 0)
+            {
+                return false;
+            }
+            read += n;
+        }
+        return true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _shutdownCts.Cancel();
+        try
+        {
+            _listener.Close();
+        }
+        catch
+        {
+        }
+        try
+        {
+            await _loop.ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+        _shutdownCts.Dispose();
+        _listener.Dispose();
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackUdpDnsServer.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackUdpDnsServer.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// A loopback UDP "DNS" server that bounces an arbitrary canned response back to whoever sends
+/// it a datagram. Used to exercise <see cref="UdpDnsTransport"/> without hitting the real
+/// network.
+/// </summary>
+internal sealed class LoopbackUdpDnsServer : IAsyncDisposable
+{
+    private readonly Socket _socket;
+    private readonly CancellationTokenSource _shutdownCts;
+    private readonly Task _loop;
+
+    private Func<byte[], byte[]> _responder = _ => Array.Empty<byte>();
+
+    public LoopbackUdpDnsServer()
+    {
+        _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        _socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        EndPoint = (IPEndPoint)_socket.LocalEndPoint!;
+        _shutdownCts = new CancellationTokenSource();
+        _loop = Task.Run(() => RunAsync(_shutdownCts.Token));
+    }
+
+    public IPEndPoint EndPoint { get; }
+
+    /// <summary>
+    /// Sets the responder. Called once per inbound datagram with the raw request bytes;
+    /// returns the bytes to send back (empty = drop, simulating a black-holed server).
+    /// </summary>
+    public void OnRequest(Func<byte[], byte[]> responder)
+    {
+        _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[65_535];
+        EndPoint remoteAny = new IPEndPoint(IPAddress.Any, 0);
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            SocketReceiveFromResult result;
+            try
+            {
+                result = await _socket.ReceiveFromAsync(buffer, SocketFlags.None, remoteAny, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+            catch (SocketException)
+            {
+                return;
+            }
+
+            byte[] request = buffer[..result.ReceivedBytes];
+            byte[] response = _responder(request);
+            if (response.Length == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                await _socket.SendToAsync(response, SocketFlags.None, result.RemoteEndPoint, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+            catch (SocketException)
+            {
+                // Ignore — the test client may have disposed already.
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _shutdownCts.Cancel();
+        try
+        {
+            _socket.Close();
+        }
+        catch
+        {
+        }
+        try
+        {
+            await _loop.ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+        _shutdownCts.Dispose();
+        _socket.Dispose();
+    }
+
+    /// <summary>
+    /// Builds a minimal DNS response (header only, all sections empty, NoError) carrying the
+    /// supplied transaction ID. Useful when the test only cares about transport behavior.
+    /// </summary>
+    public static byte[] BuildMinimalResponse(ushort id, bool truncated = false)
+    {
+        // 12-octet header + nothing else.
+        byte[] msg = new byte[12];
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(0, 2), id);
+        // Flags: QR=1 (response), OpCode=Query=0, AA=0, TC=truncated, RD=0, RA=1, RCODE=NoError.
+        ushort flags = 0x8080;
+        if (truncated)
+        {
+            flags |= 0x0200;
+        }
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(2, 2), flags);
+        // QDCOUNT = ANCOUNT = NSCOUNT = ARCOUNT = 0
+        return msg;
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/UdpDnsTransportTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/UdpDnsTransportTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Buffers.Binary;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+public sealed class UdpDnsTransportTests
+{
+    [Fact]
+    public async Task ExchangeAsync_BouncesRequestAgainstLoopbackServer()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            // Echo the request's transaction ID into a minimal NoError response.
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        byte[] request = LoopbackUdpDnsServer.BuildMinimalResponse(id: 0x1234);
+        // The minimal-response builder happens to produce a valid 12-octet header; reuse it as
+        // a stand-in request for the transport test.
+
+        ReadOnlyMemory<byte> response = await transport.ExchangeAsync(request);
+        Assert.Equal(12, response.Length);
+        ushort echoedId = BinaryPrimitives.ReadUInt16BigEndian(response.Span[..2]);
+        Assert.Equal(0x1234, echoedId);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_TimesOutWhenServerDrops()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(_ => Array.Empty<byte>()); // black-hole every request
+
+        using var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromMilliseconds(200),
+        });
+
+        byte[] request = LoopbackUdpDnsServer.BuildMinimalResponse(0x4242);
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => transport.ExchangeAsync(request));
+        Assert.Equal(DnsErrorCode.Timeout, ex.Code);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_PropagatesExternalCancellation()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(_ => Array.Empty<byte>()); // black-hole
+
+        using var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        byte[] request = LoopbackUdpDnsServer.BuildMinimalResponse(0xFFFF);
+        using var externalCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        // External cancellation surfaces as OperationCanceledException, not DnsException —
+        // the resolver layer needs to see the cancellation cause directly.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => transport.ExchangeAsync(request, externalCts.Token));
+    }
+
+    [Fact]
+    public void Constructor_RequiresEndPoint()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => new UdpDnsTransport(new UdpDnsTransportOptions()));
+        Assert.Contains("EndPoint", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+        transport.Dispose();
+
+        byte[] request = LoopbackUdpDnsServer.BuildMinimalResponse(0);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => transport.ExchangeAsync(request));
+    }
+
+    [Fact]
+    public async Task ExchangeAsync_ConcurrentCalls_AreSerializedCorrectly()
+    {
+        // Two parallel exchanges against the same transport. Each gets the right echoed ID,
+        // proving the per-exchange receive buffer isolation works.
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            ushort id = BinaryPrimitives.ReadUInt16BigEndian(req.AsSpan(0, 2));
+            // Slow the server a touch so the two exchanges genuinely race.
+            Thread.Sleep(10);
+            return LoopbackUdpDnsServer.BuildMinimalResponse(id);
+        });
+
+        using var transport = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        byte[] req1 = LoopbackUdpDnsServer.BuildMinimalResponse(0x1111);
+        byte[] req2 = LoopbackUdpDnsServer.BuildMinimalResponse(0x2222);
+
+        Task<ReadOnlyMemory<byte>> t1 = transport.ExchangeAsync(req1);
+        Task<ReadOnlyMemory<byte>> t2 = transport.ExchangeAsync(req2);
+
+        ReadOnlyMemory<byte>[] both = await Task.WhenAll(t1, t2);
+        ushort id1 = BinaryPrimitives.ReadUInt16BigEndian(both[0].Span[..2]);
+        ushort id2 = BinaryPrimitives.ReadUInt16BigEndian(both[1].Span[..2]);
+        Assert.Equal(0x1111, id1);
+        Assert.Equal(0x2222, id2);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.slnx
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.slnx
@@ -26,4 +26,28 @@
 	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client/tests/">
 		<Project Path="Assimalign.Cohesion.Dns.Client/tests/Assimalign.Cohesion.Dns.Client.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Dot/">
+		<File Path="Assimalign.Cohesion.Dns.Client.Dot/README.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Dot/docs/OVERVIEW.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Dot/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Dot/src/">
+		<Project Path="Assimalign.Cohesion.Dns.Client.Dot/src/Assimalign.Cohesion.Dns.Client.Dot.csproj" />
+	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Doh/">
+		<File Path="Assimalign.Cohesion.Dns.Client.Doh/README.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Doh/docs/OVERVIEW.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Doh/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Doh/src/">
+		<Project Path="Assimalign.Cohesion.Dns.Client.Doh/src/Assimalign.Cohesion.Dns.Client.Doh.csproj" />
+	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Doq/">
+		<File Path="Assimalign.Cohesion.Dns.Client.Doq/README.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Doq/docs/OVERVIEW.md" />
+		<File Path="Assimalign.Cohesion.Dns.Client.Doq/docs/REQUIREMENTS.md" />
+	</Folder>
+	<Folder Name="/Dns/Assimalign.Cohesion.Dns.Client.Doq/src/">
+		<Project Path="Assimalign.Cohesion.Dns.Client.Doq/src/Assimalign.Cohesion.Dns.Client.Doq.csproj" />
+	</Folder>
 </Solution>


### PR DESCRIPTION
## Summary

- Plaintext DNS transports land: `UdpDnsTransport` (RFC 1035 §4.2.1) and `TcpDnsTransport` (RFC 1035 §4.2.2 + RFC 7766 connection reuse + stale-connection retry).
- DoT / DoH / DoQ ship as placeholder packages — csproj, README, OVERVIEW, full `docs/REQUIREMENTS.md` contract — so the family layout is stable while the implementations wait on the broader Cohesion HTTP / TLS / QUIC story.
- 15 new tests in `Assimalign.Cohesion.Dns.Client.Tests` (loopback round-trip, timeouts, cancellation, idle close, stale recovery, concurrent exchanges). All 58 existing wire-format tests still green.

## What lands

### `UdpDnsTransport`
- Connected UDP socket per transport instance, reused across exchanges (stable source port).
- Per-exchange receive buffers — concurrent `ExchangeAsync` calls don't cross-contaminate.
- TC-bit responses surfaced to the caller; TCP fallback is a resolver-layer concern.

### `TcpDnsTransport`
- Two-octet length-prefix framing per RFC 1035 §4.2.2.
- Lazy connection open, RFC 7766 idle-close (default 30s).
- **RFC 7766 §6.2.3 stale-connection recovery**: one retry on a fresh socket when a reused connection fails mid-exchange. DNS queries are idempotent so this is safe.
- Serialized exchanges (pipelining is a follow-up gated on resolver-side ID correlation).

Both transports:
- Route external `CancellationToken` cancellation through as `OperationCanceledException`.
- Route internal timeout as `DnsException(Timeout)`.
- Route socket failures as `DnsException(Transport)`.

### Placeholder packages (3)

| Package | RFC | Why deferred |
|---------|-----|--------------|
| `Assimalign.Cohesion.Dns.Client.Dot` | 7858 | Wait for shared Cohesion TLS plumbing |
| `Assimalign.Cohesion.Dns.Client.Doh` | 8484 | Wait for `Assimalign.Cohesion.Http.ClientFactory` to stabilize |
| `Assimalign.Cohesion.Dns.Client.Doq` | 9250 | Wait for `Assimalign.Cohesion.Transports` QUIC client transport |

Each `docs/REQUIREMENTS.md` is the implementation contract the eventual PR must satisfy — public surface, dependency rules, RFC behavior, test plan, open design questions.

## Implementation note: raw sockets vs Cohesion.Transports

Transports use `System.Net.Sockets.Socket` directly rather than building on `Assimalign.Cohesion.Transports.{Udp,Tcp}ClientTransport`. The Transports library models bidirectional pipe-backed flows with pluggable middleware — the right model for streaming protocols, gratuitous for one-shot DNS request/response. Documented in each class's remarks; revisit if Transports grows a request/response shape.

## What does NOT land in PR 3

- Recursive resolver + cache → PR 4
- Referral chasing, bailiwick, glue, QNAME minimization, attack regression suite → PR 5
- DoT / DoH / DoQ implementations → deferred per epic decision

## Test plan

- [x] All new Dns.Client tests pass locally (15/15)
- [x] All existing Dns tests still pass (58/58)
- [x] All three placeholder packages build cleanly
- [x] Full \`libraries/Dns/Assimalign.Cohesion.Dns.slnx\` solution builds with 0 warnings / 0 errors
- [ ] CI matrix green on ubuntu, windows, macos for all 5 Dns assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)