### PR TITLE
feat(dns.client): forwarding resolver + TTL cache (L01.01.08 PR4)

### DIFF
--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
@@ -10,8 +10,9 @@ of the `Assimalign.Cohesion.Dns` contracts.
 |---------|--------|
 | `UdpDnsTransport` &mdash; RFC 1035 §4.2.1 UDP transport | Shipping |
 | `TcpDnsTransport` &mdash; RFC 1035 §4.2.2 length-prefix TCP transport, RFC 7766 connection reuse | Shipping |
+| `ForwardingDnsResolver` &mdash; cache-aware forwarding resolver, RFC 5452 spoof protection, RFC 5966 TC fallback, RFC 2308 negative caching | Shipping |
 | `DotDnsTransport`, `DohDnsTransport`, `DoqDnsTransport` | Placeholder packages (see `Assimalign.Cohesion.Dns.Client.{Dot,Doh,Doq}`) |
-| Recursive resolver + cache | Deferred to a follow-up PR |
+| Iterative resolver from root hints, referral chasing, bailiwick + glue policing, QNAME minimization | Deferred to a follow-up PR |
 
 ## Transport contract
 
@@ -36,6 +37,57 @@ parsing live in `Assimalign.Cohesion.Dns`. This split keeps the
 transport implementation small and lets the resolver decide
 message-level concerns like EDNS payload size or DNSSEC bits without
 involving the network layer.
+
+## Forwarding resolver
+
+`ForwardingDnsResolver` is a cache-aware client that delegates the recursive
+walk to one or more upstream resolvers (a corporate DNS server, a public
+service like `1.1.1.1` / `9.9.9.9`, a local `unbound`). It's the right shape
+for stub resolvers, side-car caches, and any deployment where a trusted
+upstream already exists.
+
+```csharp
+using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+{
+    EndPoint = new IPEndPoint(IPAddress.Parse("1.1.1.1"), 53),
+});
+using var tcp = new TcpDnsTransport(new TcpDnsTransportOptions
+{
+    EndPoint = new IPEndPoint(IPAddress.Parse("1.1.1.1"), 53),
+});
+
+var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+{
+    Forwarders     = { udp },
+    TcpFallbacks   = { [udp] = tcp },   // retry on TCP when UDP comes back truncated
+    QueryTimeout   = TimeSpan.FromSeconds(5),
+    EdnsPayloadSize = 1232,             // RFC 6891 + dnsflagday.net guidance
+    MaxCacheTtl    = TimeSpan.FromHours(1),
+});
+
+DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+```
+
+The resolver:
+
+- **Caches** positive answers, NXDOMAIN, and NODATA (RFC 2308) by question.
+  Negative caching uses `min(SOA.TTL, SOA.MINIMUM)` from the authority
+  section. Cached non-success responses re-throw the same exception shape
+  on the next call so callers don't have to distinguish hit from miss.
+- **Validates** every response per RFC 5452: the transaction id, QR flag,
+  and question triple (name + type + class) must echo the outgoing query.
+  Failures surface as `DnsException(Spoofed)`. Transaction ids are drawn
+  from `RandomNumberGenerator` for every query.
+- **Fails over** to the next configured forwarder when an exchange fails
+  with `Transport` or `Timeout`. Authoritative non-success responses
+  (NXDOMAIN, SERVFAIL, REFUSED) are not retried &mdash; they're the answer.
+- **Falls back to TCP** when a UDP response carries the TC flag and a TCP
+  transport is registered in `TcpFallbacks` (RFC 5966). When no TCP
+  fallback exists the truncated response is returned as-is.
+
+Iterative resolution from root hints &mdash; referral chasing, bailiwick
+checks, glue policing, QNAME minimization &mdash; is a separate concern
+that lands in a follow-up.
 
 ## Connection reuse + retry semantics
 

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolver.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolver.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// A forwarding DNS resolver. Sends every question to one of the configured upstream
+/// forwarders, validates the response against the outgoing query (RFC 5452 transaction-id +
+/// question-section echo), and caches positive / NXDOMAIN / NODATA answers by TTL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// "Forwarding" here means the resolver does not perform its own iterative walk &#8211; it
+/// delegates the recursion to the configured upstream(s) and inherits their recursion-cache
+/// behavior. This is the right shape for stub resolvers, side-car caches, and any deployment
+/// where a trusted upstream (a corporate resolver, a public service like
+/// <c>1.1.1.1</c>/<c>9.9.9.9</c>, a local <c>unbound</c>) already exists.
+/// </para>
+/// <para>
+/// Iterative resolution from root hints &#8211; with referral chasing, bailiwick checks, glue
+/// policing, and QNAME minimization &#8211; is a separate concern that lands in a follow-up
+/// (Stories L01.01.08.06.02 / 06.03).
+/// </para>
+/// <para>
+/// <strong>Spoofing protection.</strong> Every outgoing query gets a fresh
+/// cryptographically-random 16-bit transaction id
+/// (<see cref="RandomNumberGenerator.GetInt32(int)"/>). The response is rejected with
+/// <see cref="DnsErrorCode.Spoofed"/> if the id, question count, or question triple
+/// (name + type + class) does not echo the query. Source-port randomization is handled by
+/// the OS (the underlying socket is created with an ephemeral local port).
+/// </para>
+/// <para>
+/// <strong>TC fallback.</strong> When a UDP response carries the TC flag (RFC 5966), the
+/// resolver retries the same question on the TCP transport configured in
+/// <see cref="ForwardingDnsResolverOptions.TcpFallbacks"/>. If no TCP fallback is registered
+/// for that UDP forwarder, the truncated response is surfaced to the caller as-is &#8211;
+/// they can decide whether to retry, ignore the TC bit, or treat the partial answer as
+/// authoritative for their purposes.
+/// </para>
+/// <para>
+/// <strong>Forwarder rotation.</strong> Forwarders are tried in the order configured. A
+/// failure that surfaces as <see cref="DnsErrorCode.Transport"/> or
+/// <see cref="DnsErrorCode.Timeout"/> fails over to the next forwarder; a successful exchange
+/// that returns NXDOMAIN, NODATA, or another RCODE is the authoritative answer and is not
+/// retried elsewhere.
+/// </para>
+/// </remarks>
+public sealed class ForwardingDnsResolver : DnsResolver
+{
+    private readonly ForwardingDnsResolverOptions _options;
+    private readonly DnsAnswerCache? _cache;
+
+    /// <summary>
+    /// Initializes a new <see cref="ForwardingDnsResolver"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="options"/>.<c>Forwarders</c> is empty
+    /// or contains <see langword="null"/>, or a timeout / cache parameter is invalid.</exception>
+    public ForwardingDnsResolver(ForwardingDnsResolverOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Forwarders.Count == 0)
+        {
+            throw new ArgumentException(
+                $"{nameof(ForwardingDnsResolverOptions)}.{nameof(ForwardingDnsResolverOptions.Forwarders)} must contain at least one transport.",
+                nameof(options));
+        }
+        foreach (DnsTransport t in options.Forwarders)
+        {
+            if (t is null)
+            {
+                throw new ArgumentException(
+                    "Forwarder list contains a null entry.",
+                    nameof(options));
+            }
+        }
+        if (options.QueryTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                $"{nameof(ForwardingDnsResolverOptions)}.{nameof(ForwardingDnsResolverOptions.QueryTimeout)} must be positive.",
+                nameof(options));
+        }
+
+        _options = options;
+        _cache = options.EnableCache
+            ? new DnsAnswerCache(options.CacheCapacity, options.MinCacheTtl, options.MaxCacheTtl, options.TimeProvider)
+            : null;
+    }
+
+    /// <summary>
+    /// Number of entries currently held by the cache, or zero when caching is disabled.
+    /// Exposed for diagnostics and tests; not part of the long-term public surface guarantee.
+    /// </summary>
+    public int CacheCount => _cache?.Count ?? 0;
+
+    /// <inheritdoc />
+    public override Task<DnsMessage> QueryAsync(DnsQuestion question, CancellationToken cancellationToken = default)
+        => ResolveAsync(question, cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// In forwarding mode the answer comes from a recursive upstream, so
+    /// <see cref="ResolveAsync"/> and <see cref="QueryAsync"/> are the same operation.
+    /// </remarks>
+    public override async Task<DnsMessage> ResolveAsync(DnsQuestion question, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (question.Type == default)
+        {
+            throw new ArgumentException("Question type must be set.", nameof(question));
+        }
+
+        // Cache check first. We invoke ThrowIfNonSuccess on the cached message so a cached
+        // NXDOMAIN / SERVFAIL raises the same exception shape as a fresh query.
+        if (_cache is not null && _cache.TryGet(question, out DnsMessage? cached))
+        {
+            return ThrowIfNonSuccess(cached, question);
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_options.QueryTimeout);
+
+        DnsException? lastFailure = null;
+        foreach (DnsTransport forwarder in _options.Forwarders)
+        {
+            DnsMessage response;
+            try
+            {
+                response = await ExchangeAsync(forwarder, question, timeoutCts, cancellationToken).ConfigureAwait(false);
+            }
+            catch (DnsException ex) when (ex.Code is DnsErrorCode.Transport or DnsErrorCode.Timeout)
+            {
+                // Failover to the next forwarder. Remember the last error so we can throw it
+                // if every forwarder fails.
+                lastFailure = ex;
+                continue;
+            }
+
+            // TC fallback: if the answer is truncated and we have a TCP transport for this
+            // forwarder, retry the exchange over TCP.
+            if ((response.Header.Flags & DnsHeaderFlags.Truncated) != 0
+                && _options.TcpFallbacks.TryGetValue(forwarder, out DnsTransport? tcp))
+            {
+                try
+                {
+                    response = await ExchangeAsync(tcp, question, timeoutCts, cancellationToken).ConfigureAwait(false);
+                }
+                catch (DnsException ex) when (ex.Code is DnsErrorCode.Transport or DnsErrorCode.Timeout)
+                {
+                    // The TCP fallback failed; keep the truncated UDP answer and let the
+                    // caller decide. Don't fail over to the next forwarder because we already
+                    // have a (truncated) authoritative-from-upstream answer.
+                    _ = ex;
+                }
+            }
+
+            _cache?.Put(question, response);
+            return ThrowIfNonSuccess(response, question);
+        }
+
+        // Every forwarder failed.
+        if (lastFailure is not null)
+        {
+            throw lastFailure;
+        }
+        // Defensive — empty forwarder list is rejected in the constructor.
+        DnsException.ThrowTransport("no forwarders attempted");
+        throw new InvalidOperationException();
+    }
+
+    /// <inheritdoc />
+    public override Task ClearCacheAsync(CancellationToken cancellationToken = default)
+    {
+        _cache?.Clear();
+        return Task.CompletedTask;
+    }
+
+    private async Task<DnsMessage> ExchangeAsync(
+        DnsTransport transport,
+        DnsQuestion question,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken)
+    {
+        ushort id = (ushort)RandomNumberGenerator.GetInt32(0, 65_536);
+        DnsMessage query = BuildQuery(id, question);
+        byte[] requestBytes = SerializeQuery(query);
+
+        ReadOnlyMemory<byte> responseBytes;
+        try
+        {
+            responseBytes = await transport
+                .ExchangeAsync(requestBytes, timeoutCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !externalToken.IsCancellationRequested)
+        {
+            DnsException.ThrowTimeout($"{question.Name} {question.Type}");
+            throw; // unreachable
+        }
+
+        DnsMessage response;
+        try
+        {
+            response = DnsMessage.Parse(responseBytes.Span);
+        }
+        catch (DnsException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            DnsException.ThrowMalformed($"failed to parse response for {question.Name} {question.Type}", ex);
+            throw; // unreachable
+        }
+
+        ValidateResponse(response, query);
+        return response;
+    }
+
+    private DnsMessage BuildQuery(ushort id, DnsQuestion question)
+    {
+        bool useEdns = _options.EdnsPayloadSize > 0;
+        var header = new DnsHeader(
+            id,
+            DnsHeaderFlags.RecursionDesired,
+            DnsOpCode.Query,
+            DnsResponseCode.NoError,
+            questionCount: 1,
+            answerCount: 0,
+            authorityCount: 0,
+            additionalCount: useEdns ? (ushort)1 : (ushort)0);
+
+        IReadOnlyList<DnsRecord> additionals = useEdns
+            ? new DnsRecord[] { new DnsOptRecord(_options.EdnsPayloadSize) }
+            : Array.Empty<DnsRecord>();
+
+        return new DnsMessage(
+            header,
+            new[] { question },
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>(),
+            additionals);
+    }
+
+    private static byte[] SerializeQuery(DnsMessage query)
+    {
+        // 1232 octets is the modern guidance for UDP-safe DNS messages (RFC 6891 §6.2.4 +
+        // dnsflagday.net). Queries are always small relative to that bound.
+        byte[] buffer = new byte[1232];
+        int written = query.WriteTo(buffer);
+        // Trim to actual length; the transport API accepts a ReadOnlyMemory of any size.
+        byte[] trimmed = new byte[written];
+        Buffer.BlockCopy(buffer, 0, trimmed, 0, written);
+        return trimmed;
+    }
+
+    private static void ValidateResponse(DnsMessage response, DnsMessage query)
+    {
+        if (response.Header.Id != query.Header.Id)
+        {
+            DnsException.ThrowSpoofed(
+                $"response transaction id 0x{response.Header.Id:X4} does not match query id 0x{query.Header.Id:X4}");
+        }
+        if ((response.Header.Flags & DnsHeaderFlags.Response) == 0)
+        {
+            DnsException.ThrowSpoofed("response message does not have the QR flag set");
+        }
+        if (response.Questions.Count != query.Questions.Count)
+        {
+            DnsException.ThrowSpoofed(
+                $"response question count {response.Questions.Count} does not echo query count {query.Questions.Count}");
+        }
+        for (int i = 0; i < query.Questions.Count; i++)
+        {
+            DnsQuestion rq = response.Questions[i];
+            DnsQuestion qq = query.Questions[i];
+            if (!rq.Name.Equals(qq.Name) || rq.Type != qq.Type || rq.Class != qq.Class)
+            {
+                DnsException.ThrowSpoofed(
+                    $"response question {i} ({rq}) does not echo query question ({qq})");
+            }
+        }
+    }
+
+    private static DnsMessage ThrowIfNonSuccess(DnsMessage response, DnsQuestion question)
+    {
+        DnsResponseCode rcode = response.Header.ResponseCode;
+        if (rcode == DnsResponseCode.NoError)
+        {
+            return response;
+        }
+        if (rcode == DnsResponseCode.NXDomain)
+        {
+            DnsException.ThrowNotFound(question.ToString());
+        }
+        DnsException.ThrowServerFailure(question.ToString(), rcode);
+        throw new InvalidOperationException(); // unreachable
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolverOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolverOptions.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Dns;
+
+/// <summary>
+/// Configuration for <see cref="ForwardingDnsResolver"/>.
+/// </summary>
+public sealed class ForwardingDnsResolverOptions
+{
+    /// <summary>
+    /// Ordered list of upstream forwarders the resolver should try. Each entry is a
+    /// <see cref="DnsTransport"/> bound to a specific endpoint; the resolver tries them in
+    /// the listed order and fails over on transport failure. The resolver does NOT take
+    /// ownership of these transports &#8211; the caller is responsible for their lifetime.
+    /// </summary>
+    public IList<DnsTransport> Forwarders { get; } = new List<DnsTransport>();
+
+    /// <summary>
+    /// Optional UDP&rarr;TCP fallback mapping. When the resolver receives a UDP response with
+    /// the TC flag set (RFC 5966), it retries the same question on the mapped TCP transport.
+    /// If no mapping exists for a given UDP transport, the truncated response is returned
+    /// as-is &#8211; consumers can then retry on TCP themselves.
+    /// </summary>
+    public IDictionary<DnsTransport, DnsTransport> TcpFallbacks { get; }
+        = new Dictionary<DnsTransport, DnsTransport>();
+
+    /// <summary>
+    /// End-to-end timeout for one resolve / query call &#8211; covers all forwarder attempts
+    /// and the optional TCP fallback. Defaults to 10 seconds.
+    /// </summary>
+    public TimeSpan QueryTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// EDNS UDP payload size to advertise in the OPT record on outgoing queries
+    /// (RFC 6891 &#167; 6.2.3). Defaults to 1232 octets &#8211; the modern guidance that
+    /// stays inside a typical Ethernet MTU and avoids fragmentation attacks. Set to zero to
+    /// suppress EDNS entirely (compatible with very old resolvers; not recommended).
+    /// </summary>
+    public ushort EdnsPayloadSize { get; set; } = 1232;
+
+    /// <summary>
+    /// When <see langword="true"/>, the resolver caches positive, NXDOMAIN, and NODATA
+    /// responses keyed by question, honoring per-record TTL (RFC 1035 &#167; 4.3.2) and
+    /// SOA-derived negative TTL (RFC 2308 &#167; 5). Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool EnableCache { get; set; } = true;
+
+    /// <summary>
+    /// Maximum number of entries in the cache. Defaults to 10,000. Ignored when
+    /// <see cref="EnableCache"/> is <see langword="false"/>.
+    /// </summary>
+    public int CacheCapacity { get; set; } = 10_000;
+
+    /// <summary>
+    /// Optional floor on cached TTL. When set, an answer with a lower effective TTL is held
+    /// in the cache for this long instead. <see langword="null"/> means "use the RR TTL
+    /// as-is."
+    /// </summary>
+    public TimeSpan? MinCacheTtl { get; set; }
+
+    /// <summary>
+    /// Optional ceiling on cached TTL. When set, an answer with a higher effective TTL is
+    /// capped. <see langword="null"/> means "no ceiling beyond the RR TTL."
+    /// </summary>
+    public TimeSpan? MaxCacheTtl { get; set; }
+
+    /// <summary>
+    /// Time source used by the cache. Defaults to <see cref="TimeProvider.System"/>; tests
+    /// can inject <see cref="System.TimeProvider"/> implementations to advance the clock
+    /// deterministically.
+    /// </summary>
+    public TimeProvider? TimeProvider { get; set; }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsAnswerCache.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsAnswerCache.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// In-memory TTL-aware DNS answer cache. Keyed by <see cref="DnsQuestion"/>; stores the
+/// full <see cref="DnsMessage"/> so callers see the same answer/authority/additional
+/// sections the upstream produced. Eviction is governed by RFC 1035 &#167; 4.3.2 (positive)
+/// and RFC 2308 &#167; 5 (negative).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Capacity is enforced by approximate-LRU eviction: when the cache is full, a new
+/// <see cref="Put"/> drops the oldest-inserted entry. This is intentionally simple &#8211;
+/// precise LRU buys little against a workload dominated by repeated lookups of a small
+/// working set, and the implementation cost shows up everywhere.
+/// </para>
+/// <para>
+/// Thread-safety: all operations are guarded by a single lock. Cache lookups on the hit
+/// path do not allocate.
+/// </para>
+/// </remarks>
+internal sealed class DnsAnswerCache
+{
+    private readonly int _capacity;
+    private readonly TimeSpan? _minTtl;
+    private readonly TimeSpan? _maxTtl;
+    private readonly TimeProvider _timeProvider;
+    private readonly Lock _gate = new();
+    private readonly Dictionary<DnsQuestion, LinkedListNode<Entry>> _entries;
+    private readonly LinkedList<Entry> _order = new();
+
+    public DnsAnswerCache(int capacity, TimeSpan? minTtl, TimeSpan? maxTtl, TimeProvider? timeProvider = null)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Cache capacity must be positive.");
+        }
+        if (minTtl is { } min && min < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minTtl), minTtl, "MinTtl must be non-negative.");
+        }
+        if (maxTtl is { } max && max < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTtl), maxTtl, "MaxTtl must be non-negative.");
+        }
+        if (minTtl is not null && maxTtl is not null && minTtl > maxTtl)
+        {
+            throw new ArgumentException("MinTtl must not exceed MaxTtl.", nameof(minTtl));
+        }
+
+        _capacity = capacity;
+        _minTtl = minTtl;
+        _maxTtl = maxTtl;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _entries = new Dictionary<DnsQuestion, LinkedListNode<Entry>>(capacity);
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _entries.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Looks up an entry by question. Returns <see langword="false"/> on miss or expired entry
+    /// (expired entries are evicted on hit).
+    /// </summary>
+    public bool TryGet(DnsQuestion question, [NotNullWhen(true)] out DnsMessage? message)
+    {
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(question, out LinkedListNode<Entry>? node))
+            {
+                if (_timeProvider.GetUtcNow() < node.Value.ExpiresAtUtc)
+                {
+                    message = node.Value.Message;
+                    return true;
+                }
+                // Expired — evict.
+                _entries.Remove(question);
+                _order.Remove(node);
+            }
+        }
+        message = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores <paramref name="message"/> against <paramref name="question"/>. Computes the
+    /// effective TTL per RFC 1035 §4.3.2 / RFC 2308 §5, clamps it to the configured floor /
+    /// ceiling, and skips the insert when the effective TTL is zero.
+    /// </summary>
+    public void Put(DnsQuestion question, DnsMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        TimeSpan ttl = ComputeCacheTtl(message);
+        if (_minTtl is { } min && ttl < min)
+        {
+            ttl = min;
+        }
+        if (_maxTtl is { } max && ttl > max)
+        {
+            ttl = max;
+        }
+        if (ttl <= TimeSpan.Zero)
+        {
+            return; // RFC 1035 §4.3.2 — TTL=0 forbids caching.
+        }
+
+        DateTimeOffset expiresAt = _timeProvider.GetUtcNow() + ttl;
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(question, out LinkedListNode<Entry>? existing))
+            {
+                _order.Remove(existing);
+                _entries.Remove(question);
+            }
+
+            if (_entries.Count >= _capacity)
+            {
+                // Approximate-LRU eviction: drop the head (oldest-inserted) entry.
+                LinkedListNode<Entry>? oldest = _order.First;
+                if (oldest is not null)
+                {
+                    _entries.Remove(oldest.Value.Question);
+                    _order.Remove(oldest);
+                }
+            }
+
+            LinkedListNode<Entry> node = _order.AddLast(new Entry(question, message, expiresAt));
+            _entries[question] = node;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _entries.Clear();
+            _order.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Computes the effective cache TTL for a response message.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Positive answers (NoError + at least one answer): the minimum TTL across the answer
+    /// section, bounded by the minimum TTL across the authority-section NS records. RFC 1035
+    /// §4.3.2 says "the value in the TTL field is interpreted as the maximum number of seconds
+    /// the record can be cached."
+    /// </para>
+    /// <para>
+    /// Negative answers (NXDOMAIN or NoError + no answer): per RFC 2308 §5 the negative-caching
+    /// TTL is <c>min(SOA.TTL, SOA.MINIMUM)</c> drawn from the SOA record in the authority
+    /// section. When there's no SOA (deliberately ANTI-RFC-2308 servers exist), the negative
+    /// is treated as uncacheable (TTL = 0).
+    /// </para>
+    /// </remarks>
+    internal static TimeSpan ComputeCacheTtl(DnsMessage message)
+    {
+        bool isNegative = message.Header.ResponseCode == DnsResponseCode.NXDomain || message.Answers.Count == 0;
+
+        if (isNegative)
+        {
+            foreach (DnsRecord rr in message.Authorities)
+            {
+                if (rr is DnsSoaRecord soa)
+                {
+                    uint negTtl = Math.Min(rr.TimeToLive, soa.MinimumTtl);
+                    return TimeSpan.FromSeconds(negTtl);
+                }
+            }
+            return TimeSpan.Zero;
+        }
+
+        uint minTtl = uint.MaxValue;
+        foreach (DnsRecord rr in message.Answers)
+        {
+            if (rr.TimeToLive < minTtl)
+            {
+                minTtl = rr.TimeToLive;
+            }
+        }
+        foreach (DnsRecord rr in message.Authorities)
+        {
+            if (rr.Type == DnsRecordType.NS && rr.TimeToLive < minTtl)
+            {
+                minTtl = rr.TimeToLive;
+            }
+        }
+        return minTtl == uint.MaxValue ? TimeSpan.Zero : TimeSpan.FromSeconds(minTtl);
+    }
+
+    private sealed record Entry(DnsQuestion Question, DnsMessage Message, DateTimeOffset ExpiresAtUtc);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsAnswerCacheTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsAnswerCacheTests.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+public sealed class DnsAnswerCacheTests
+{
+    [Fact]
+    public void TryGet_OnEmptyCache_Misses()
+    {
+        var cache = new DnsAnswerCache(capacity: 8, minTtl: null, maxTtl: null);
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_ThenTryGet_ReturnsStoredMessage()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, null, null, clock);
+
+        DnsMessage message = BuildPositive("example.com", ttl: 300);
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), message);
+
+        Assert.True(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out DnsMessage? hit));
+        Assert.Same(message, hit);
+    }
+
+    [Fact]
+    public void TryGet_AfterTtlElapses_EvictsEntry()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, null, null, clock);
+
+        DnsMessage message = BuildPositive("example.com", ttl: 30);
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), message);
+
+        clock.Advance(TimeSpan.FromSeconds(31));
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void Put_NameDifferingOnlyInCase_AliasesSameEntry()
+    {
+        var cache = new DnsAnswerCache(8, null, null);
+        cache.Put(new DnsQuestion("Example.COM", DnsRecordType.A), BuildPositive("example.com", 300));
+
+        Assert.True(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+        Assert.True(cache.TryGet(new DnsQuestion("EXAMPLE.com", DnsRecordType.A), out _));
+        Assert.True(cache.TryGet(new DnsQuestion("example.com.", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_DifferingTypes_ShareKeyspaceCorrectly()
+    {
+        var cache = new DnsAnswerCache(8, null, null);
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), BuildPositive("example.com", 300));
+
+        Assert.True(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.AAAA), out _));
+    }
+
+    [Fact]
+    public void Put_BeyondCapacity_EvictsOldest()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(2, null, null, clock);
+
+        cache.Put(new DnsQuestion("a.example.com", DnsRecordType.A), BuildPositive("a.example.com", 300));
+        cache.Put(new DnsQuestion("b.example.com", DnsRecordType.A), BuildPositive("b.example.com", 300));
+        cache.Put(new DnsQuestion("c.example.com", DnsRecordType.A), BuildPositive("c.example.com", 300));
+
+        Assert.False(cache.TryGet(new DnsQuestion("a.example.com", DnsRecordType.A), out _));
+        Assert.True(cache.TryGet(new DnsQuestion("b.example.com", DnsRecordType.A), out _));
+        Assert.True(cache.TryGet(new DnsQuestion("c.example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_ZeroTtl_DoesNotCache()
+    {
+        var cache = new DnsAnswerCache(8, null, null);
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), BuildPositive("example.com", ttl: 0));
+        Assert.Equal(0, cache.Count);
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_MinTtl_ExtendsShortTtl()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, minTtl: TimeSpan.FromSeconds(60), maxTtl: null, clock);
+
+        // Record TTL is 5s but MinTtl floor is 60s.
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), BuildPositive("example.com", ttl: 5));
+
+        clock.Advance(TimeSpan.FromSeconds(30));
+        Assert.True(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+
+        clock.Advance(TimeSpan.FromSeconds(31)); // total 61s
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_MaxTtl_CapsLongTtl()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, minTtl: null, maxTtl: TimeSpan.FromSeconds(60), clock);
+
+        // Record TTL is 3600s but MaxTtl caps to 60s.
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.A), BuildPositive("example.com", ttl: 3600));
+
+        clock.Advance(TimeSpan.FromSeconds(61));
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_NxDomainWithSoa_CachedForSoaNegativeTtl()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, null, null, clock);
+
+        DnsSoaRecord soa = DnsTestMessages.ExampleComSoa(minimumTtl: 30, ttl: 60);
+        DnsMessage nx = BuildNxDomain("nope.example.com", soa);
+
+        cache.Put(new DnsQuestion("nope.example.com", DnsRecordType.A), nx);
+
+        // negative TTL = min(SOA.TTL=60, SOA.MINIMUM=30) = 30
+        clock.Advance(TimeSpan.FromSeconds(20));
+        Assert.True(cache.TryGet(new DnsQuestion("nope.example.com", DnsRecordType.A), out _));
+
+        clock.Advance(TimeSpan.FromSeconds(15)); // total 35s, past the 30s SOA-derived TTL
+        Assert.False(cache.TryGet(new DnsQuestion("nope.example.com", DnsRecordType.A), out _));
+    }
+
+    [Fact]
+    public void Put_NxDomainWithoutSoa_IsNotCached()
+    {
+        var cache = new DnsAnswerCache(8, null, null);
+
+        var header = new DnsHeader(
+            id: 0x1234,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NXDomain,
+            1, 0, 0, 0);
+
+        var nx = new DnsMessage(
+            header,
+            new[] { new DnsQuestion("nope.example.com", DnsRecordType.A) },
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>());
+
+        cache.Put(new DnsQuestion("nope.example.com", DnsRecordType.A), nx);
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void Put_NoDataWithSoa_CachedForSoaNegativeTtl()
+    {
+        // NoError + empty answer + SOA in authority = NODATA per RFC 2308 §2.2.
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsAnswerCache(8, null, null, clock);
+
+        DnsSoaRecord soa = DnsTestMessages.ExampleComSoa(minimumTtl: 45, ttl: 90);
+        var header = new DnsHeader(
+            id: 0x1111,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NoError,
+            1, 0, 1, 0);
+
+        var nodata = new DnsMessage(
+            header,
+            new[] { new DnsQuestion("example.com", DnsRecordType.AAAA) },
+            Array.Empty<DnsRecord>(),
+            new DnsRecord[] { soa },
+            Array.Empty<DnsRecord>());
+
+        cache.Put(new DnsQuestion("example.com", DnsRecordType.AAAA), nodata);
+
+        clock.Advance(TimeSpan.FromSeconds(40));
+        Assert.True(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.AAAA), out _));
+
+        clock.Advance(TimeSpan.FromSeconds(10)); // 50s > min(SOA.TTL=90, SOA.MINIMUM=45)=45
+        Assert.False(cache.TryGet(new DnsQuestion("example.com", DnsRecordType.AAAA), out _));
+    }
+
+    [Fact]
+    public void Clear_RemovesEverything()
+    {
+        var cache = new DnsAnswerCache(8, null, null);
+        cache.Put(new DnsQuestion("a.example.com", DnsRecordType.A), BuildPositive("a.example.com", 300));
+        cache.Put(new DnsQuestion("b.example.com", DnsRecordType.A), BuildPositive("b.example.com", 300));
+
+        cache.Clear();
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void Constructor_RejectsInvalidCapacity()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DnsAnswerCache(0, null, null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DnsAnswerCache(-1, null, null));
+    }
+
+    [Fact]
+    public void Constructor_RejectsInvalidTtls()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new DnsAnswerCache(8, minTtl: TimeSpan.FromSeconds(-1), null));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new DnsAnswerCache(8, null, maxTtl: TimeSpan.FromSeconds(-1)));
+        Assert.Throws<ArgumentException>(
+            () => new DnsAnswerCache(8, minTtl: TimeSpan.FromSeconds(120), maxTtl: TimeSpan.FromSeconds(60)));
+    }
+
+    private static DnsMessage BuildPositive(string name, uint ttl)
+    {
+        var header = new DnsHeader(
+            id: 1,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NoError,
+            1, 1, 0, 0);
+
+        return new DnsMessage(
+            header,
+            new[] { new DnsQuestion(name, DnsRecordType.A) },
+            new DnsRecord[] { new DnsARecord(name, IPAddress.Parse("127.0.0.1"), ttl) },
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>());
+    }
+
+    private static DnsMessage BuildNxDomain(string name, DnsSoaRecord soa)
+    {
+        var header = new DnsHeader(
+            id: 2,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NXDomain,
+            1, 0, 1, 0);
+
+        return new DnsMessage(
+            header,
+            new[] { new DnsQuestion(name, DnsRecordType.A) },
+            Array.Empty<DnsRecord>(),
+            new DnsRecord[] { soa },
+            Array.Empty<DnsRecord>());
+    }
+
+    /// <summary>
+    /// Minimal fake TimeProvider for cache TTL tests.
+    /// </summary>
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/ForwardingDnsResolverTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/ForwardingDnsResolverTests.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+public sealed class ForwardingDnsResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_RoundTripsAgainstLoopbackResolver()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        int requestCount = 0;
+        server.OnRequest(req =>
+        {
+            requestCount++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+
+        Assert.Single(answer.Answers);
+        DnsARecord a = Assert.IsType<DnsARecord>(answer.Answers[0]);
+        Assert.Equal(IPAddress.Parse("93.184.216.34"), a.Address);
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CachesPositiveAnswer()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        int requestCount = 0;
+        server.OnRequest(req =>
+        {
+            requestCount++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions { Forwarders = { udp } });
+
+        var q = new DnsQuestion("example.com", DnsRecordType.A);
+        DnsMessage a = await resolver.ResolveAsync(q);
+        DnsMessage b = await resolver.ResolveAsync(q);
+
+        Assert.Same(a, b); // Cache hit returns the exact same object.
+        Assert.Equal(1, requestCount);
+        Assert.Equal(1, resolver.CacheCount);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NxDomainSurfacesAsNotFoundAndIsCached()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        int requestCount = 0;
+        server.OnRequest(req =>
+        {
+            requestCount++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildNxDomain(query, DnsTestMessages.ExampleComSoa());
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions { Forwarders = { udp } });
+
+        var q = new DnsQuestion("nope.example.com", DnsRecordType.A);
+
+        DnsException ex1 = await Assert.ThrowsAsync<DnsException>(() => resolver.ResolveAsync(q));
+        Assert.Equal(DnsErrorCode.NotFound, ex1.Code);
+
+        // Second call also throws NotFound but doesn't hit the transport — cached NXDOMAIN.
+        DnsException ex2 = await Assert.ThrowsAsync<DnsException>(() => resolver.ResolveAsync(q));
+        Assert.Equal(DnsErrorCode.NotFound, ex2.Code);
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ServerFailureSurfacesAsServerFailure()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildWithRcode(query, DnsResponseCode.ServFail);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions { Forwarders = { udp } });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A)));
+        Assert.Equal(DnsErrorCode.ServerFailure, ex.Code);
+        Assert.Equal(DnsResponseCode.ServFail, ex.ResponseCode);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_TransactionIdMismatchSurfacesAsSpoofed()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            // Return a response with an intentionally wrong id.
+            ushort wrongId = (ushort)(query.Header.Id ^ 0xFFFF);
+            return DnsTestMessages.BuildWithCustomIdAndQuestion(
+                wrongId,
+                query.Questions[0],
+                new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A)));
+        Assert.Equal(DnsErrorCode.Spoofed, ex.Code);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_QuestionMismatchSurfacesAsSpoofed()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            // Echo correct ID but a different question.
+            return DnsTestMessages.BuildWithCustomIdAndQuestion(
+                query.Header.Id,
+                new DnsQuestion("evil.example.com", DnsRecordType.A),
+                new DnsRecord[] { new DnsARecord("evil.example.com", IPAddress.Parse("6.6.6.6"), 300) });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A)));
+        Assert.Equal(DnsErrorCode.Spoofed, ex.Code);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FailsOverToSecondForwarderOnTransportFailure()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        // First forwarder points to TEST-NET-1 (RFC 5737) so connect will fail or time out.
+        using var bad = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = new IPEndPoint(IPAddress.Parse("192.0.2.1"), 53),
+            QueryTimeout = TimeSpan.FromMilliseconds(200),
+        });
+        using var good = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { bad, good },
+            QueryTimeout = TimeSpan.FromSeconds(5),
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Single(answer.Answers);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToTcpOnTcBit()
+    {
+        await using var udpServer = new LoopbackUdpDnsServer();
+        await using var tcpServer = new LoopbackTcpDnsServer();
+
+        int udpHits = 0, tcpHits = 0;
+        udpServer.OnRequest(req =>
+        {
+            udpHits++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            // Truncated response with no answer records.
+            return DnsTestMessages.BuildAnswer(query, Array.Empty<DnsRecord>(), truncated: true);
+        });
+        tcpServer.OnRequest(req =>
+        {
+            tcpHits++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = udpServer.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+        using var tcp = new TcpDnsTransport(new TcpDnsTransportOptions
+        {
+            EndPoint = tcpServer.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            TcpFallbacks = { [udp] = tcp },
+            QueryTimeout = TimeSpan.FromSeconds(5),
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Single(answer.Answers);
+        Assert.Equal(1, udpHits);
+        Assert.Equal(1, tcpHits);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_TruncatedReturnedAsIsWhenNoTcpFallback()
+    {
+        await using var udpServer = new LoopbackUdpDnsServer();
+        udpServer.OnRequest(req =>
+        {
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, Array.Empty<DnsRecord>(), truncated: true);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = udpServer.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromSeconds(2),
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.True((answer.Header.Flags & DnsHeaderFlags.Truncated) != 0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_OutgoingQueryCarriesRdAndEdns()
+    {
+        DnsMessage? capturedQuery = null;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            capturedQuery = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(capturedQuery, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            EdnsPayloadSize = 1232,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.NotNull(capturedQuery);
+        Assert.True((capturedQuery!.Header.Flags & DnsHeaderFlags.RecursionDesired) != 0);
+        DnsOptRecord? opt = capturedQuery.Edns;
+        Assert.NotNull(opt);
+        Assert.Equal(1232, opt!.UdpPayloadSize);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DisablingEdns_OmitsOptRecord()
+    {
+        DnsMessage? capturedQuery = null;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            capturedQuery = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(capturedQuery, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            EdnsPayloadSize = 0,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Null(capturedQuery!.Edns);
+    }
+
+    [Fact]
+    public async Task ClearCacheAsync_ForcesRefetch()
+    {
+        int hits = 0;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            hits++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions { Forwarders = { udp } });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Equal(1, hits);
+
+        await resolver.ClearCacheAsync();
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Equal(2, hits);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DisablingCache_SkipsCacheEntirely()
+    {
+        int hits = 0;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            hits++;
+            DnsMessage query = DnsTestMessages.ParseQuery(req);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            EnableCache = false,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        _ = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Equal(2, hits);
+        Assert.Equal(0, resolver.CacheCount);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PropagatesExternalCancellation()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(_ => Array.Empty<byte>()); // black-hole
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(10),
+        });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A), cts.Token));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_QueryTimeoutSurfacesAsTimeout()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(_ => Array.Empty<byte>()); // black-hole
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
+        {
+            EndPoint = server.EndPoint,
+            QueryTimeout = TimeSpan.FromSeconds(10),
+        });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            QueryTimeout = TimeSpan.FromMilliseconds(200),
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A)));
+        Assert.Equal(DnsErrorCode.Timeout, ex.Code);
+    }
+
+    [Fact]
+    public void Constructor_RejectsEmptyForwarders()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ForwardingDnsResolver(new ForwardingDnsResolverOptions()));
+    }
+
+    [Fact]
+    public void Constructor_RejectsNullForwarder()
+    {
+        var options = new ForwardingDnsResolverOptions();
+        options.Forwarders.Add(null!);
+        Assert.Throws<ArgumentException>(() => new ForwardingDnsResolver(options));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        await using var server = new LoopbackUdpDnsServer();
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions { Forwarders = { udp } });
+
+        resolver.Dispose();
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A)));
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/DnsTestMessages.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/DnsTestMessages.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// Helpers for constructing typed DNS request / response messages from raw bytes in tests.
+/// </summary>
+internal static class DnsTestMessages
+{
+    /// <summary>
+    /// Parses an inbound query into a <see cref="DnsMessage"/>.
+    /// </summary>
+    public static DnsMessage ParseQuery(ReadOnlySpan<byte> request) => DnsMessage.Parse(request);
+
+    /// <summary>
+    /// Builds a NoError response that echoes the query's id + question and carries the supplied
+    /// answer records. <paramref name="authoritative"/> sets the AA flag.
+    /// </summary>
+    public static byte[] BuildAnswer(
+        DnsMessage query,
+        IReadOnlyList<DnsRecord> answers,
+        bool truncated = false,
+        bool authoritative = false,
+        IReadOnlyList<DnsRecord>? authorities = null,
+        IReadOnlyList<DnsRecord>? additionals = null)
+    {
+        DnsHeaderFlags flags = DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable;
+        if (truncated)
+        {
+            flags |= DnsHeaderFlags.Truncated;
+        }
+        if (authoritative)
+        {
+            flags |= DnsHeaderFlags.AuthoritativeAnswer;
+        }
+
+        var header = new DnsHeader(
+            query.Header.Id,
+            flags,
+            DnsOpCode.Query,
+            DnsResponseCode.NoError,
+            (ushort)query.Questions.Count,
+            (ushort)answers.Count,
+            (ushort)(authorities?.Count ?? 0),
+            (ushort)(additionals?.Count ?? 0));
+
+        var response = new DnsMessage(
+            header,
+            query.Questions,
+            answers,
+            authorities ?? Array.Empty<DnsRecord>(),
+            additionals ?? Array.Empty<DnsRecord>());
+
+        return Serialize(response);
+    }
+
+    /// <summary>
+    /// Builds an NXDOMAIN response with the supplied SOA authority (for RFC 2308 negative
+    /// caching).
+    /// </summary>
+    public static byte[] BuildNxDomain(DnsMessage query, DnsSoaRecord soa)
+    {
+        var header = new DnsHeader(
+            query.Header.Id,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NXDomain,
+            (ushort)query.Questions.Count,
+            0,
+            1,
+            0);
+
+        var response = new DnsMessage(
+            header,
+            query.Questions,
+            Array.Empty<DnsRecord>(),
+            new DnsRecord[] { soa },
+            Array.Empty<DnsRecord>());
+
+        return Serialize(response);
+    }
+
+    /// <summary>
+    /// Builds a response with an explicit RCODE. Useful for SERVFAIL / REFUSED tests.
+    /// </summary>
+    public static byte[] BuildWithRcode(DnsMessage query, DnsResponseCode rcode)
+    {
+        var header = new DnsHeader(
+            query.Header.Id,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            rcode,
+            (ushort)query.Questions.Count,
+            0,
+            0,
+            0);
+
+        var response = new DnsMessage(
+            header,
+            query.Questions,
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>());
+
+        return Serialize(response);
+    }
+
+    /// <summary>
+    /// Builds a response with the supplied id and question (used for spoof tests where the
+    /// response intentionally does not echo the query).
+    /// </summary>
+    public static byte[] BuildWithCustomIdAndQuestion(
+        ushort id,
+        DnsQuestion question,
+        IReadOnlyList<DnsRecord> answers)
+    {
+        var header = new DnsHeader(
+            id,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            DnsResponseCode.NoError,
+            1,
+            (ushort)answers.Count,
+            0,
+            0);
+
+        var response = new DnsMessage(
+            header,
+            new[] { question },
+            answers,
+            Array.Empty<DnsRecord>(),
+            Array.Empty<DnsRecord>());
+
+        return Serialize(response);
+    }
+
+    public static DnsSoaRecord ExampleComSoa(uint minimumTtl = 60, uint ttl = 300)
+        => new(
+            name: "example.com",
+            primaryNameServer: "ns1.example.com",
+            responsibleMailbox: "hostmaster.example.com",
+            serial: 1,
+            refreshInterval: 7200,
+            retryInterval: 3600,
+            expireLimit: 1_209_600,
+            minimumTtl: minimumTtl,
+            timeToLive: ttl);
+
+    public static DnsARecord ExampleComA(string ip = "93.184.216.34", uint ttl = 300)
+        => new("example.com", IPAddress.Parse(ip), ttl);
+
+    private static byte[] Serialize(DnsMessage message)
+    {
+        // 4096 octets is generous for any test response.
+        byte[] buffer = new byte[4096];
+        int written = message.WriteTo(buffer);
+        byte[] trimmed = new byte[written];
+        Buffer.BlockCopy(buffer, 0, trimmed, 0, written);
+        return trimmed;
+    }
+}


### PR DESCRIPTION
## Summary

- **`ForwardingDnsResolver`** — cache-aware `DnsResolver` that delegates the recursive walk to one or more upstream forwarders (1.1.1.1, 9.9.9.9, corporate DNS, local unbound).
- **TTL-aware in-memory cache** with RFC 1035 §4.3.2 positive caching and RFC 2308 §5 negative caching (NXDOMAIN + NODATA via SOA-derived TTL).
- **RFC 5452 spoof protection** — cryptographically-random transaction ids per query, question-section echo validation.
- **RFC 5966 TC→TCP fallback** — UDP responses with TC=1 retry on a configured TCP transport.
- 33 new tests (15 cache + 18 resolver) on top of the 15 transport tests from PR 3 and the 58 wire-format tests from PR 2. All 106 green locally.

## What lands

### `ForwardingDnsResolver` + `ForwardingDnsResolverOptions`

```csharp
using var udp = new UdpDnsTransport(new UdpDnsTransportOptions
{
    EndPoint = new IPEndPoint(IPAddress.Parse(\"1.1.1.1\"), 53),
});
using var tcp = new TcpDnsTransport(new TcpDnsTransportOptions
{
    EndPoint = new IPEndPoint(IPAddress.Parse(\"1.1.1.1\"), 53),
});

var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
{
    Forwarders      = { udp },
    TcpFallbacks    = { [udp] = tcp },   // retry on TCP when UDP truncates
    QueryTimeout    = TimeSpan.FromSeconds(5),
    EdnsPayloadSize = 1232,              // RFC 6891 + dnsflagday.net
    MaxCacheTtl     = TimeSpan.FromHours(1),
});

DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion(\"example.com\", DnsRecordType.A));
```

**Behavior:**

| Concern | Behavior |
|---------|----------|
| Forwarder rotation | Try in order, fail over on `Transport` / `Timeout`. Authoritative non-success answers (NXDOMAIN, SERVFAIL, REFUSED) are not retried. |
| Caching | Positive + NXDOMAIN + NODATA, keyed by question. Cached non-success responses re-throw the same exception shape on the next call. |
| Cache TTL | `min(answer + NS authority TTLs)` for positive; `min(SOA.TTL, SOA.MINIMUM)` for negative; TTL = 0 is not cached. |
| Spoof check | Reject responses whose id, QR flag, or question triple does not echo the query. |
| TC handling | Retry over TCP if a fallback is registered; otherwise return the truncated message as-is. |
| Cancellation | External token → `OperationCanceledException`; internal `QueryTimeout` → `DnsException(Timeout)`. |
| EDNS | Outgoing OPT advertises `EdnsPayloadSize` (default 1232). Set to 0 to suppress. |
| Disposal | Resolver does NOT dispose transports — the caller owns them. |

### `DnsAnswerCache` (internal)

In-memory cache keyed by `DnsQuestion`, with approximate-LRU eviction at capacity, injectable `TimeProvider` for deterministic tests, and a single-lock thread-safety model. Cache hit path doesn't allocate.

## Tests

33 new tests across two files in `Assimalign.Cohesion.Dns.Client.Tests`:

**`DnsAnswerCacheTests` (15)** — hit / miss, TTL expiration, case-insensitive name keying, type discrimination, capacity eviction, zero-TTL skip, min / max TTL clamping, NXDOMAIN with / without SOA, NODATA + SOA, Clear(), constructor validation.

**`ForwardingDnsResolverTests` (18)** — round-trip, positive caching, NXDOMAIN surfacing + caching, SERVFAIL surfacing, transaction-id spoof rejection, question-mismatch rejection, forwarder failover, TC→TCP fallback, truncated-without-fallback passthrough, RD + EDNS in outgoing query, EDNS suppression, ClearCacheAsync, cache-disabled mode, external cancellation, internal timeout, constructor validation, ObjectDisposed after Dispose.

## What does NOT land in PR 4

- Iterative resolution from root hints → PR 5
- Referral chasing + bailiwick + glue policing → PR 5
- QNAME minimization (RFC 7816) → PR 5
- Kaminsky-style attack-regression suite → PR 5

## Test plan

- [x] All new tests pass locally (33/33)
- [x] All existing tests still pass — 58 wire-format + 15 transport (106/106)
- [x] Full \`libraries/Dns/Assimalign.Cohesion.Dns.slnx\` solution builds with 0 warnings / 0 errors
- [ ] CI matrix green on ubuntu / windows / macos across all 5 Dns assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)