### PR TITLE
feat(dns.client): out-of-bailiwick NS + delegation cache + EDNS cookies (L01.01.08 PR6)

### DIFF
--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/README.md
@@ -12,9 +12,9 @@ of the `Assimalign.Cohesion.Dns` contracts.
 | `TcpDnsTransport` &mdash; RFC 1035 §4.2.2 length-prefix TCP transport, RFC 7766 connection reuse | Shipping |
 | `StubDnsClient` &mdash; one-shot non-recursive client over a single transport | Shipping |
 | `ForwardingDnsResolver` &mdash; cache-aware forwarding resolver, RFC 5452 spoof protection, RFC 5966 TC fallback, RFC 2308 negative caching | Shipping |
-| `IterativeDnsResolver` &mdash; iterative resolver from root hints with bailiwick + glue policy + QNAME minimization (RFC 9156) | Shipping |
+| `IterativeDnsResolver` &mdash; iterative resolver with bailiwick + glue policy + QNAME minimization (RFC 9156) + out-of-bailiwick NS resolution + delegation caching + EDNS Cookies (RFC 7873) | Shipping |
 | `DotDnsTransport`, `DohDnsTransport`, `DoqDnsTransport` | Placeholder packages (see `Assimalign.Cohesion.Dns.Client.{Dot,Doh,Doq}`) |
-| Out-of-bailiwick NS-name resolution + delegation caching + EDNS Cookies (RFC 7873) + 0x20 case randomization | Deferred to a follow-up PR |
+| 0x20 case randomization | Deferred &mdash; interacts poorly with DNSSEC, revisit when there's demand |
 
 ## Transport contract
 
@@ -77,11 +77,28 @@ The resolver enforces:
 - **Budget enforcement** — bounded referral depth (default 30) and
   bounded total upstream exchanges (default 50) per resolve.
 
-> **PR-5 limitation:** if a referral arrives with no in-bailiwick glue,
-> the resolver currently surfaces `DnsErrorCode.Transport` rather than
-> recursing to resolve the out-of-bailiwick NS name. Well-glued
-> production zones (the IANA root + every TLD that matters) are
-> unaffected. Out-of-bailiwick NS resolution lands in a follow-up.
+**Out-of-bailiwick NS resolution** &mdash; when a referral carries no
+in-bailiwick glue (e.g. the `.com` authority delegating to
+`ns1.example-dns.net`), the resolver recursively resolves the NS
+name through its own cache and the shared per-query budget.
+Bounded by `MaxNsResolutionDepth` (default 5) so a pathological
+delegation chain can't exhaust resources.
+
+**Delegation caching** &mdash; on every successful referral the
+`(zone, NS endpoints)` pair is cached with the NS records' TTL. The
+next query for any name in the cached zone skips the
+root&rarr;TLD walk and starts from the closest enclosing
+delegation. Enabled by default;
+`IterativeDnsResolverOptions.EnableDelegationCache = false`
+forces a full walk per query.
+
+**EDNS Cookies (RFC 7873)** &mdash; every outgoing query carries an
+EDNS Cookie option. Server cookies are cached by upstream IP for
+the resolver's lifetime; a BADCOOKIE response (extended RCODE 23)
+triggers one retry with the newly-received cookie. Client cookies
+default to cryptographically random; pin a known value via
+`EdnsClientCookie` for tests. Disable entirely with
+`EnableEdnsCookies = false`.
 
 ## Stub client
 

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolver.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Assimalign.Cohesion.Dns.Internal;
@@ -51,6 +52,7 @@ public sealed class ForwardingDnsResolver : DnsResolver
 {
     private readonly ForwardingDnsResolverOptions _options;
     private readonly DnsAnswerCache? _cache;
+    private readonly DnsCookieStore? _cookies;
 
     /// <summary>
     /// Initializes a new <see cref="ForwardingDnsResolver"/>.
@@ -83,9 +85,21 @@ public sealed class ForwardingDnsResolver : DnsResolver
                 nameof(options));
         }
 
+        if (options.EdnsClientCookie is { } cc && cc.Length != 8)
+        {
+            throw new ArgumentException(
+                $"{nameof(ForwardingDnsResolverOptions)}.{nameof(ForwardingDnsResolverOptions.EdnsClientCookie)} must be exactly 8 octets when set.",
+                nameof(options));
+        }
+
         _options = options;
         _cache = options.EnableCache
             ? new DnsAnswerCache(options.CacheCapacity, options.MinCacheTtl, options.MaxCacheTtl, options.TimeProvider)
+            : null;
+        _cookies = options.EnableEdnsCookies
+            ? options.EdnsClientCookie is { } seed
+                ? new DnsCookieStore(seed)
+                : DnsCookieStore.CreateRandom()
             : null;
     }
 
@@ -156,6 +170,22 @@ public sealed class ForwardingDnsResolver : DnsResolver
                 }
             }
 
+            // BADCOOKIE (RCODE 23): the server demands a server cookie. The cookie store
+            // already cached the new cookie in ExchangeAsync; retry once with it. BADCOOKIE
+            // is an extended RCODE so we read the combined header + OPT value.
+            if (DnsQueryHelper.EffectiveRcode(response) == DnsResponseCode.BadCookie && _cookies is not null)
+            {
+                try
+                {
+                    response = await ExchangeAsync(forwarder, question, timeoutCts, cancellationToken).ConfigureAwait(false);
+                }
+                catch (DnsException ex) when (ex.Code is DnsErrorCode.Transport or DnsErrorCode.Timeout)
+                {
+                    lastFailure = ex;
+                    continue; // retry the next forwarder
+                }
+            }
+
             _cache?.Put(question, response);
             return ThrowIfNonSuccess(response, question);
         }
@@ -177,23 +207,43 @@ public sealed class ForwardingDnsResolver : DnsResolver
         return Task.CompletedTask;
     }
 
-    private Task<DnsMessage> ExchangeAsync(
+    private async Task<DnsMessage> ExchangeAsync(
         DnsTransport transport,
         DnsQuestion question,
         CancellationTokenSource timeoutCts,
         CancellationToken externalToken)
     {
+        System.Net.IPAddress? serverIp = TryGetServerIp(transport.Endpoint);
+        IReadOnlyList<DnsEdnsOption>? options = null;
+        if (_cookies is not null && serverIp is not null && _options.EdnsPayloadSize > 0)
+        {
+            options = new DnsEdnsOption[] { _cookies.BuildOption(serverIp) };
+        }
+
         DnsMessage query = DnsQueryHelper.BuildQuery(
             DnsQueryHelper.NewTransactionId(),
             question,
             recursionDesired: true,
-            ednsPayloadSize: _options.EdnsPayloadSize);
-        return DnsQueryHelper.ExchangeAsync(transport, query, timeoutCts, externalToken);
+            ednsPayloadSize: _options.EdnsPayloadSize,
+            ednsOptions: options);
+
+        DnsMessage response = await DnsQueryHelper.ExchangeAsync(transport, query, timeoutCts, externalToken).ConfigureAwait(false);
+        if (_cookies is not null && serverIp is not null)
+        {
+            _cookies.TryRecordServerCookie(serverIp, response);
+        }
+        return response;
     }
+
+    private static System.Net.IPAddress? TryGetServerIp(System.Net.EndPoint endpoint) => endpoint switch
+    {
+        System.Net.IPEndPoint ip => ip.Address,
+        _ => null,
+    };
 
     private static DnsMessage ThrowIfNonSuccess(DnsMessage response, DnsQuestion question)
     {
-        DnsResponseCode rcode = response.Header.ResponseCode;
+        DnsResponseCode rcode = DnsQueryHelper.EffectiveRcode(response);
         if (rcode == DnsResponseCode.NoError)
         {
             return response;

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolverOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/ForwardingDnsResolverOptions.cs
@@ -71,4 +71,18 @@ public sealed class ForwardingDnsResolverOptions
     /// deterministically.
     /// </summary>
     public TimeProvider? TimeProvider { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, every outgoing query carries an EDNS Cookie option per
+    /// RFC 7873. Server cookies are cached by forwarder IP for the resolver's lifetime; a
+    /// BADCOOKIE response (RCODE 23) triggers one retry with the new cookie. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool EnableEdnsCookies { get; set; } = true;
+
+    /// <summary>
+    /// Optional explicit 8-octet client cookie. When <see langword="null"/>, the resolver
+    /// generates a cryptographically random cookie at construction.
+    /// </summary>
+    public byte[]? EdnsClientCookie { get; set; }
 }

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsCookieStore.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsCookieStore.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Security.Cryptography;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Per-resolver EDNS Cookie state (RFC 7873). Holds a single 8-octet client cookie and a
+/// map of server cookies keyed by upstream IP, used to authenticate request/response pairs
+/// against off-path spoofing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The client cookie is generated once per <see cref="DnsCookieStore"/> instance and reused
+/// across all outgoing queries from that resolver. RFC 7873 &#167; 4 recommends a stable
+/// client cookie per (client_ip, server_ip) pair; collapsing to a single cookie per resolver
+/// is the standard simplification and matches what stub libraries do in practice.
+/// </para>
+/// <para>
+/// Server cookies are 8&#8211;32 octets returned by RFC-7873-aware authorities. They are
+/// cached by IP because the IP is what an off-path attacker would spoof &#8211; not the
+/// server's DNS name. The cache is unbounded for now; real deployments roll server cookies
+/// over slowly enough that a process-lifetime entry per upstream is fine.
+/// </para>
+/// </remarks>
+internal sealed class DnsCookieStore
+{
+    private readonly byte[] _clientCookie;
+    private readonly ConcurrentDictionary<IPAddress, byte[]> _serverCookies = new();
+
+    /// <summary>
+    /// Initializes a new store with an explicit client cookie. Tests use this to pin the
+    /// cookie for deterministic assertions; production code calls
+    /// <see cref="CreateRandom"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="clientCookie"/> is not exactly 8 octets.</exception>
+    public DnsCookieStore(ReadOnlySpan<byte> clientCookie)
+    {
+        if (clientCookie.Length != 8)
+        {
+            throw new ArgumentException("Client cookie must be exactly 8 octets.", nameof(clientCookie));
+        }
+        _clientCookie = clientCookie.ToArray();
+    }
+
+    /// <summary>
+    /// Creates a new store with a cryptographically random 8-octet client cookie.
+    /// </summary>
+    public static DnsCookieStore CreateRandom()
+    {
+        Span<byte> cookie = stackalloc byte[8];
+        RandomNumberGenerator.Fill(cookie);
+        return new DnsCookieStore(cookie);
+    }
+
+    /// <summary>The 8-octet client cookie this store sends with every outgoing query.</summary>
+    public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+
+    /// <summary>
+    /// Builds the EDNS Cookie option to attach to a query bound for <paramref name="serverIp"/>.
+    /// Includes the cached server cookie when one is known so the upstream can authenticate
+    /// the binding; otherwise sends a client-cookie-only option to elicit a server cookie.
+    /// </summary>
+    public DnsEdnsCookieOption BuildOption(IPAddress serverIp)
+    {
+        ArgumentNullException.ThrowIfNull(serverIp);
+        return _serverCookies.TryGetValue(serverIp, out byte[]? server)
+            ? new DnsEdnsCookieOption(_clientCookie, server)
+            : new DnsEdnsCookieOption(_clientCookie);
+    }
+
+    /// <summary>
+    /// Inspects <paramref name="response"/> for an EDNS Cookie option, validates the client
+    /// cookie echo, and caches the server cookie under <paramref name="serverIp"/> when one
+    /// is present.
+    /// </summary>
+    /// <returns><see langword="true"/> when the response carried a valid server cookie.</returns>
+    public bool TryRecordServerCookie(IPAddress serverIp, DnsMessage response)
+    {
+        ArgumentNullException.ThrowIfNull(serverIp);
+        ArgumentNullException.ThrowIfNull(response);
+
+        DnsOptRecord? opt = response.Edns;
+        if (opt is null)
+        {
+            return false;
+        }
+
+        foreach (DnsEdnsOption option in opt.Options)
+        {
+            if (option is not DnsEdnsCookieOption cookie)
+            {
+                continue;
+            }
+            // RFC 7873 §5.3: the client must verify the echoed client cookie matches the one
+            // it sent. A mismatch indicates a spoofed response and is treated as a cookie
+            // failure — we ignore the server cookie rather than caching it.
+            if (!cookie.ClientCookie.SequenceEqual(_clientCookie))
+            {
+                return false;
+            }
+            if (cookie.HasServerCookie)
+            {
+                _serverCookies[serverIp] = cookie.ServerCookie.ToArray();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Forgets any cached server cookie for <paramref name="serverIp"/>.</summary>
+    public void Forget(IPAddress serverIp)
+    {
+        ArgumentNullException.ThrowIfNull(serverIp);
+        _serverCookies.TryRemove(serverIp, out _);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsDelegationCache.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsDelegationCache.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Threading;
+
+namespace Assimalign.Cohesion.Dns.Internal;
+
+/// <summary>
+/// Caches NS-record-driven delegations so an iterative resolver can skip the root&rarr;TLD
+/// walk for questions whose closest enclosing delegation is already known. Indexed by zone
+/// name; lookups return the most-specific enclosing entry for a given QNAME.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each entry holds the list of authoritative <see cref="IPEndPoint"/>s for the zone and an
+/// absolute expiration computed from the minimum NS TTL the resolver observed. RFC 1035
+/// &#167; 4.3.2 + RFC 7719 govern the TTL semantics: NS records are cached per their TTL,
+/// and the resolver MAY rely on the cache as long as the TTL hasn't elapsed.
+/// </para>
+/// <para>
+/// Approximate-LRU eviction at capacity (same shape as
+/// <see cref="DnsAnswerCache"/>): when full, drop the oldest-inserted entry. Thread-safety is
+/// guarded by a single lock.
+/// </para>
+/// </remarks>
+internal sealed class DnsDelegationCache
+{
+    private readonly int _capacity;
+    private readonly TimeProvider _timeProvider;
+    private readonly Lock _gate = new();
+    private readonly Dictionary<DnsName, LinkedListNode<Entry>> _entries;
+    private readonly LinkedList<Entry> _order = new();
+
+    public DnsDelegationCache(int capacity, TimeProvider? timeProvider = null)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Capacity must be positive.");
+        }
+        _capacity = capacity;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _entries = new Dictionary<DnsName, LinkedListNode<Entry>>(capacity);
+    }
+
+    /// <summary>Current number of cached delegations.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _entries.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Looks up the closest enclosing cached delegation for <paramref name="qname"/>. Walks
+    /// from <paramref name="qname"/> upward through its ancestors and returns the
+    /// most-specific live entry, or <see langword="false"/> if none applies.
+    /// </summary>
+    public bool TryGetClosest(
+        DnsName qname,
+        [NotNullWhen(true)] out DnsName? zone,
+        [NotNullWhen(true)] out IReadOnlyList<IPEndPoint>? endpoints)
+    {
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        DnsName current = qname;
+        lock (_gate)
+        {
+            while (true)
+            {
+                if (_entries.TryGetValue(current, out LinkedListNode<Entry>? node))
+                {
+                    if (now < node.Value.ExpiresAtUtc)
+                    {
+                        zone = node.Value.Zone;
+                        endpoints = node.Value.Endpoints;
+                        return true;
+                    }
+                    // Expired — evict and continue searching upward.
+                    _entries.Remove(current);
+                    _order.Remove(node);
+                }
+                if (current.IsRoot)
+                {
+                    break;
+                }
+                current = DnsBailiwick.Parent(current);
+            }
+        }
+        zone = null;
+        endpoints = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores a delegation for <paramref name="zone"/>. The TTL is the minimum across the
+    /// NS records that produced this delegation; a zero TTL skips the insert per RFC 1035
+    /// &#167; 4.3.2.
+    /// </summary>
+    public void Put(DnsName zone, IReadOnlyList<IPEndPoint> endpoints, TimeSpan ttl)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        if (endpoints.Count == 0 || ttl <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        DateTimeOffset expiresAt = _timeProvider.GetUtcNow() + ttl;
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(zone, out LinkedListNode<Entry>? existing))
+            {
+                _order.Remove(existing);
+                _entries.Remove(zone);
+            }
+
+            if (_entries.Count >= _capacity)
+            {
+                LinkedListNode<Entry>? oldest = _order.First;
+                if (oldest is not null)
+                {
+                    _entries.Remove(oldest.Value.Zone);
+                    _order.Remove(oldest);
+                }
+            }
+
+            LinkedListNode<Entry> node = _order.AddLast(new Entry(zone, endpoints, expiresAt));
+            _entries[zone] = node;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _entries.Clear();
+            _order.Clear();
+        }
+    }
+
+    private sealed record Entry(DnsName Zone, IReadOnlyList<IPEndPoint> Endpoints, DateTimeOffset ExpiresAtUtc);
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsQueryHelper.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/Internal/DnsQueryHelper.cs
@@ -26,11 +26,14 @@ internal static class DnsQueryHelper
     /// for iterative queries against authoritative servers.</param>
     /// <param name="ednsPayloadSize">EDNS UDP payload size to advertise via OPT; pass zero to
     /// omit the OPT record.</param>
+    /// <param name="ednsOptions">Optional list of EDNS options to attach to the OPT record
+    /// (cookies, ECS, padding, etc.). Ignored when <paramref name="ednsPayloadSize"/> is zero.</param>
     public static DnsMessage BuildQuery(
         ushort id,
         DnsQuestion question,
         bool recursionDesired,
-        ushort ednsPayloadSize)
+        ushort ednsPayloadSize,
+        IReadOnlyList<DnsEdnsOption>? ednsOptions = null)
     {
         bool useEdns = ednsPayloadSize > 0;
         DnsHeaderFlags flags = recursionDesired ? DnsHeaderFlags.RecursionDesired : DnsHeaderFlags.None;
@@ -45,9 +48,18 @@ internal static class DnsQueryHelper
             authorityCount: 0,
             additionalCount: useEdns ? (ushort)1 : (ushort)0);
 
-        IReadOnlyList<DnsRecord> additionals = useEdns
-            ? new DnsRecord[] { new DnsOptRecord(ednsPayloadSize) }
-            : Array.Empty<DnsRecord>();
+        IReadOnlyList<DnsRecord> additionals;
+        if (useEdns)
+        {
+            DnsOptRecord opt = ednsOptions is { Count: > 0 }
+                ? new DnsOptRecord(ednsPayloadSize, extendedRCodeHigh: 0, version: 0, DnsEdnsFlags.None, ednsOptions)
+                : new DnsOptRecord(ednsPayloadSize);
+            additionals = new DnsRecord[] { opt };
+        }
+        else
+        {
+            additionals = Array.Empty<DnsRecord>();
+        }
 
         return new DnsMessage(
             header,
@@ -63,6 +75,20 @@ internal static class DnsQueryHelper
     /// </summary>
     public static ushort NewTransactionId()
         => (ushort)RandomNumberGenerator.GetInt32(0, 65_536);
+
+    /// <summary>
+    /// Returns the 12-bit RCODE that combines the 4-bit value in the header with the
+    /// 8-bit upper byte in the OPT TTL. RFC 6891 &#167; 6.1.3: extended RCODEs (BADVERS,
+    /// BADCOOKIE, &#8230;) split across these two fields, so reading just the header gives
+    /// the wrong answer for any RCODE &#8805; 16.
+    /// </summary>
+    public static DnsResponseCode EffectiveRcode(DnsMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        int low = (int)message.Header.ResponseCode & 0x0F;
+        int high = message.Edns?.ExtendedRCodeHigh ?? 0;
+        return (DnsResponseCode)((high << 4) | low);
+    }
 
     /// <summary>
     /// Serializes a query into a byte array of exactly the produced length.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/IterativeDnsResolver.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/IterativeDnsResolver.cs
@@ -25,34 +25,29 @@ namespace Assimalign.Cohesion.Dns;
 ///   <item><description>Glue policy &#8211; A/AAAA records in the additional section are only
 ///   trusted when their owner name is inside the delegated zone. Out-of-bailiwick glue is
 ///   discarded so a malicious authority cannot poison an unrelated zone.</description></item>
+///   <item><description>Out-of-bailiwick NS resolution &#8211; when a referral carries no
+///   in-bailiwick glue, the resolver recursively resolves the NS names through the same
+///   cache and budget so production zones (.com, .net, etc.) work without manual glue
+///   wiring.</description></item>
+///   <item><description>Delegation caching &#8211; NS RRsets are cached by zone so
+///   subsequent queries for names under a known zone skip the root&rarr;TLD walk.</description></item>
 ///   <item><description>QNAME minimization (RFC 9156) when
-///   <see cref="IterativeDnsResolverOptions.EnableQNameMinimization"/> is set: each step probes
-///   for NS with only the labels the current authority needs to know, hiding the rest of the
-///   QNAME until we reach an authority closer to the leaf.</description></item>
+///   <see cref="IterativeDnsResolverOptions.EnableQNameMinimization"/> is set.</description></item>
+///   <item><description>EDNS Cookies (RFC 7873) when
+///   <see cref="IterativeDnsResolverOptions.EnableEdnsCookies"/> is set &#8211; server
+///   cookies are cached by upstream IP and a BADCOOKIE response triggers one retry.</description></item>
 ///   <item><description>RFC 5966 TC&rarr;TCP fallback per step when
 ///   <see cref="IterativeDnsResolverOptions.TcpTransportFactory"/> is set.</description></item>
-///   <item><description>Budget enforcement &#8211; bounded referral depth and bounded total
-///   upstream exchanges per resolve to defeat pathological delegation chains and
-///   denial-of-resolver loops.</description></item>
+///   <item><description>Budget enforcement &#8211; bounded referral depth, bounded total
+///   upstream exchanges per resolve, bounded NS-resolution recursion depth.</description></item>
 /// </list>
-/// <para>
-/// <strong>NS-name resolution.</strong> When a referral arrives without in-bailiwick glue,
-/// the current implementation skips that NS rather than recursing to resolve the NS name.
-/// In-bailiwick referrals from well-glued zones (the IANA root + every TLD that matters)
-/// are unaffected; misconfigured zones with all-out-of-bailiwick NS names will surface
-/// <see cref="DnsErrorCode.Transport"/>. Out-of-bailiwick NS resolution is a follow-up
-/// concern (Story L01.01.08 PR6).
-/// </para>
-/// <para>
-/// <strong>Caching.</strong> Successful, NXDOMAIN, and NODATA responses are cached by
-/// question with TTL semantics matching <see cref="ForwardingDnsResolver"/>. Delegation
-/// caching (caching NS RRsets at the zone level for subsequent walks) is a follow-up.
-/// </para>
 /// </remarks>
 public sealed class IterativeDnsResolver : DnsResolver
 {
     private readonly IterativeDnsResolverOptions _options;
     private readonly DnsAnswerCache? _cache;
+    private readonly DnsDelegationCache? _delegationCache;
+    private readonly DnsCookieStore? _cookies;
     private readonly IReadOnlyList<IPEndPoint> _rootEndpoints;
 
     /// <summary>
@@ -91,17 +86,39 @@ public sealed class IterativeDnsResolver : DnsResolver
                 $"{nameof(IterativeDnsResolverOptions)}.{nameof(IterativeDnsResolverOptions.MaxQueriesPerResolve)} must be positive.",
                 nameof(options));
         }
+        if (options.MaxNsResolutionDepth < 0)
+        {
+            throw new ArgumentException(
+                $"{nameof(IterativeDnsResolverOptions)}.{nameof(IterativeDnsResolverOptions.MaxNsResolutionDepth)} must be non-negative.",
+                nameof(options));
+        }
+        if (options.EdnsClientCookie is { } cc && cc.Length != 8)
+        {
+            throw new ArgumentException(
+                $"{nameof(IterativeDnsResolverOptions)}.{nameof(IterativeDnsResolverOptions.EdnsClientCookie)} must be exactly 8 octets when set.",
+                nameof(options));
+        }
 
         _options = options;
         _cache = options.EnableCache
             ? new DnsAnswerCache(options.CacheCapacity, options.MinCacheTtl, options.MaxCacheTtl, options.TimeProvider)
             : null;
-
+        _delegationCache = options.EnableDelegationCache
+            ? new DnsDelegationCache(options.DelegationCacheCapacity, options.TimeProvider)
+            : null;
+        _cookies = options.EnableEdnsCookies
+            ? options.EdnsClientCookie is { } seed
+                ? new DnsCookieStore(seed)
+                : DnsCookieStore.CreateRandom()
+            : null;
         _rootEndpoints = new List<IPEndPoint>(options.RootEndpoints);
     }
 
-    /// <summary>Number of entries currently held by the cache.</summary>
+    /// <summary>Number of entries in the answer cache, or zero when caching is disabled.</summary>
     public int CacheCount => _cache?.Count ?? 0;
+
+    /// <summary>Number of entries in the delegation cache, or zero when disabled.</summary>
+    public int DelegationCacheCount => _delegationCache?.Count ?? 0;
 
     /// <inheritdoc />
     public override Task<DnsMessage> QueryAsync(DnsQuestion question, CancellationToken cancellationToken = default)
@@ -124,7 +141,8 @@ public sealed class IterativeDnsResolver : DnsResolver
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(_options.QueryTimeout);
 
-        DnsMessage response = await WalkAsync(question, timeoutCts, cancellationToken).ConfigureAwait(false);
+        var context = new ResolveContext(_options.MaxQueriesPerResolve);
+        DnsMessage response = await ResolveCoreAsync(question, context, timeoutCts, cancellationToken).ConfigureAwait(false);
         _cache?.Put(question, response);
         return ThrowIfNonSuccess(response, question);
     }
@@ -133,44 +151,75 @@ public sealed class IterativeDnsResolver : DnsResolver
     public override Task ClearCacheAsync(CancellationToken cancellationToken = default)
     {
         _cache?.Clear();
+        _delegationCache?.Clear();
         return Task.CompletedTask;
+    }
+
+    private async Task<DnsMessage> ResolveCoreAsync(
+        DnsQuestion question,
+        ResolveContext context,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken)
+    {
+        // Cache short-circuit. This may be called from out-of-bailiwick NS resolution where
+        // the parent question already passed cache check, but the NS-resolution sub-query
+        // hits a fresh cache key.
+        if (_cache is not null && _cache.TryGet(question, out DnsMessage? cached))
+        {
+            return cached;
+        }
+
+        // Cycle detection: if we're already resolving this question, fail rather than recurse
+        // again. Prevents loops when one NS name's resolution requires another NS name whose
+        // resolution requires the first.
+        if (!context.MarkInFlight(question))
+        {
+            DnsException.ThrowTransport($"resolution cycle detected for {question}");
+        }
+        try
+        {
+            return await WalkAsync(question, context, timeoutCts, externalToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.ClearInFlight(question);
+        }
     }
 
     private async Task<DnsMessage> WalkAsync(
         DnsQuestion question,
+        ResolveContext context,
         CancellationTokenSource timeoutCts,
         CancellationToken externalToken)
     {
-        DnsName currentZone = DnsName.Root;
-        IReadOnlyList<IPEndPoint> currentAuthorities = _rootEndpoints;
+        // Delegation-cache short-circuit: start at the most-specific known delegation rather
+        // than the root.
+        DnsName currentZone;
+        IReadOnlyList<IPEndPoint> currentAuthorities;
+        if (_delegationCache is not null
+            && _delegationCache.TryGetClosest(question.Name, out DnsName? cachedZone, out IReadOnlyList<IPEndPoint>? cachedEndpoints))
+        {
+            currentZone = cachedZone.Value;
+            currentAuthorities = cachedEndpoints;
+        }
+        else
+        {
+            currentZone = DnsName.Root;
+            currentAuthorities = _rootEndpoints;
+        }
 
-        int queries = 0;
         DnsException? lastFailure = null;
 
         for (int depth = 0; depth < _options.MaxReferralDepth; depth++)
         {
-            // Decide what to send at this step. With QNAME minimization on we send NS for the
-            // label one deeper than `currentZone`; otherwise we send the original question.
             DnsQuestion step = NextStepQuestion(question, currentZone);
 
-            // Try each authority at this level until one answers or we exhaust the list.
             DnsMessage? response = null;
             foreach (IPEndPoint endpoint in currentAuthorities)
             {
-                if (queries >= _options.MaxQueriesPerResolve)
-                {
-                    if (lastFailure is not null)
-                    {
-                        throw lastFailure;
-                    }
-                    DnsException.ThrowTransport(
-                        $"iterative query budget exhausted ({_options.MaxQueriesPerResolve}) resolving {question}");
-                }
-                queries++;
-
                 try
                 {
-                    response = await ExchangeStepAsync(endpoint, step, timeoutCts, externalToken).ConfigureAwait(false);
+                    response = await ExchangeStepAsync(endpoint, step, context, timeoutCts, externalToken).ConfigureAwait(false);
                     break;
                 }
                 catch (DnsException ex) when (ex.Code is DnsErrorCode.Transport or DnsErrorCode.Timeout or DnsErrorCode.Spoofed or DnsErrorCode.Malformed)
@@ -189,73 +238,69 @@ public sealed class IterativeDnsResolver : DnsResolver
                 DnsException.ThrowTransport($"no reachable authority for zone {currentZone}");
             }
 
-            DnsResponseCode rcode = response!.Header.ResponseCode;
-            bool isAuthoritative = (response.Header.Flags & DnsHeaderFlags.AuthoritativeAnswer) != 0;
+            DnsResponseCode rcode = DnsQueryHelper.EffectiveRcode(response!);
+            bool isAuthoritative = (response!.Header.Flags & DnsHeaderFlags.AuthoritativeAnswer) != 0;
 
-            // NXDOMAIN against the full QNAME is a terminal answer.
             if (rcode == DnsResponseCode.NXDomain && step.Name.Equals(question.Name))
             {
                 return RebuildForOriginalQuestion(response, question);
             }
-
-            // SERVFAIL / REFUSED / etc against this authority — try a different zone? No,
-            // we've already exhausted this level's authorities (we only got here with a
-            // response). Propagate the failure.
             if (rcode is not (DnsResponseCode.NoError or DnsResponseCode.NXDomain))
             {
                 return RebuildForOriginalQuestion(response, question);
             }
-
-            // Authoritative answer for the step question.
             if (isAuthoritative && response.Answers.Count > 0)
             {
-                // If we're asking the full question, this is the answer.
                 if (step.Name.Equals(question.Name) && step.Type == question.Type)
                 {
                     return RebuildForOriginalQuestion(response, question);
                 }
-                // QNAME-min probe got an authoritative answer at an intermediate label. That
-                // means the current zone is also authoritative for the full QNAME. Re-issue
-                // the original question against the same authority list.
-                continue;
+                continue; // QNAME-min probe got an answer; re-issue the full question.
             }
-
-            // Authoritative NoError with no answer at the full QNAME = NODATA.
             if (isAuthoritative && step.Name.Equals(question.Name) && step.Type == question.Type)
             {
-                return RebuildForOriginalQuestion(response, question);
+                return RebuildForOriginalQuestion(response, question); // NODATA
             }
 
-            // Look for a referral in the authority section.
             var nsRecords = ExtractNsRecords(response.Authorities);
             if (nsRecords.Count == 0)
             {
-                // No answer and no referral — this authority gave up. Try treating it as
-                // NODATA at this label and advance.
                 if (step.Name.Equals(question.Name))
                 {
                     return RebuildForOriginalQuestion(response, question);
                 }
-                continue; // advance QNAME-min one label by re-evaluating NextStepQuestion
+                continue; // QNAME-min: advance one label.
             }
 
             DnsName? newZone = DnsBailiwick.ZoneOfNsRecords(nsRecords, question.Name);
             if (newZone is null || !DnsBailiwick.IsInBailiwick(newZone.Value, currentZone) || newZone.Value.Equals(currentZone))
             {
-                // Out-of-bailiwick or same-zone referral. Drop it — would loop or be spoofed.
                 DnsException.ThrowSpoofed(
                     $"referral from zone {currentZone} delegates to {newZone?.ToString() ?? "<unknown>"} which is not strictly below it");
             }
 
-            // Collect glue: A/AAAA records in additional whose owner names match the NS RDATA
-            // AND are inside the new zone (in-bailiwick glue policy).
-            var newAuthorities = ResolveNsToEndpoints(nsRecords, response.Additionals, newZone!.Value);
+            // Collect in-bailiwick glue.
+            List<IPEndPoint> newAuthorities = ResolveNsToEndpoints(nsRecords, response.Additionals, newZone!.Value);
+
+            // Out-of-bailiwick or missing glue: recursively resolve NS names, charging the
+            // shared budget. Skipped at depth limit to avoid runaway recursion.
+            if (newAuthorities.Count == 0 && context.NsResolutionDepth < _options.MaxNsResolutionDepth)
+            {
+                newAuthorities = await ResolveOutOfBailiwickNsAsync(
+                    nsRecords, question.Class, context, timeoutCts, externalToken).ConfigureAwait(false);
+            }
+
             if (newAuthorities.Count == 0)
             {
-                // Referral with no usable glue. PR 5 scope: skip this level and surface a
-                // transport error. PR 6 will add out-of-bailiwick NS resolution.
                 DnsException.ThrowTransport(
-                    $"referral to {newZone} has no in-bailiwick glue; NS-name resolution is not yet implemented");
+                    $"could not resolve any NS for delegation to {newZone}");
+            }
+
+            // Update delegation cache with the (zone, endpoints) we just learned.
+            if (_delegationCache is not null)
+            {
+                TimeSpan nsTtl = ComputeNsTtl(nsRecords);
+                _delegationCache.Put(newZone!.Value, newAuthorities, nsTtl);
             }
 
             currentZone = newZone!.Value;
@@ -264,6 +309,64 @@ public sealed class IterativeDnsResolver : DnsResolver
 
         DnsException.ThrowTransport($"referral depth limit ({_options.MaxReferralDepth}) exceeded resolving {question}");
         throw new InvalidOperationException(); // unreachable
+    }
+
+    private async Task<List<IPEndPoint>> ResolveOutOfBailiwickNsAsync(
+        IReadOnlyList<DnsRecord> nsRecords,
+        DnsClass questionClass,
+        ResolveContext context,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken)
+    {
+        var endpoints = new List<IPEndPoint>();
+        context.EnterNsResolution();
+        try
+        {
+            foreach (DnsRecord ns in nsRecords)
+            {
+                if (ns is not DnsNsRecord nsRr)
+                {
+                    continue;
+                }
+                // Try IPv4 first, fall back to IPv6.
+                foreach (DnsRecordType type in new[] { DnsRecordType.A, DnsRecordType.AAAA })
+                {
+                    var subQuestion = new DnsQuestion(nsRr.NameServer, type, questionClass);
+                    try
+                    {
+                        DnsMessage subResponse = await ResolveCoreAsync(
+                            subQuestion, context, timeoutCts, externalToken).ConfigureAwait(false);
+                        foreach (DnsRecord rr in subResponse.Answers)
+                        {
+                            if (rr is DnsARecord a)
+                            {
+                                endpoints.Add(new IPEndPoint(a.Address, 53));
+                            }
+                            else if (rr is DnsAaaaRecord aaaa)
+                            {
+                                endpoints.Add(new IPEndPoint(aaaa.Address, 53));
+                            }
+                        }
+                    }
+                    catch (DnsException)
+                    {
+                        // This NS name couldn't be resolved; try the next type or NS record.
+                    }
+                }
+
+                if (endpoints.Count > 0)
+                {
+                    // We have at least one usable address — no need to resolve every NS.
+                    // Stops doing extra work in the common case of well-mirrored NS names.
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            context.LeaveNsResolution();
+        }
+        return endpoints;
     }
 
     private DnsQuestion NextStepQuestion(DnsQuestion question, DnsName currentZone)
@@ -277,15 +380,9 @@ public sealed class IterativeDnsResolver : DnsResolver
         {
             return question;
         }
-        // RFC 9156 §3.1 — use NS as the probe type for the minimized name.
         return new DnsQuestion(minimized, DnsRecordType.NS, question.Class);
     }
 
-    /// <summary>
-    /// Returns the name one label below <paramref name="zone"/> on the path to
-    /// <paramref name="target"/>. Returns <paramref name="target"/> itself when the zone is
-    /// already its parent.
-    /// </summary>
     internal static DnsName MinimizeOneLabel(DnsName target, DnsName zone)
     {
         string[] tLabels = target.GetLabels();
@@ -295,7 +392,6 @@ public sealed class IterativeDnsResolver : DnsResolver
         {
             return target;
         }
-        // Take zLabels.Length + 1 labels from the end of target.
         int take = zLabels.Length + 1;
         int start = tLabels.Length - take;
         return new DnsName(string.Join('.', tLabels, start, take));
@@ -304,14 +400,48 @@ public sealed class IterativeDnsResolver : DnsResolver
     private async Task<DnsMessage> ExchangeStepAsync(
         IPEndPoint endpoint,
         DnsQuestion step,
+        ResolveContext context,
         CancellationTokenSource timeoutCts,
         CancellationToken externalToken)
     {
+        context.IncrementQueryCount();
+        if (context.QueryCount > _options.MaxQueriesPerResolve)
+        {
+            DnsException.ThrowTransport(
+                $"iterative query budget exhausted ({_options.MaxQueriesPerResolve})");
+        }
+
+        DnsMessage response = await ExchangeAtEndpointAsync(endpoint, step, timeoutCts, externalToken).ConfigureAwait(false);
+
+        // BADCOOKIE: server demands a server cookie. If they sent one, we already cached
+        // it via TryRecordServerCookie inside ExchangeAtEndpointAsync — retry once.
+        // BADCOOKIE is an extended RCODE so we read the combined header + OPT value.
+        if (DnsQueryHelper.EffectiveRcode(response) == DnsResponseCode.BadCookie && _cookies is not null)
+        {
+            context.IncrementQueryCount();
+            response = await ExchangeAtEndpointAsync(endpoint, step, timeoutCts, externalToken).ConfigureAwait(false);
+        }
+        return response;
+    }
+
+    private async Task<DnsMessage> ExchangeAtEndpointAsync(
+        IPEndPoint endpoint,
+        DnsQuestion step,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken)
+    {
+        IReadOnlyList<DnsEdnsOption>? options = null;
+        if (_cookies is not null && _options.EdnsPayloadSize > 0)
+        {
+            options = new DnsEdnsOption[] { _cookies.BuildOption(endpoint.Address) };
+        }
+
         DnsMessage query = DnsQueryHelper.BuildQuery(
             DnsQueryHelper.NewTransactionId(),
             step,
-            recursionDesired: false, // iterative — talking to authoritative servers
-            ednsPayloadSize: _options.EdnsPayloadSize);
+            recursionDesired: false,
+            ednsPayloadSize: _options.EdnsPayloadSize,
+            ednsOptions: options);
 
         DnsTransport udp = _options.UdpTransportFactory(endpoint);
         DnsMessage response;
@@ -324,7 +454,6 @@ public sealed class IterativeDnsResolver : DnsResolver
             await udp.DisposeAsync().ConfigureAwait(false);
         }
 
-        // RFC 5966 TC handling.
         if ((response.Header.Flags & DnsHeaderFlags.Truncated) != 0 && _options.TcpTransportFactory is not null)
         {
             DnsTransport tcp = _options.TcpTransportFactory(endpoint);
@@ -338,6 +467,7 @@ public sealed class IterativeDnsResolver : DnsResolver
             }
         }
 
+        _cookies?.TryRecordServerCookie(endpoint.Address, response);
         return response;
     }
 
@@ -352,6 +482,19 @@ public sealed class IterativeDnsResolver : DnsResolver
             }
         }
         return ns;
+    }
+
+    private static TimeSpan ComputeNsTtl(IReadOnlyList<DnsRecord> nsRecords)
+    {
+        uint minTtl = uint.MaxValue;
+        foreach (DnsRecord rr in nsRecords)
+        {
+            if (rr.TimeToLive < minTtl)
+            {
+                minTtl = rr.TimeToLive;
+            }
+        }
+        return minTtl == uint.MaxValue ? TimeSpan.Zero : TimeSpan.FromSeconds(minTtl);
     }
 
     private static List<IPEndPoint> ResolveNsToEndpoints(
@@ -372,8 +515,6 @@ public sealed class IterativeDnsResolver : DnsResolver
                 {
                     continue;
                 }
-                // In-bailiwick glue: glue records are only trusted if their owner is inside
-                // the zone the NS delegates. Out-of-bailiwick glue is a poisoning vector.
                 if (!DnsBailiwick.IsInBailiwick(add.Name, bailiwick))
                 {
                     continue;
@@ -393,9 +534,6 @@ public sealed class IterativeDnsResolver : DnsResolver
 
     private static DnsMessage RebuildForOriginalQuestion(DnsMessage response, DnsQuestion question)
     {
-        // The response's question section may carry a minimized question (NS for an
-        // intermediate label) rather than the original. Repackage it under the original
-        // question so callers see the API-level question they asked about.
         if (response.Questions.Count == 1
             && response.Questions[0].Name.Equals(question.Name)
             && response.Questions[0].Type == question.Type
@@ -414,7 +552,7 @@ public sealed class IterativeDnsResolver : DnsResolver
 
     private static DnsMessage ThrowIfNonSuccess(DnsMessage response, DnsQuestion question)
     {
-        DnsResponseCode rcode = response.Header.ResponseCode;
+        DnsResponseCode rcode = DnsQueryHelper.EffectiveRcode(response);
         if (rcode == DnsResponseCode.NoError)
         {
             return response;
@@ -425,5 +563,33 @@ public sealed class IterativeDnsResolver : DnsResolver
         }
         DnsException.ThrowServerFailure(question.ToString(), rcode);
         throw new InvalidOperationException(); // unreachable
+    }
+
+    /// <summary>
+    /// Per-resolve state: shared budget, cycle-detection set, and NS-resolution depth tracker.
+    /// One instance lives for the duration of <see cref="ResolveAsync"/>; recursive
+    /// sub-resolves for out-of-bailiwick NS names reuse the same instance so the budget is
+    /// charged across the whole resolve.
+    /// </summary>
+    private sealed class ResolveContext
+    {
+        private readonly HashSet<DnsQuestion> _inFlight = new();
+
+        public ResolveContext(int maxQueries)
+        {
+            MaxQueries = maxQueries;
+        }
+
+        public int MaxQueries { get; }
+        public int QueryCount { get; private set; }
+        public int NsResolutionDepth { get; private set; }
+
+        public void IncrementQueryCount() => QueryCount++;
+
+        public bool MarkInFlight(DnsQuestion q) => _inFlight.Add(q);
+        public void ClearInFlight(DnsQuestion q) => _inFlight.Remove(q);
+
+        public void EnterNsResolution() => NsResolutionDepth++;
+        public void LeaveNsResolution() => NsResolutionDepth--;
     }
 }

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/IterativeDnsResolverOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/IterativeDnsResolverOptions.cs
@@ -85,6 +85,41 @@ public sealed class IterativeDnsResolverOptions
     /// <summary>Time source used by the cache. Defaults to <see cref="System.TimeProvider.System"/>.</summary>
     public TimeProvider? TimeProvider { get; set; }
 
+    /// <summary>
+    /// When <see langword="true"/>, the resolver caches NS delegations by zone so subsequent
+    /// queries for names under the same zone skip the root&rarr;TLD walk. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool EnableDelegationCache { get; set; } = true;
+
+    /// <summary>
+    /// Maximum number of cached delegations. Defaults to 2,000 &#8211; enough for a stub
+    /// resolver to remember every TLD it has seen without bloating memory.
+    /// </summary>
+    public int DelegationCacheCapacity { get; set; } = 2_000;
+
+    /// <summary>
+    /// When <see langword="true"/>, every outgoing query carries an EDNS Cookie option per
+    /// RFC 7873. Server cookies are cached by upstream IP for the resolver's lifetime; a
+    /// BADCOOKIE response (RCODE 23) triggers one retry with the new cookie. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool EnableEdnsCookies { get; set; } = true;
+
+    /// <summary>
+    /// Optional explicit 8-octet client cookie. When <see langword="null"/>, the resolver
+    /// generates a cryptographically random cookie at construction. Tests pin a known
+    /// cookie via this property to verify the exact bytes the resolver puts on the wire.
+    /// </summary>
+    public byte[]? EdnsClientCookie { get; set; }
+
+    /// <summary>
+    /// Maximum number of recursive sub-resolves the resolver will perform to find IPs for
+    /// out-of-bailiwick NS names. Bounds the budget consumed by NS-name resolution detours.
+    /// Defaults to 5.
+    /// </summary>
+    public int MaxNsResolutionDepth { get; set; } = 5;
+
     private static DnsTransport DefaultUdpFactory(IPEndPoint endpoint)
         => new UdpDnsTransport(new UdpDnsTransportOptions
         {

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/StubDnsClient.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/StubDnsClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Assimalign.Cohesion.Dns.Internal;
@@ -18,6 +20,12 @@ namespace Assimalign.Cohesion.Dns;
 /// <see cref="IterativeDnsResolver"/> instead.
 /// </para>
 /// <para>
+/// When <see cref="StubDnsClientOptions.EnableEdnsCookies"/> is set, every outgoing query
+/// carries an EDNS Cookie option (RFC 7873). The server cookie is cached for the lifetime of
+/// the client (keyed by the transport's resolved IP) and a BADCOOKIE response (RCODE 23)
+/// triggers one retry with the freshly-received cookie.
+/// </para>
+/// <para>
 /// The client does not take ownership of the transport: the caller is responsible for
 /// disposing the transport instance. Disposing the client itself is a no-op beyond marking
 /// it as disposed.
@@ -26,6 +34,7 @@ namespace Assimalign.Cohesion.Dns;
 public sealed class StubDnsClient : DnsClient
 {
     private readonly StubDnsClientOptions _options;
+    private readonly DnsCookieStore? _cookies;
 
     /// <summary>
     /// Initializes a new <see cref="StubDnsClient"/>.
@@ -48,8 +57,19 @@ public sealed class StubDnsClient : DnsClient
                 $"{nameof(StubDnsClientOptions)}.{nameof(StubDnsClientOptions.QueryTimeout)} must be positive.",
                 nameof(options));
         }
+        if (options.EdnsClientCookie is { } cc && cc.Length != 8)
+        {
+            throw new ArgumentException(
+                $"{nameof(StubDnsClientOptions)}.{nameof(StubDnsClientOptions.EdnsClientCookie)} must be exactly 8 octets when set.",
+                nameof(options));
+        }
 
         _options = options;
+        _cookies = options.EnableEdnsCookies
+            ? options.EdnsClientCookie is { } seed
+                ? new DnsCookieStore(seed)
+                : DnsCookieStore.CreateRandom()
+            : null;
     }
 
     /// <inheritdoc />
@@ -64,24 +84,60 @@ public sealed class StubDnsClient : DnsClient
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(_options.QueryTimeout);
 
+        DnsMessage response = await ExchangeAsync(question, timeoutCts, cancellationToken).ConfigureAwait(false);
+
+        // BADCOOKIE retry: the cookie store has already cached the new server cookie via the
+        // TryRecordServerCookie call inside ExchangeAsync. The RCODE is extended (>15) so we
+        // must read the combined header + OPT value.
+        if (DnsQueryHelper.EffectiveRcode(response) == DnsResponseCode.BadCookie && _cookies is not null)
+        {
+            response = await ExchangeAsync(question, timeoutCts, cancellationToken).ConfigureAwait(false);
+        }
+
+        return ThrowIfNonSuccess(response, question);
+    }
+
+    private async Task<DnsMessage> ExchangeAsync(
+        DnsQuestion question,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken)
+    {
+        IPAddress? serverIp = TryGetServerIp(_options.Transport!.Endpoint);
+        IReadOnlyList<DnsEdnsOption>? options = null;
+        if (_cookies is not null && serverIp is not null && _options.EdnsPayloadSize > 0)
+        {
+            options = new DnsEdnsOption[] { _cookies.BuildOption(serverIp) };
+        }
+
         DnsMessage query = DnsQueryHelper.BuildQuery(
             DnsQueryHelper.NewTransactionId(),
             question,
             recursionDesired: _options.RecursionDesired,
-            ednsPayloadSize: _options.EdnsPayloadSize);
+            ednsPayloadSize: _options.EdnsPayloadSize,
+            ednsOptions: options);
 
         DnsMessage response = await DnsQueryHelper.ExchangeAsync(
             _options.Transport!,
             query,
             timeoutCts,
-            cancellationToken).ConfigureAwait(false);
+            externalToken).ConfigureAwait(false);
 
-        return ThrowIfNonSuccess(response, question);
+        if (_cookies is not null && serverIp is not null)
+        {
+            _cookies.TryRecordServerCookie(serverIp, response);
+        }
+        return response;
     }
+
+    private static IPAddress? TryGetServerIp(EndPoint endpoint) => endpoint switch
+    {
+        IPEndPoint ip => ip.Address,
+        _ => null,
+    };
 
     private static DnsMessage ThrowIfNonSuccess(DnsMessage response, DnsQuestion question)
     {
-        DnsResponseCode rcode = response.Header.ResponseCode;
+        DnsResponseCode rcode = DnsQueryHelper.EffectiveRcode(response);
         if (rcode == DnsResponseCode.NoError)
         {
             return response;

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/StubDnsClientOptions.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/src/StubDnsClientOptions.cs
@@ -30,4 +30,18 @@ public sealed class StubDnsClientOptions
     /// octets. Set to zero to omit the OPT record entirely.
     /// </summary>
     public ushort EdnsPayloadSize { get; set; } = 1232;
+
+    /// <summary>
+    /// When <see langword="true"/>, every outgoing query carries an EDNS Cookie option per
+    /// RFC 7873. The server cookie is cached for the lifetime of this client; a BADCOOKIE
+    /// response (RCODE 23) triggers one retry with the new cookie. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool EnableEdnsCookies { get; set; } = true;
+
+    /// <summary>
+    /// Optional explicit 8-octet client cookie. When <see langword="null"/>, the client
+    /// generates a cryptographically random cookie at construction.
+    /// </summary>
+    public byte[]? EdnsClientCookie { get; set; }
 }

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsDelegationCacheTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsDelegationCacheTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Assimalign.Cohesion.Dns.Internal;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+public sealed class DnsDelegationCacheTests
+{
+    [Fact]
+    public void TryGetClosest_OnEmptyCache_Misses()
+    {
+        var cache = new DnsDelegationCache(capacity: 8);
+        Assert.False(cache.TryGetClosest("www.example.com", out _, out _));
+    }
+
+    [Fact]
+    public void Put_ThenTryGetClosest_HitsExactZone()
+    {
+        var cache = new DnsDelegationCache(8);
+        var endpoints = new IPEndPoint[] { new(IPAddress.Loopback, 53) };
+        cache.Put("example.com", endpoints, TimeSpan.FromMinutes(5));
+
+        Assert.True(cache.TryGetClosest("example.com", out DnsName? zone, out IReadOnlyList<IPEndPoint>? eps));
+        Assert.Equal(new DnsName("example.com"), zone);
+        Assert.Equal(endpoints, eps);
+    }
+
+    [Fact]
+    public void TryGetClosest_FindsAncestorWhenExactMiss()
+    {
+        var cache = new DnsDelegationCache(8);
+        var endpoints = new IPEndPoint[] { new(IPAddress.Loopback, 53) };
+        cache.Put("example.com", endpoints, TimeSpan.FromMinutes(5));
+
+        Assert.True(cache.TryGetClosest("www.example.com", out DnsName? zone, out _));
+        Assert.Equal(new DnsName("example.com"), zone);
+
+        Assert.True(cache.TryGetClosest("deep.sub.example.com", out zone, out _));
+        Assert.Equal(new DnsName("example.com"), zone);
+    }
+
+    [Fact]
+    public void TryGetClosest_PrefersMostSpecific()
+    {
+        var cache = new DnsDelegationCache(8);
+        var comEndpoints = new IPEndPoint[] { new(IPAddress.Parse("1.1.1.1"), 53) };
+        var exampleEndpoints = new IPEndPoint[] { new(IPAddress.Parse("2.2.2.2"), 53) };
+        cache.Put("com", comEndpoints, TimeSpan.FromMinutes(5));
+        cache.Put("example.com", exampleEndpoints, TimeSpan.FromMinutes(5));
+
+        Assert.True(cache.TryGetClosest("www.example.com", out DnsName? zone, out IReadOnlyList<IPEndPoint>? eps));
+        Assert.Equal(new DnsName("example.com"), zone);
+        Assert.Equal(exampleEndpoints, eps);
+
+        Assert.True(cache.TryGetClosest("foo.com", out zone, out eps));
+        Assert.Equal(new DnsName("com"), zone);
+        Assert.Equal(comEndpoints, eps);
+    }
+
+    [Fact]
+    public void TryGetClosest_AfterExpiration_FallsThroughToAncestor()
+    {
+        var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var cache = new DnsDelegationCache(8, clock);
+
+        cache.Put("com", new IPEndPoint[] { new(IPAddress.Parse("1.1.1.1"), 53) }, TimeSpan.FromMinutes(30));
+        cache.Put("example.com", new IPEndPoint[] { new(IPAddress.Parse("2.2.2.2"), 53) }, TimeSpan.FromSeconds(10));
+
+        // After 30s the example.com entry has expired but com is still live.
+        clock.Advance(TimeSpan.FromSeconds(30));
+        Assert.True(cache.TryGetClosest("www.example.com", out DnsName? zone, out _));
+        Assert.Equal(new DnsName("com"), zone);
+    }
+
+    [Fact]
+    public void Put_ZeroTtl_DoesNotCache()
+    {
+        var cache = new DnsDelegationCache(8);
+        cache.Put("example.com", new IPEndPoint[] { new(IPAddress.Loopback, 53) }, TimeSpan.Zero);
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void Put_BeyondCapacity_EvictsOldest()
+    {
+        var cache = new DnsDelegationCache(2);
+        cache.Put("a.com", new IPEndPoint[] { new(IPAddress.Loopback, 53) }, TimeSpan.FromMinutes(5));
+        cache.Put("b.com", new IPEndPoint[] { new(IPAddress.Loopback, 53) }, TimeSpan.FromMinutes(5));
+        cache.Put("c.com", new IPEndPoint[] { new(IPAddress.Loopback, 53) }, TimeSpan.FromMinutes(5));
+
+        Assert.False(cache.TryGetClosest("a.com", out _, out _));
+        Assert.True(cache.TryGetClosest("b.com", out _, out _));
+        Assert.True(cache.TryGetClosest("c.com", out _, out _));
+    }
+
+    [Fact]
+    public void Clear_RemovesEverything()
+    {
+        var cache = new DnsDelegationCache(8);
+        cache.Put("example.com", new IPEndPoint[] { new(IPAddress.Loopback, 53) }, TimeSpan.FromMinutes(5));
+        cache.Clear();
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void Constructor_RejectsInvalidCapacity()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DnsDelegationCache(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DnsDelegationCache(-1));
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan d) => _now += d;
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsEdnsCookieTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/DnsEdnsCookieTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// EDNS Cookie (RFC 7873) integration tests. Verify that resolvers attach the cookie option
+/// to outgoing queries, cache the server cookie returned by the upstream, attach the
+/// (client + server) pair on subsequent queries, and retry once on BADCOOKIE.
+/// </summary>
+public sealed class DnsEdnsCookieTests
+{
+    private static readonly byte[] FixedClientCookie =
+        new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+
+    private static readonly byte[] ServerCookie =
+        new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 };
+
+    [Fact]
+    public async Task StubClient_AttachesClientCookieToOutgoingQuery()
+    {
+        DnsEdnsCookieOption? captured = null;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsMessage.Parse(req);
+            captured = DnsTestMessages.ExtractCookie(query);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var stub = new StubDnsClient(new StubDnsClientOptions
+        {
+            Transport = udp,
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        _ = await stub.QueryAsync(new DnsQuestion("example.com", DnsRecordType.A));
+
+        Assert.NotNull(captured);
+        Assert.Equal(FixedClientCookie, captured!.ClientCookie.ToArray());
+        Assert.False(captured.HasServerCookie); // first query has no server cookie yet
+    }
+
+    [Fact]
+    public async Task StubClient_DisablingCookies_OmitsOption()
+    {
+        DnsEdnsCookieOption? captured = null;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsMessage.Parse(req);
+            captured = DnsTestMessages.ExtractCookie(query);
+            return DnsTestMessages.BuildAnswer(query, new DnsRecord[] { DnsTestMessages.ExampleComA() });
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var stub = new StubDnsClient(new StubDnsClientOptions
+        {
+            Transport = udp,
+            EnableEdnsCookies = false,
+        });
+
+        _ = await stub.QueryAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Null(captured);
+    }
+
+    [Fact]
+    public async Task StubClient_CachesServerCookie_AndEchoesItOnSubsequentQuery()
+    {
+        var captured = new List<DnsEdnsCookieOption?>();
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsMessage.Parse(req);
+            captured.Add(DnsTestMessages.ExtractCookie(query));
+            return DnsTestMessages.BuildAnswerWithCookie(
+                query,
+                new DnsRecord[] { DnsTestMessages.ExampleComA() },
+                clientCookieEcho: FixedClientCookie,
+                serverCookie: ServerCookie);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var stub = new StubDnsClient(new StubDnsClientOptions
+        {
+            Transport = udp,
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        _ = await stub.QueryAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        _ = await stub.QueryAsync(new DnsQuestion("example2.com", DnsRecordType.A));
+
+        Assert.Equal(2, captured.Count);
+        Assert.NotNull(captured[0]);
+        Assert.False(captured[0]!.HasServerCookie);
+        Assert.NotNull(captured[1]);
+        Assert.True(captured[1]!.HasServerCookie);
+        Assert.Equal(ServerCookie, captured[1]!.ServerCookie.ToArray());
+        Assert.Equal(FixedClientCookie, captured[1]!.ClientCookie.ToArray());
+    }
+
+    [Fact]
+    public async Task StubClient_BadCookieResponse_TriggersOneRetry()
+    {
+        int requestCount = 0;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            requestCount++;
+            DnsMessage query = DnsMessage.Parse(req);
+            if (requestCount == 1)
+            {
+                // First request: BADCOOKIE with a server cookie attached.
+                return DnsTestMessages.BuildAnswerWithCookie(
+                    query,
+                    Array.Empty<DnsRecord>(),
+                    clientCookieEcho: FixedClientCookie,
+                    serverCookie: ServerCookie,
+                    rcode: DnsResponseCode.BadCookie);
+            }
+            // Second request: accept with the server cookie + return real answer.
+            DnsEdnsCookieOption? cookie = DnsTestMessages.ExtractCookie(query);
+            Assert.NotNull(cookie);
+            Assert.True(cookie!.HasServerCookie);
+            return DnsTestMessages.BuildAnswerWithCookie(
+                query,
+                new DnsRecord[] { DnsTestMessages.ExampleComA() },
+                clientCookieEcho: FixedClientCookie,
+                serverCookie: ServerCookie);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var stub = new StubDnsClient(new StubDnsClientOptions
+        {
+            Transport = udp,
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        DnsMessage answer = await stub.QueryAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Single(answer.Answers);
+        Assert.Equal(2, requestCount); // one BADCOOKIE + one retry
+    }
+
+    [Fact]
+    public async Task StubClient_RejectsWrongClientCookieEcho_DoesNotCacheServerCookie()
+    {
+        // A malicious or buggy server echoes the wrong client cookie back. The store must
+        // ignore the server cookie attached to that response — subsequent queries still send
+        // a client-cookie-only option.
+        var captured = new List<DnsEdnsCookieOption?>();
+        byte[] wrongEcho = (byte[])FixedClientCookie.Clone();
+        wrongEcho[0] ^= 0xFF;
+
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            DnsMessage query = DnsMessage.Parse(req);
+            captured.Add(DnsTestMessages.ExtractCookie(query));
+            return DnsTestMessages.BuildAnswerWithCookie(
+                query,
+                new DnsRecord[] { DnsTestMessages.ExampleComA() },
+                clientCookieEcho: wrongEcho,
+                serverCookie: ServerCookie);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var stub = new StubDnsClient(new StubDnsClientOptions
+        {
+            Transport = udp,
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        _ = await stub.QueryAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        _ = await stub.QueryAsync(new DnsQuestion("example2.com", DnsRecordType.A));
+
+        // Both queries should send a client-cookie-only option (no server cookie cached).
+        Assert.All(captured, c =>
+        {
+            Assert.NotNull(c);
+            Assert.False(c!.HasServerCookie);
+        });
+    }
+
+    [Fact]
+    public async Task ForwardingResolver_AttachesCookieAndHandlesBadCookie()
+    {
+        int requestCount = 0;
+        await using var server = new LoopbackUdpDnsServer();
+        server.OnRequest(req =>
+        {
+            requestCount++;
+            DnsMessage query = DnsMessage.Parse(req);
+            if (requestCount == 1)
+            {
+                return DnsTestMessages.BuildAnswerWithCookie(
+                    query,
+                    Array.Empty<DnsRecord>(),
+                    clientCookieEcho: FixedClientCookie,
+                    serverCookie: ServerCookie,
+                    rcode: DnsResponseCode.BadCookie);
+            }
+            return DnsTestMessages.BuildAnswerWithCookie(
+                query,
+                new DnsRecord[] { DnsTestMessages.ExampleComA() },
+                clientCookieEcho: FixedClientCookie,
+                serverCookie: ServerCookie);
+        });
+
+        using var udp = new UdpDnsTransport(new UdpDnsTransportOptions { EndPoint = server.EndPoint });
+        var resolver = new ForwardingDnsResolver(new ForwardingDnsResolverOptions
+        {
+            Forwarders = { udp },
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("example.com", DnsRecordType.A));
+        Assert.Single(answer.Answers);
+        Assert.Equal(2, requestCount);
+    }
+
+    [Fact]
+    public async Task IterativeResolver_AttachesCookieOnEveryStep()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        await using var example = new LoopbackDnsAuthority("example.com");
+        root.Delegate("com", "ns1.com", com);
+        com.Delegate("example.com", "ns1.example.com", example);
+        example.AddRecord(new DnsARecord("www.example.com", IPAddress.Parse("93.184.216.34"), 300));
+
+        var observedCookies = new List<DnsEdnsCookieOption?>();
+        root.OnInboundQuery = m => observedCookies.Add(DnsTestMessages.ExtractCookie(m));
+        com.OnInboundQuery = m => observedCookies.Add(DnsTestMessages.ExtractCookie(m));
+        example.OnInboundQuery = m => observedCookies.Add(DnsTestMessages.ExtractCookie(m));
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+            EdnsClientCookie = FixedClientCookie,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("www.example.com", DnsRecordType.A));
+
+        // Every authority that received a request saw a cookie carrying our client cookie.
+        Assert.NotEmpty(observedCookies);
+        Assert.All(observedCookies, c =>
+        {
+            Assert.NotNull(c);
+            Assert.Equal(FixedClientCookie, c!.ClientCookie.ToArray());
+        });
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/IterativeDnsResolverHardeningTests.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/IterativeDnsResolverHardeningTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Dns.Tests;
+
+/// <summary>
+/// Tests for the PR-6 hardening additions to <see cref="IterativeDnsResolver"/>:
+/// out-of-bailiwick NS resolution and delegation caching.
+/// </summary>
+public sealed class IterativeDnsResolverHardeningTests
+{
+    /// <summary>
+    /// Real-world style: the .com authority delegates example.com to ns1.example-dns.net.
+    /// The NS name lives in a different zone with no glue available from .com. The resolver
+    /// must recursively resolve ns1.example-dns.net via the same walk and reuse the result.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_ResolvesOutOfBailiwickNsName()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        await using var dnsNet = new LoopbackDnsAuthority("example-dns.net");
+        await using var net = new LoopbackDnsAuthority("net");
+        await using var exampleCom = new LoopbackDnsAuthority("example.com");
+
+        root.Delegate("com", "ns1.com", com);
+        root.Delegate("net", "ns1.net", net);
+
+        // .net delegates example-dns.net with in-bailiwick glue so the resolver can find
+        // the NS-hosting authority on its own.
+        net.Delegate("example-dns.net", "ns1.example-dns.net", dnsNet);
+
+        // The example-dns.net zone holds an A record for the NS name we'll see referenced
+        // from .com — this is the out-of-bailiwick NS the resolver must resolve.
+        dnsNet.AddRecord(new DnsARecord(
+            "ns1.example-dns.net",
+            exampleCom.VirtualEndPoint.Address,
+            300));
+
+        // .com delegates example.com using an out-of-bailiwick NS name (the name lives in
+        // example-dns.net, not .com). No glue is provided by .com because the strict glue
+        // policy would discard it anyway — the resolver must resolve it.
+        com.Delegate("example.com", "ns1.example-dns.net", exampleCom, includeGlue: false);
+
+        exampleCom.AddRecord(new DnsARecord("www.example.com", IPAddress.Parse("93.184.216.34"), 300));
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+        });
+
+        DnsMessage answer = await resolver.ResolveAsync(new DnsQuestion("www.example.com", DnsRecordType.A));
+        Assert.Single(answer.Answers);
+        DnsARecord a = Assert.IsType<DnsARecord>(answer.Answers[0]);
+        Assert.Equal(IPAddress.Parse("93.184.216.34"), a.Address);
+    }
+
+    /// <summary>
+    /// Out-of-bailiwick NS resolution is bounded by <see
+    /// cref="IterativeDnsResolverOptions.MaxNsResolutionDepth"/> so a pathological zone
+    /// requiring deep NS-name chasing can't blow the query budget.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_NsResolutionDepth_Bounded()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        // Delegation with out-of-bailiwick NS and no glue, plus depth 0 means the resolver
+        // is not allowed to do any NS-name lookups at all.
+        root.Delegate("com", "ns1.com", com);
+        com.Delegate("example.com", "ns1.example-dns.net", new LoopbackDnsAuthority("example.com"), includeGlue: false);
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+            MaxNsResolutionDepth = 0,
+        });
+
+        DnsException ex = await Assert.ThrowsAsync<DnsException>(
+            () => resolver.ResolveAsync(new DnsQuestion("www.example.com", DnsRecordType.A)));
+        Assert.Equal(DnsErrorCode.Transport, ex.Code);
+    }
+
+    /// <summary>
+    /// Second query for a name under a previously-resolved zone should hit the delegation
+    /// cache and skip the root&rarr;TLD walk. Verify by counting how many times the root
+    /// authority is contacted across two resolves.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_DelegationCache_SkipsRootWalkOnSecondQuery()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        await using var example = new LoopbackDnsAuthority("example.com");
+        root.Delegate("com", "ns1.com", com);
+        com.Delegate("example.com", "ns1.example.com", example);
+        example.AddRecord(new DnsARecord("a.example.com", IPAddress.Parse("1.2.3.4"), 300));
+        example.AddRecord(new DnsARecord("b.example.com", IPAddress.Parse("5.6.7.8"), 300));
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("a.example.com", DnsRecordType.A));
+        int rootHitsAfterFirst = root.RequestCount;
+        int comHitsAfterFirst = com.RequestCount;
+
+        // Second query for a DIFFERENT name in example.com: should NOT walk through root or
+        // com, but go directly to example.com via the cached delegation.
+        _ = await resolver.ResolveAsync(new DnsQuestion("b.example.com", DnsRecordType.A));
+
+        Assert.Equal(rootHitsAfterFirst, root.RequestCount);
+        Assert.Equal(comHitsAfterFirst, com.RequestCount);
+        Assert.True(resolver.DelegationCacheCount > 0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DelegationCache_ClearedByClearCacheAsync()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        await using var example = new LoopbackDnsAuthority("example.com");
+        root.Delegate("com", "ns1.com", com);
+        com.Delegate("example.com", "ns1.example.com", example);
+        example.AddRecord(new DnsARecord("www.example.com", IPAddress.Parse("1.2.3.4"), 300));
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("www.example.com", DnsRecordType.A));
+        Assert.True(resolver.DelegationCacheCount > 0);
+
+        await resolver.ClearCacheAsync();
+        Assert.Equal(0, resolver.DelegationCacheCount);
+        Assert.Equal(0, resolver.CacheCount);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DelegationCacheDisabled_AlwaysWalksFromRoot()
+    {
+        await using var root = new LoopbackDnsAuthority(".");
+        await using var com = new LoopbackDnsAuthority("com");
+        await using var example = new LoopbackDnsAuthority("example.com");
+        root.Delegate("com", "ns1.com", com);
+        com.Delegate("example.com", "ns1.example.com", example);
+        example.AddRecord(new DnsARecord("a.example.com", IPAddress.Parse("1.2.3.4"), 300));
+        example.AddRecord(new DnsARecord("b.example.com", IPAddress.Parse("5.6.7.8"), 300));
+
+        var resolver = new IterativeDnsResolver(new IterativeDnsResolverOptions
+        {
+            RootEndpoints = new List<IPEndPoint> { root.VirtualEndPoint },
+            UdpTransportFactory = LoopbackDnsAuthority.CreateTransportFactory(),
+            TcpTransportFactory = null,
+            EnableQNameMinimization = false,
+            EnableDelegationCache = false,
+        });
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("a.example.com", DnsRecordType.A));
+        int rootHitsAfterFirst = root.RequestCount;
+
+        _ = await resolver.ResolveAsync(new DnsQuestion("b.example.com", DnsRecordType.A));
+
+        // No delegation cache means the second query also walks through root.
+        Assert.True(root.RequestCount > rootHitsAfterFirst);
+        Assert.Equal(0, resolver.DelegationCacheCount);
+    }
+}

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/DnsTestMessages.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/DnsTestMessages.cs
@@ -151,6 +151,71 @@ internal static class DnsTestMessages
     public static DnsARecord ExampleComA(string ip = "93.184.216.34", uint ttl = 300)
         => new("example.com", IPAddress.Parse(ip), ttl);
 
+    /// <summary>
+    /// Builds a response that attaches an EDNS Cookie option carrying the supplied server
+    /// cookie. Used to verify that resolvers cache server cookies for subsequent queries.
+    /// </summary>
+    public static byte[] BuildAnswerWithCookie(
+        DnsMessage query,
+        IReadOnlyList<DnsRecord> answers,
+        byte[] clientCookieEcho,
+        byte[]? serverCookie,
+        DnsResponseCode rcode = DnsResponseCode.NoError)
+    {
+        var cookie = serverCookie is null
+            ? new DnsEdnsCookieOption(clientCookieEcho)
+            : new DnsEdnsCookieOption(clientCookieEcho, serverCookie);
+
+        // RFC 6891 §6.1.3: RCODEs ≥16 split across the header's low 4 bits and the OPT TTL's
+        // upper 8 bits. Encode that split here so a BADCOOKIE (RCODE 23) test produces the
+        // right wire bytes.
+        int rcodeInt = (int)rcode;
+        byte extHigh = (byte)((rcodeInt >> 4) & 0xFF);
+        DnsResponseCode lowRcode = (DnsResponseCode)(rcodeInt & 0x0F);
+
+        var opt = new DnsOptRecord(udpPayloadSize: 1232, extendedRCodeHigh: extHigh, version: 0, DnsEdnsFlags.None, new DnsEdnsOption[] { cookie });
+
+        var header = new DnsHeader(
+            query.Header.Id,
+            DnsHeaderFlags.Response | DnsHeaderFlags.RecursionAvailable,
+            DnsOpCode.Query,
+            lowRcode,
+            (ushort)query.Questions.Count,
+            (ushort)answers.Count,
+            0,
+            1);
+
+        var response = new DnsMessage(
+            header,
+            query.Questions,
+            answers,
+            Array.Empty<DnsRecord>(),
+            new DnsRecord[] { opt });
+
+        return Serialize(response);
+    }
+
+    /// <summary>
+    /// Extracts the EDNS Cookie option (if any) from an inbound query. Used in test
+    /// responders to verify the client sent the expected client + server cookie pair.
+    /// </summary>
+    public static DnsEdnsCookieOption? ExtractCookie(DnsMessage message)
+    {
+        DnsOptRecord? opt = message.Edns;
+        if (opt is null)
+        {
+            return null;
+        }
+        foreach (DnsEdnsOption option in opt.Options)
+        {
+            if (option is DnsEdnsCookieOption cookie)
+            {
+                return cookie;
+            }
+        }
+        return null;
+    }
+
     private static byte[] Serialize(DnsMessage message)
     {
         // 4096 octets is generous for any test response.

--- a/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackDnsAuthority.cs
+++ b/libraries/Dns/Assimalign.Cohesion.Dns.Client/tests/TestFixtures/LoopbackDnsAuthority.cs
@@ -104,6 +104,13 @@ internal sealed class LoopbackDnsAuthority : IAsyncDisposable
     public DnsQuestion? LastQuestion { get; private set; }
 
     /// <summary>
+    /// Optional hook invoked once per inbound query, before the authority responds. Tests
+    /// use this to capture EDNS options, header flags, or anything else not covered by the
+    /// <see cref="LastQuestion"/> shortcut.
+    /// </summary>
+    public Action<DnsMessage>? OnInboundQuery { get; set; }
+
+    /// <summary>
     /// Adds a record to this authority's zone.
     /// </summary>
     public LoopbackDnsAuthority AddRecord(DnsRecord record)
@@ -166,6 +173,7 @@ internal sealed class LoopbackDnsAuthority : IAsyncDisposable
 
         DnsQuestion q = query.Questions[0];
         LastQuestion = q;
+        OnInboundQuery?.Invoke(query);
 
         // 1. Refused if entirely outside our zone.
         if (!IsInZoneOrChild(q.Name))


### PR DESCRIPTION
## Summary

- **Out-of-bailiwick NS resolution**: when a referral arrives with no in-bailiwick glue (the common case for real TLDs — `.com` delegates to `ns1.gtld-servers.net`), the resolver now recursively resolves the NS name through its own walk + cache.
- **Delegation caching**: every successful referral is cached by zone; subsequent queries under a known zone skip the root→TLD walk.
- **EDNS Cookies (RFC 7873)**: every outgoing query carries a cookie option. Server cookies are cached by upstream IP; BADCOOKIE triggers one retry. All three client surfaces (Stub, Forwarding, Iterative) participate.
- **Extended RCODE handling** (RFC 6891 §6.1.3): added `DnsQueryHelper.EffectiveRcode` and rewired every response-code check through it so BADCOOKIE (23) and friends surface correctly instead of showing up as the low-nibble alias.
- 21 new tests + extensions to the loopback fixtures. All 173 Dns-family tests green.

## Public surface added

```csharp
// IterativeDnsResolverOptions:
public bool   EnableDelegationCache  { get; set; } = true;
public int    DelegationCacheCapacity { get; set; } = 2_000;
public bool   EnableEdnsCookies      { get; set; } = true;
public byte[]? EdnsClientCookie      { get; set; }
public int    MaxNsResolutionDepth   { get; set; } = 5;

// ForwardingDnsResolverOptions + StubDnsClientOptions:
public bool   EnableEdnsCookies      { get; set; } = true;
public byte[]? EdnsClientCookie      { get; set; }

// IterativeDnsResolver:
public int    DelegationCacheCount   { get; }
```

## Internal additions

- `DnsCookieStore` — single 8-octet client cookie + per-server-IP server-cookie cache. Validates the echoed client cookie before caching the server cookie.
- `DnsDelegationCache` — TTL-aware closest-enclosing-zone cache with approximate-LRU eviction. Same shape as the answer cache.
- `DnsQueryHelper.EffectiveRcode(message)` — combines the header's low 4 bits with the OPT TTL's upper 8 bits to surface extended RCODEs correctly.
- `DnsQueryHelper.BuildQuery` extended with an optional `ednsOptions` parameter so cookies (and future ECS / Padding / etc.) attach cleanly.
- `IterativeDnsResolver.ResolveContext` (private) — shared budget + cycle-detection + NS-recursion-depth state, threaded through every recursive sub-resolve.

## Behavior changes

| Concern | Before | After |
|---|---|---|
| Referral with no in-bailiwick glue | `Transport` error | Recursively resolve NS name (bounded by `MaxNsResolutionDepth`) |
| Second query under known zone | Walks root→TLD again | Starts from cached delegation |
| BADCOOKIE response | Surfaced as `ServerFailure(YXRRSet)` (wrong) | Triggers one retry with the new server cookie |
| Outgoing query (all clients) | OPT record only | OPT + Cookie option |
| `ClearCacheAsync` | Clears answer cache | Clears answer cache + delegation cache |

## Tests

**21 new tests** across three new test files:

- `DnsDelegationCacheTests` (9): hit/miss, closest-enclosing lookup, most-specific preference, TTL fall-through, zero-TTL skip, capacity eviction, clear, constructor validation.
- `DnsEdnsCookieTests` (7): client-cookie attach, cookie-disabled mode, server-cookie cache + echo, BADCOOKIE retry (Stub + Forwarding), wrong-client-cookie-echo rejection, iterative cookies on every step.
- `IterativeDnsResolverHardeningTests` (5): out-of-bailiwick NS resolution end-to-end, NS-depth limit enforcement, delegation cache skips root walk, ClearCacheAsync clears both caches, EnableDelegationCache=false always walks from root.

All 115 Dns.Client tests pass (94 from PR 5 + 21 new). All 58 wire-format tests still pass. **173 total green.**

## Deferred / out of scope

- **0x20 case randomization**: interacts poorly with DNSSEC and adds little once cookies + ID randomization are in place. Revisit if there's demand.
- **DnsMessage extended-RCODE projection**: the wire-format library could expose the combined RCODE as a property on `DnsMessage` itself. Doing it on the resolver side via `DnsQueryHelper.EffectiveRcode` covers the immediate need without changing the contract layer.

## Test plan

- [x] All new tests pass locally (21/21)
- [x] All previously-shipping tests still pass (94 Dns.Client + 58 wire-format)
- [x] Full \`libraries/Dns/Assimalign.Cohesion.Dns.slnx\` builds with 0 warnings / 0 errors
- [ ] CI matrix green on ubuntu / windows / macos across all 5 Dns assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)