### PR TITLE
feat(http): RFC 9112 §3.2 request-target parsing (L01.01.11 PR3)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1MessageReader.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1MessageReader.cs
@@ -40,19 +40,43 @@ internal static class Http1MessageReader
             throw new InvalidDataException($"The HTTP version '{requestLineParts[2]}' is not supported by the HTTP/1.1 transport.");
         }
 
+        HttpMethod method = HttpMethod.GetCanonicalizedValue(requestLineParts[0]);
+        // RFC 9112 §3.2 — parse the request-target into one of the four canonical forms
+        // (origin / absolute / authority / asterisk) with method/form pairing enforcement.
+        if (!HttpRequestTarget.TryParse(requestLineParts[1], method, out HttpRequestTarget target, out string? targetError))
+        {
+            throw new InvalidDataException(
+                $"The HTTP/1.1 request line '{requestLine}' has a malformed request-target: {targetError}");
+        }
+
         HttpHeaderCollection headers = await ReadHeadersAsync(stream, cancellationToken).ConfigureAwait(false);
         byte[] bodyBytes = await ReadBodyAsync(stream, headers, cancellationToken).ConfigureAwait(false);
-        HttpQueryCollection queryCollection = ParseQuery(requestLineParts[1], out HttpPath path);
+        HttpQueryCollection queryCollection = new HttpQuery(target.Query.Value).Parse();
         HttpCookieCollection cookies = ParseCookies(headers);
-        HttpHost host = headers.TryGetValue(HttpHeaderKey.Host, out HttpHeaderValue hostValue)
-            ? new HttpHost(hostValue.Value)
-            : HttpHost.Empty;
+
+        // Host resolution depends on the request-target form (RFC 9112 §3.2.2 / §3.2.3):
+        //   - absolute-form  → authority component of the target supersedes any Host header
+        //   - authority-form → the target itself IS the authority (CONNECT)
+        //   - origin-form / asterisk → fall back to the Host header
+        HttpHost host = target.Form switch
+        {
+            HttpRequestTargetForm.Absolute => target.Host,
+            HttpRequestTargetForm.Authority => target.Host,
+            _ => headers.TryGetValue(HttpHeaderKey.Host, out HttpHeaderValue hostValue)
+                ? new HttpHost(hostValue.Value)
+                : HttpHost.Empty,
+        };
+
+        // Scheme follows the same precedence: absolute-form carries it on the wire.
+        HttpScheme requestScheme = target.Form == HttpRequestTargetForm.Absolute
+            ? target.Scheme
+            : scheme;
 
         Http1Request request = new(
             host,
-            path,
-            HttpMethod.GetCanonicalizedValue(requestLineParts[0]),
-            scheme,
+            target.Path,
+            method,
+            requestScheme,
             queryCollection,
             headers,
             cookies,
@@ -196,38 +220,6 @@ internal static class Http1MessageReader
                 return;
             }
         }
-    }
-
-    private static HttpQueryCollection ParseQuery(string requestTarget, out HttpPath path)
-    {
-        ArgumentNullException.ThrowIfNull(requestTarget);
-
-        if (requestTarget.Length > 0 && requestTarget[0] is '/' or '*')
-        {
-            return ParseOriginFormQuery(requestTarget, out path);
-        }
-
-        if (Uri.TryCreate(requestTarget, UriKind.Absolute, out Uri? uri))
-        {
-            path = HttpPath.FromUriComponent(uri.AbsolutePath);
-            return new HttpQuery(uri.Query).Parse();
-        }
-
-        return ParseOriginFormQuery(requestTarget, out path);
-    }
-
-    private static HttpQueryCollection ParseOriginFormQuery(string requestTarget, out HttpPath path)
-    {
-        int queryIndex = requestTarget.IndexOf('?');
-
-        if (queryIndex >= 0)
-        {
-            path = HttpPath.FromUriComponent(requestTarget[..queryIndex]);
-            return new HttpQuery(requestTarget[(queryIndex + 1)..]).Parse();
-        }
-
-        path = HttpPath.FromUriComponent(requestTarget);
-        return new HttpQueryCollection();
     }
 
     private static HttpCookieCollection ParseCookies(HttpHeaderCollection headers)

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http1TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http1TransportTests.cs
@@ -57,9 +57,10 @@ public class Http1TransportTests
     [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should parse absolute-form request targets")]
     public async Task Http1_OnAbsoluteFormRequest_ShouldParsePathAndQuery()
     {
-        // Arrange
+        // RFC 9112 §3.2.2 — absolute-form, used when a proxy forwards a request.
+        // The authority component of the target supersedes any Host header.
         byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
-            "GET http://api.test/widgets?id=42 HTTP/1.1\r\nHost: api.test\r\n\r\n");
+            "GET https://upstream.example.com:8443/widgets?id=42 HTTP/1.1\r\nHost: lying-host-header.test\r\n\r\n");
         TestTransportConnectionContext transportContext = new(payload);
         TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
         HttpConnectionListenerOptions options = new();
@@ -72,8 +73,80 @@ public class Http1TransportTests
         IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
 
         // Assert
+        httpContext.Request.Method.ShouldBe(HttpMethod.Get);
         httpContext.Request.Path.Value.ShouldBe("/widgets");
         httpContext.Request.Query["id"].Value.ShouldBe("42");
+        // Authority component of the target wins over the Host header per RFC 9112 §3.2.2.
+        httpContext.Request.Host.Value.ShouldBe("upstream.example.com:8443");
+        httpContext.Request.Scheme.ShouldBe(HttpScheme.Https);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should parse authority-form CONNECT targets")]
+    public async Task Http1_OnAuthorityFormConnectRequest_ShouldExtractHostAndPort()
+    {
+        // RFC 9112 §3.2.3 — authority-form, reserved for CONNECT.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "CONNECT origin.example.com:443 HTTP/1.1\r\nHost: origin.example.com:443\r\n\r\n");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        // Act
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        // Assert
+        httpContext.Request.Method.ShouldBe(HttpMethod.Connect);
+        httpContext.Request.Host.Value.ShouldBe("origin.example.com:443");
+        httpContext.Request.Path.ShouldBe(HttpPath.Root);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should parse asterisk-form OPTIONS targets")]
+    public async Task Http1_OnAsteriskFormOptionsRequest_ShouldExposeAsteriskPath()
+    {
+        // RFC 9112 §3.2.4 — asterisk-form, reserved for OPTIONS *.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "OPTIONS * HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        // Act
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        // Assert
+        httpContext.Request.Method.ShouldBe(HttpMethod.Options);
+        httpContext.Request.Path.Value.ShouldBe("*");
+        // Asterisk-form has no authority on the target; Host header is the fallback.
+        httpContext.Request.Host.Value.ShouldBe("api.test");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should reject malformed request-targets")]
+    [InlineData("CONNECT /path HTTP/1.1\r\nHost: api.test\r\n\r\n")]          // CONNECT requires authority-form
+    [InlineData("GET * HTTP/1.1\r\nHost: api.test\r\n\r\n")]                  // asterisk-form is OPTIONS-only
+    [InlineData("GET example.com:80 HTTP/1.1\r\nHost: api.test\r\n\r\n")]     // authority-form on non-CONNECT
+    [InlineData("GET  HTTP/1.1\r\nHost: api.test\r\n\r\n")]                   // empty target (collapses to 2 parts after Split)
+    [InlineData("GET ftp://example.com/p HTTP/1.1\r\nHost: api.test\r\n\r\n")] // unsupported scheme
+    public async Task Http1_OnMalformedRequestTarget_ShouldThrow(string payloadText)
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(payloadText);
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        await Should.ThrowAsync<InvalidDataException>(
+            async () => await ReadSingleContextAsync(httpConnectionContext));
     }
 
     [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should deliver URL encoded request body intact to the application layer")]

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
@@ -31,6 +31,13 @@ public enum HttpErrorCode
     InvalidPath,
 
     /// <summary>
+    /// A request contained a malformed request-target (RFC 9112 &#167; 3.2). Includes
+    /// targets that do not match any of the four canonical forms (origin / absolute /
+    /// authority / asterisk) and targets that violate the method/form pairing rules.
+    /// </summary>
+    InvalidRequestTarget,
+
+    /// <summary>
     /// A request or response contained an invalid header.
     /// </summary>
     InvalidHeader,

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRequestTarget.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRequestTarget.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Diagnostics;
+using Assimalign.Cohesion.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed HTTP/1.1 request-target (RFC 9112 &#167; 3.2). Captures the form
+/// (<see cref="HttpRequestTargetForm.Origin"/>,
+/// <see cref="HttpRequestTargetForm.Absolute"/>,
+/// <see cref="HttpRequestTargetForm.Authority"/>,
+/// <see cref="HttpRequestTargetForm.Asterisk"/>) plus the components meaningful to that
+/// form (scheme, host, path, query).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Method/form pairings are enforced by <see cref="TryParse(System.ReadOnlySpan{char},
+/// HttpMethod, out HttpRequestTarget, out string)"/>:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="HttpMethod.Connect"/> requires
+///   <see cref="HttpRequestTargetForm.Authority"/> &#8211; no other method may use it.</description></item>
+///   <item><description><see cref="HttpRequestTargetForm.Asterisk"/> is reserved for
+///   <see cref="HttpMethod.Options"/> only.</description></item>
+///   <item><description><see cref="HttpRequestTargetForm.Origin"/> and
+///   <see cref="HttpRequestTargetForm.Absolute"/> are valid for every other method.</description></item>
+/// </list>
+/// </remarks>
+[DebuggerDisplay("{Form,nq}: {RawValue,nq}")]
+public readonly struct HttpRequestTarget : IEquatable<HttpRequestTarget>
+{
+    /// <summary>
+    /// The canonical asterisk target used by <c>OPTIONS *</c> requests.
+    /// </summary>
+    public static HttpRequestTarget Asterisk { get; } = new(
+        HttpRequestTargetForm.Asterisk,
+        HttpScheme.None,
+        HttpHost.Empty,
+        new HttpPath("*"),
+        new HttpQuery(string.Empty),
+        "*");
+
+    private HttpRequestTarget(
+        HttpRequestTargetForm form,
+        HttpScheme scheme,
+        HttpHost host,
+        HttpPath path,
+        HttpQuery query,
+        string rawValue)
+    {
+        Form = form;
+        Scheme = scheme;
+        Host = host;
+        Path = path;
+        Query = query;
+        RawValue = rawValue;
+    }
+
+    /// <summary>The parsed form of this request-target.</summary>
+    public HttpRequestTargetForm Form { get; }
+
+    /// <summary>
+    /// Scheme parsed from an absolute-form target. <see cref="HttpScheme.None"/> for the
+    /// other three forms (origin / authority / asterisk).
+    /// </summary>
+    public HttpScheme Scheme { get; }
+
+    /// <summary>
+    /// Host parsed from an absolute-form or authority-form target.
+    /// <see cref="HttpHost.Empty"/> for origin-form and asterisk-form &#8211; consumers
+    /// derive the host from the <c>Host</c> header instead.
+    /// </summary>
+    public HttpHost Host { get; }
+
+    /// <summary>
+    /// Path component of the target. For origin-form and absolute-form this is the
+    /// absolute path. For authority-form this is <see cref="HttpPath.Root"/>. For
+    /// asterisk-form this is the literal asterisk path.
+    /// </summary>
+    public HttpPath Path { get; }
+
+    /// <summary>
+    /// Query string. Empty for authority-form and asterisk-form.
+    /// </summary>
+    public HttpQuery Query { get; }
+
+    /// <summary>
+    /// The original raw target string as it appeared on the wire. Useful for logging,
+    /// proxying, and round-tripping the request line unchanged.
+    /// </summary>
+    public string RawValue { get; }
+
+    /// <summary>
+    /// Parses <paramref name="raw"/> as a request-target appropriate for
+    /// <paramref name="method"/>. Returns <see langword="false"/> when the target is
+    /// malformed or violates the method/form pairing.
+    /// </summary>
+    public static bool TryParse(
+        ReadOnlySpan<char> raw,
+        HttpMethod method,
+        out HttpRequestTarget result)
+        => TryParse(raw, method, out result, out _);
+
+    /// <summary>
+    /// Parses <paramref name="raw"/> as a request-target appropriate for
+    /// <paramref name="method"/>. On failure, <paramref name="error"/> carries a
+    /// human-readable explanation.
+    /// </summary>
+    public static bool TryParse(
+        ReadOnlySpan<char> raw,
+        HttpMethod method,
+        out HttpRequestTarget result,
+        out string? error)
+    {
+        result = default;
+        error = null;
+
+        if (raw.IsEmpty)
+        {
+            error = "Request-target is empty.";
+            return false;
+        }
+        if (ContainsControlOrSpace(raw, out int badIndex))
+        {
+            error = $"Request-target contains an invalid character at position {badIndex}.";
+            return false;
+        }
+
+        // RFC 9112 §3.2.4 — the literal '*' is asterisk-form. Reserved for OPTIONS.
+        if (raw.Length == 1 && raw[0] == '*')
+        {
+            if (!IsOptions(method))
+            {
+                error = $"Asterisk-form request-target is reserved for OPTIONS; got method '{method.Value}'.";
+                return false;
+            }
+            result = Asterisk;
+            return true;
+        }
+
+        // RFC 9112 §3.2.3 — CONNECT MUST use authority-form (host:port).
+        bool isConnect = string.Equals(method.Value, "CONNECT", StringComparison.Ordinal);
+        if (isConnect)
+        {
+            return TryParseAuthorityForm(raw, out result, out error);
+        }
+
+        // Distinguish origin-form (starts with '/') from absolute-form (contains '://').
+        if (raw[0] == '/')
+        {
+            return TryParseOriginForm(raw, out result, out error);
+        }
+
+        if (LooksLikeAbsoluteForm(raw))
+        {
+            return TryParseAbsoluteForm(raw, out result, out error);
+        }
+
+        // Anything else (e.g. authority-form with a non-CONNECT method) is malformed.
+        error = $"Request-target '{raw.ToString()}' does not match any RFC 9112 §3.2 form for method '{method.Value}'.";
+        return false;
+    }
+
+    /// <summary>
+    /// Parses <paramref name="raw"/> as a request-target appropriate for
+    /// <paramref name="method"/>. Throws <see cref="HttpException"/> when the target is
+    /// malformed; use <see cref="TryParse(System.ReadOnlySpan{char}, HttpMethod, out HttpRequestTarget)"/>
+    /// when the caller wants the bool-out shape instead.
+    /// </summary>
+    /// <exception cref="HttpException">The target is malformed or violates the method/form
+    /// pairing.</exception>
+    public static HttpRequestTarget Parse(ReadOnlySpan<char> raw, HttpMethod method)
+    {
+        if (!TryParse(raw, method, out HttpRequestTarget result, out string? error))
+        {
+            ThrowHelper.InvalidHttpRequestTarget(error ?? "Malformed request-target.");
+        }
+        return result;
+    }
+
+    private static bool TryParseOriginForm(
+        ReadOnlySpan<char> raw,
+        out HttpRequestTarget result,
+        out string? error)
+    {
+        result = default;
+        error = null;
+
+        int queryIndex = raw.IndexOf('?');
+        ReadOnlySpan<char> pathSpan = queryIndex < 0 ? raw : raw[..queryIndex];
+        ReadOnlySpan<char> querySpan = queryIndex < 0 ? ReadOnlySpan<char>.Empty : raw[(queryIndex + 1)..];
+
+        if (pathSpan.IsEmpty || pathSpan[0] != '/')
+        {
+            error = "origin-form request-target must begin with '/'.";
+            return false;
+        }
+
+        HttpPath path;
+        try
+        {
+            path = new HttpPath(pathSpan.ToString());
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+
+        result = new HttpRequestTarget(
+            HttpRequestTargetForm.Origin,
+            HttpScheme.None,
+            HttpHost.Empty,
+            path,
+            new HttpQuery(querySpan.ToString()),
+            raw.ToString());
+        return true;
+    }
+
+    private static bool TryParseAbsoluteForm(
+        ReadOnlySpan<char> raw,
+        out HttpRequestTarget result,
+        out string? error)
+    {
+        result = default;
+        error = null;
+
+        if (!Uri.TryCreate(raw.ToString(), UriKind.Absolute, out Uri? uri))
+        {
+            error = "absolute-form request-target is not a valid absolute URI.";
+            return false;
+        }
+
+        HttpScheme scheme = uri.Scheme switch
+        {
+            "http" => HttpScheme.Http,
+            "https" => HttpScheme.Https,
+            _ => HttpScheme.None,
+        };
+        if (scheme == HttpScheme.None)
+        {
+            error = $"absolute-form request-target uses unsupported scheme '{uri.Scheme}'.";
+            return false;
+        }
+        if (string.IsNullOrEmpty(uri.Host))
+        {
+            error = "absolute-form request-target is missing the authority component.";
+            return false;
+        }
+
+        // Host as it appeared on the wire — preserve the [port] suffix per RFC 9112 §3.2.2.
+        string hostWithPort = uri.IsDefaultPort
+            ? uri.Host
+            : $"{uri.Host}:{uri.Port}";
+
+        HttpPath path;
+        try
+        {
+            path = new HttpPath(string.IsNullOrEmpty(uri.AbsolutePath) ? "/" : uri.AbsolutePath);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+
+        string queryString = uri.Query.Length > 0 && uri.Query[0] == '?' ? uri.Query[1..] : uri.Query;
+        result = new HttpRequestTarget(
+            HttpRequestTargetForm.Absolute,
+            scheme,
+            new HttpHost(hostWithPort),
+            path,
+            new HttpQuery(queryString),
+            raw.ToString());
+        return true;
+    }
+
+    private static bool TryParseAuthorityForm(
+        ReadOnlySpan<char> raw,
+        out HttpRequestTarget result,
+        out string? error)
+    {
+        result = default;
+        error = null;
+
+        // CONNECT targets are uri-host ":" port. The host may be a registered name, an
+        // IPv4 literal, or a bracketed IPv6 literal.
+        int hostEnd;
+        if (raw[0] == '[')
+        {
+            int closeBracket = raw.IndexOf(']');
+            if (closeBracket < 0)
+            {
+                error = "authority-form request-target has an unmatched '['.";
+                return false;
+            }
+            hostEnd = closeBracket + 1;
+        }
+        else
+        {
+            hostEnd = raw.IndexOf(':');
+            if (hostEnd < 0)
+            {
+                error = "authority-form request-target must include a port (host:port).";
+                return false;
+            }
+        }
+
+        if (hostEnd >= raw.Length || raw[hostEnd] != (raw[0] == '[' ? ']' : ':'))
+        {
+            // hostEnd == raw.Length when the bracket-IPv6 has no trailing port.
+            if (raw[0] == '[' && hostEnd == raw.Length)
+            {
+                error = "authority-form request-target must include a port (host:port).";
+                return false;
+            }
+        }
+
+        int portStart = raw[0] == '[' ? hostEnd : hostEnd;
+        // If the host was bracketed IPv6, hostEnd points past the closing bracket.
+        // Expect a ':' immediately after.
+        if (raw[0] == '[')
+        {
+            if (portStart >= raw.Length || raw[portStart] != ':')
+            {
+                error = "authority-form request-target with IPv6 host must include a port (e.g. [::1]:8080).";
+                return false;
+            }
+        }
+
+        // Now portStart points at the ':' that precedes the port.
+        ReadOnlySpan<char> hostSpan = raw[..portStart];
+        ReadOnlySpan<char> portSpan = raw[(portStart + 1)..];
+
+        if (hostSpan.IsEmpty)
+        {
+            error = "authority-form request-target has an empty host.";
+            return false;
+        }
+        if (portSpan.IsEmpty)
+        {
+            error = "authority-form request-target has an empty port.";
+            return false;
+        }
+        foreach (char c in portSpan)
+        {
+            if (c < '0' || c > '9')
+            {
+                error = $"authority-form request-target port '{portSpan.ToString()}' contains non-digit characters.";
+                return false;
+            }
+        }
+
+        result = new HttpRequestTarget(
+            HttpRequestTargetForm.Authority,
+            HttpScheme.None,
+            new HttpHost(raw.ToString()),
+            HttpPath.Root,
+            new HttpQuery(string.Empty),
+            raw.ToString());
+        return true;
+    }
+
+    private static bool LooksLikeAbsoluteForm(ReadOnlySpan<char> raw)
+    {
+        // RFC 3986 absolute-URI requires a scheme followed by ":" and authority-prefixed
+        // with "//" — i.e. the substring "://" appears before any '/' or '?' in the target.
+        int schemeSep = raw.IndexOf(':');
+        if (schemeSep <= 0)
+        {
+            return false;
+        }
+        if (schemeSep + 2 >= raw.Length)
+        {
+            return false;
+        }
+        if (raw[schemeSep + 1] != '/' || raw[schemeSep + 2] != '/')
+        {
+            return false;
+        }
+        // Reject schemes that contain '/' or '?' (those would indicate origin / mixed form).
+        for (int i = 0; i < schemeSep; i++)
+        {
+            char c = raw[i];
+            if (c == '/' || c == '?')
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool IsOptions(HttpMethod method)
+        => string.Equals(method.Value, "OPTIONS", StringComparison.Ordinal);
+
+    private static bool ContainsControlOrSpace(ReadOnlySpan<char> raw, out int index)
+    {
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char c = raw[i];
+            if (c <= 0x1F || c == 0x7F || c == ' ' || c == '\t')
+            {
+                index = i;
+                return true;
+            }
+        }
+        index = -1;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(HttpRequestTarget other)
+        => Form == other.Form
+        && Scheme == other.Scheme
+        && Host.Equals(other.Host)
+        && Path.Equals(other.Path)
+        && string.Equals(Query.Value, other.Query.Value, StringComparison.Ordinal)
+        && string.Equals(RawValue, other.RawValue, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpRequestTarget other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(Form, Scheme, Host, Path, Query.Value, RawValue);
+
+    /// <inheritdoc />
+    public override string ToString() => RawValue;
+
+    public static bool operator ==(HttpRequestTarget left, HttpRequestTarget right) => left.Equals(right);
+    public static bool operator !=(HttpRequestTarget left, HttpRequestTarget right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRequestTargetForm.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRequestTargetForm.cs
@@ -1,0 +1,40 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// One of the four HTTP/1.1 request-target forms defined by RFC 9112 &#167; 3.2.
+/// </summary>
+/// <remarks>
+/// The form a request-target uses depends on the HTTP method and the role of the
+/// recipient (origin server, proxy, tunnel). Validation rules tying methods to forms
+/// (e.g. <see cref="HttpMethod.Connect"/> requires <see cref="Authority"/>) are enforced
+/// by <see cref="HttpRequestTarget.TryParse(System.ReadOnlySpan{char}, HttpMethod, out HttpRequestTarget, out string)"/>.
+/// </remarks>
+public enum HttpRequestTargetForm
+{
+    /// <summary>The request-target has not been parsed or is invalid.</summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// origin-form &#8211; <c>absolute-path [ "?" query ]</c>. The most common form,
+    /// used for direct requests to an origin server.
+    /// </summary>
+    Origin = 1,
+
+    /// <summary>
+    /// absolute-form &#8211; <c>absolute-URI</c>. Used when sending a request to a proxy
+    /// so the proxy knows which origin to forward to.
+    /// </summary>
+    Absolute = 2,
+
+    /// <summary>
+    /// authority-form &#8211; <c>uri-host ":" port</c>. Used only with
+    /// <see cref="HttpMethod.Connect"/> to establish a tunnel.
+    /// </summary>
+    Authority = 3,
+
+    /// <summary>
+    /// asterisk-form &#8211; <c>"*"</c>. Used only with <see cref="HttpMethod.Options"/>
+    /// to address the server itself rather than a specific resource.
+    /// </summary>
+    Asterisk = 4,
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidRequestTargetException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidRequestTargetException.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+internal sealed class HttpInvalidRequestTargetException : HttpException
+{
+    public HttpInvalidRequestTargetException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidRequestTarget;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Shared/ThrowHelper.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Shared/ThrowHelper.cs
@@ -9,4 +9,7 @@ internal static class ThrowHelper
 
     public static void InvalidHttpMethod(string method) =>
         throw new HttpInvalidMethodException($"The provided method is invalid: '{method}'.");
+
+    public static void InvalidHttpRequestTarget(string message) =>
+        throw new HttpInvalidRequestTargetException(message);
 }

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpRequestTargetTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpRequestTargetTests.cs
@@ -1,0 +1,315 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 9112 &#167; 3.2 compliance tests for <see cref="HttpRequestTarget"/>. Covers the
+/// four canonical forms (origin / absolute / authority / asterisk), method/form pairing
+/// rules, and a malformed-input corpus.
+/// </summary>
+public class HttpRequestTargetTests
+{
+    // ============================================================================
+    // origin-form (RFC 9112 §3.2.1)
+    // ============================================================================
+
+    [Theory]
+    [InlineData("/", "/", "")]
+    [InlineData("/index.html", "/index.html", "")]
+    [InlineData("/v1/widgets", "/v1/widgets", "")]
+    [InlineData("/v1/widgets?id=42", "/v1/widgets", "id=42")]
+    [InlineData("/path?a=1&b=2&c=3", "/path", "a=1&b=2&c=3")]
+    [InlineData("/with%20space", "/with%20space", "")]
+    [InlineData("/?", "/", "")]
+    public void OriginForm_ValidTargets_ShouldParse(string raw, string expectedPath, string expectedQuery)
+    {
+        bool ok = HttpRequestTarget.TryParse(raw, HttpMethod.Get, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Origin);
+        target.Path.Value.ShouldBe(expectedPath);
+        target.Query.Value.ShouldBe(expectedQuery);
+        target.Host.ShouldBe(HttpHost.Empty);
+        target.Scheme.ShouldBe(HttpScheme.None);
+        target.RawValue.ShouldBe(raw);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("PATCH")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void OriginForm_AllowedForEveryNonConnectMethod(string methodName)
+    {
+        HttpMethod method = HttpMethod.GetCanonicalizedValue(methodName);
+
+        bool ok = HttpRequestTarget.TryParse("/path", method, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Origin);
+    }
+
+    // ============================================================================
+    // absolute-form (RFC 9112 §3.2.2)
+    // ============================================================================
+
+    [Theory]
+    [InlineData("http://example.com/", HttpScheme.Http, "example.com", "/", "")]
+    [InlineData("https://example.com/", HttpScheme.Https, "example.com", "/", "")]
+    [InlineData("http://example.com/path", HttpScheme.Http, "example.com", "/path", "")]
+    [InlineData("http://example.com:8080/", HttpScheme.Http, "example.com:8080", "/", "")]
+    [InlineData("https://example.com:8443/api?q=1", HttpScheme.Https, "example.com:8443", "/api", "q=1")]
+    [InlineData("http://api.example.com/v1/things?x=1&y=2", HttpScheme.Http, "api.example.com", "/v1/things", "x=1&y=2")]
+    public void AbsoluteForm_ValidTargets_ShouldParse(
+        string raw, HttpScheme expectedScheme, string expectedHost, string expectedPath, string expectedQuery)
+    {
+        bool ok = HttpRequestTarget.TryParse(raw, HttpMethod.Get, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Absolute);
+        target.Scheme.ShouldBe(expectedScheme);
+        target.Host.Value.ShouldBe(expectedHost);
+        target.Path.Value.ShouldBe(expectedPath);
+        target.Query.Value.ShouldBe(expectedQuery);
+        target.RawValue.ShouldBe(raw);
+    }
+
+    [Fact]
+    public void AbsoluteForm_UnsupportedScheme_ShouldFail()
+    {
+        bool ok = HttpRequestTarget.TryParse("ftp://example.com/", HttpMethod.Get, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("ftp");
+    }
+
+    [Fact]
+    public void AbsoluteForm_MissingAuthority_ShouldFail()
+    {
+        // "http:///path" — scheme + "//" + empty authority. URI parser accepts this but
+        // we reject because RFC 9112 §3.2.2 requires a non-empty authority.
+        bool ok = HttpRequestTarget.TryParse("http:///path", HttpMethod.Get, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+
+    // ============================================================================
+    // authority-form (RFC 9112 §3.2.3) — CONNECT only
+    // ============================================================================
+
+    [Theory]
+    [InlineData("example.com:443")]
+    [InlineData("api.example.com:8080")]
+    [InlineData("10.0.0.1:443")]
+    [InlineData("[::1]:8080")]
+    [InlineData("[2001:db8::1]:443")]
+    public void AuthorityForm_ValidConnectTargets_ShouldParse(string raw)
+    {
+        bool ok = HttpRequestTarget.TryParse(raw, HttpMethod.Connect, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Authority);
+        target.Host.Value.ShouldBe(raw);
+        target.Path.ShouldBe(HttpPath.Root);
+        target.Query.Value.ShouldBe(string.Empty);
+        target.Scheme.ShouldBe(HttpScheme.None);
+    }
+
+    [Fact]
+    public void AuthorityForm_WithoutPort_ShouldFail()
+    {
+        bool ok = HttpRequestTarget.TryParse("example.com", HttpMethod.Connect, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("port");
+    }
+
+    [Fact]
+    public void AuthorityForm_NonNumericPort_ShouldFail()
+    {
+        bool ok = HttpRequestTarget.TryParse("example.com:abc", HttpMethod.Connect, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("non-digit");
+    }
+
+    [Fact]
+    public void AuthorityForm_UnmatchedIPv6Bracket_ShouldFail()
+    {
+        bool ok = HttpRequestTarget.TryParse("[::1:8080", HttpMethod.Connect, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("'['");
+    }
+
+    [Fact]
+    public void AuthorityForm_IPv6WithoutPort_ShouldFail()
+    {
+        bool ok = HttpRequestTarget.TryParse("[::1]", HttpMethod.Connect, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("port");
+    }
+
+    [Fact]
+    public void AuthorityForm_OnNonConnectMethod_ShouldFail()
+    {
+        // GET example.com:443 is malformed; CONNECT is the only method that takes
+        // authority-form.
+        bool ok = HttpRequestTarget.TryParse("example.com:443", HttpMethod.Get, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ConnectMethod_WithOriginForm_ShouldFail()
+    {
+        // CONNECT /path HTTP/1.1 is malformed; CONNECT requires authority-form only.
+        bool ok = HttpRequestTarget.TryParse("/path", HttpMethod.Connect, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+        error!.ShouldContain("port");
+    }
+
+    // ============================================================================
+    // asterisk-form (RFC 9112 §3.2.4) — OPTIONS only
+    // ============================================================================
+
+    [Fact]
+    public void AsteriskForm_WithOptions_ShouldParse()
+    {
+        bool ok = HttpRequestTarget.TryParse("*", HttpMethod.Options, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Asterisk);
+        target.RawValue.ShouldBe("*");
+        target.Path.Value.ShouldBe("*");
+        target.Host.ShouldBe(HttpHost.Empty);
+        target.Scheme.ShouldBe(HttpScheme.None);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("HEAD")]
+    [InlineData("CONNECT")]
+    public void AsteriskForm_OnNonOptionsMethod_ShouldFail(string methodName)
+    {
+        HttpMethod method = HttpMethod.GetCanonicalizedValue(methodName);
+
+        bool ok = HttpRequestTarget.TryParse("*", method, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AsteriskForm_StaticConstantMatchesParsed()
+    {
+        HttpRequestTarget parsed = HttpRequestTarget.Parse("*", HttpMethod.Options);
+
+        parsed.ShouldBe(HttpRequestTarget.Asterisk);
+    }
+
+    // ============================================================================
+    // Malformed-target compliance corpus
+    // ============================================================================
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("/path with space")]
+    [InlineData("/path\twith-tab")]
+    [InlineData("/path\rwith-cr")]
+    [InlineData("/path\nwith-lf")]
+    [InlineData("/path with-null")]
+    [InlineData("/pathwith-del")]
+    public void Malformed_TargetsWithControlOrSpace_ShouldFail(string raw)
+    {
+        bool ok = HttpRequestTarget.TryParse(raw, HttpMethod.Get, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData("nope")]                 // bare token — no leading '/' or scheme
+    [InlineData("example.com/path")]     // looks like origin but missing leading '/'
+    [InlineData(":://")]                 // empty scheme
+    [InlineData("http://")]              // scheme + "//" with empty authority
+    public void Malformed_NonStandardForms_ShouldFail(string raw)
+    {
+        bool ok = HttpRequestTarget.TryParse(raw, HttpMethod.Get, out _, out string? error);
+
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void OriginForm_ProtocolRelative_IsValidPath()
+    {
+        // RFC 3986 §3.3 allows empty segments, so "//missing-scheme" is a legitimate
+        // origin-form path even though it looks like a protocol-relative URI. The
+        // server-side application can normalize if it wants stricter handling.
+        bool ok = HttpRequestTarget.TryParse("//missing-scheme", HttpMethod.Get, out HttpRequestTarget target);
+
+        ok.ShouldBeTrue();
+        target.Form.ShouldBe(HttpRequestTargetForm.Origin);
+        target.Path.Value.ShouldBe("//missing-scheme");
+    }
+
+    [Fact]
+    public void Parse_OnMalformedInput_ShouldThrowHttpException()
+    {
+        HttpException ex = Should.Throw<HttpException>(() =>
+            HttpRequestTarget.Parse("", HttpMethod.Get));
+
+        ex.Code.ShouldBe(HttpErrorCode.InvalidRequestTarget);
+    }
+
+    // ============================================================================
+    // Equality + ToString
+    // ============================================================================
+
+    [Fact]
+    public void Equals_ReturnsTrueForIdenticalTargets()
+    {
+        HttpRequestTarget a = HttpRequestTarget.Parse("/api?x=1", HttpMethod.Get);
+        HttpRequestTarget b = HttpRequestTarget.Parse("/api?x=1", HttpMethod.Get);
+
+        a.ShouldBe(b);
+        a.GetHashCode().ShouldBe(b.GetHashCode());
+        (a == b).ShouldBeTrue();
+        (a != b).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForDifferentForms()
+    {
+        HttpRequestTarget origin = HttpRequestTarget.Parse("/api", HttpMethod.Get);
+        HttpRequestTarget absolute = HttpRequestTarget.Parse("http://example.com/api", HttpMethod.Get);
+
+        origin.ShouldNotBe(absolute);
+    }
+
+    [Fact]
+    public void ToString_ReturnsRawValue()
+    {
+        HttpRequestTarget target = HttpRequestTarget.Parse("/v1/widgets?id=42", HttpMethod.Get);
+
+        target.ToString().ShouldBe("/v1/widgets?id=42");
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of the L01.01.11 Foundation - Http epic. Lands a complete request-target parser covering all four canonical forms defined by RFC 9112 §3.2 and wires it into the HTTP/1.1 message reader.

- Closes #328 — Complete HTTP/1.1 request-target parsing
- Closes #347 — origin-form and absolute-form
- Closes #348 — authority-form and asterisk-form
- Closes #349 — malformed request-target compliance corpus + parser failure tests

## What lands

### Public surface

```csharp
namespace Assimalign.Cohesion.Http;

public enum HttpRequestTargetForm { Unknown, Origin, Absolute, Authority, Asterisk }

public readonly struct HttpRequestTarget : IEquatable<HttpRequestTarget>
{
    public HttpRequestTargetForm Form { get; }
    public HttpScheme Scheme { get; }      // Absolute only
    public HttpHost Host { get; }          // Absolute + Authority
    public HttpPath Path { get; }
    public HttpQuery Query { get; }
    public string RawValue { get; }

    public static HttpRequestTarget Asterisk { get; }

    public static bool TryParse(ReadOnlySpan<char>, HttpMethod, out HttpRequestTarget);
    public static bool TryParse(ReadOnlySpan<char>, HttpMethod, out HttpRequestTarget, out string? error);
    public static HttpRequestTarget Parse(ReadOnlySpan<char>, HttpMethod);
}
```

Plus `HttpErrorCode.InvalidRequestTarget` + internal `HttpInvalidRequestTargetException` (via `ThrowHelper.InvalidHttpRequestTarget`).

### Parser rules

| Form | Detection | Method constraint |
|------|-----------|-------------------|
| Origin | starts with \`/\` | not CONNECT |
| Absolute | contains \`://\` after a scheme prefix | not CONNECT |
| Authority | \`host:port\` shape | **CONNECT only** |
| Asterisk | literal \`*\` | **OPTIONS only** |

Rejects: empty target, control characters, whitespace, unsupported schemes (only http/https accepted for absolute-form), empty authority, missing port on authority-form, unmatched IPv6 bracket, non-numeric port digits, wrong method/form pairing.

### `Http1MessageReader` integration

`Http1MessageReader.ReadRequestAsync` now calls `HttpRequestTarget.TryParse(target, method, ...)` and respects each form's semantics:

- **Absolute-form**: authority + scheme on the target supersede the Host header (RFC 9112 §3.2.2). Even a lying Host header is overridden.
- **Authority-form**: the target itself is the request authority (CONNECT).
- **Origin / asterisk**: host comes from the Host header.

Malformed targets surface as `InvalidDataException` from the reader — same shape as malformed request lines.

The stale `ParseQuery` / `ParseOriginFormQuery` helpers in `Http1MessageReader` are deleted. Their ad-hoc `Uri.TryCreate` path is now replaced by the structured parser.

## Tests

**56 new tests in `HttpRequestTargetTests`** (in `Assimalign.Cohesion.Http.Tests`):
- All four happy paths parameterized by Theory
- Method/form pairing rules (CONNECT → authority-only, asterisk → OPTIONS-only, etc.)
- IPv6 authority-form (`[::1]:8080` accepted; `[::1]` and `[::1:8080` rejected)
- Malformed corpus: empty, whitespace, CR/LF/TAB/DEL, unsupported schemes, empty authority, non-CONNECT authority-form
- Equality + hash + ToString contract
- `Parse` throws `HttpException` with `Code == InvalidRequestTarget`

**7 new transport tests in `Http1TransportTests`**:
- Strengthened absolute-form test verifies the target's authority + scheme override the Host header
- New authority-form (CONNECT) test confirms method + host extraction
- New asterisk-form (OPTIONS *) test confirms method + literal path
- 5-row malformed-target Theory rejects: `CONNECT /path`, `GET *`, `GET example.com:80`, empty target, unsupported scheme

**242 tests pass across the Http family in Release**:

| Project | Tests |
|---------|-------|
| Assimalign.Cohesion.Http.Tests | 192 (136 baseline + 56 new) |
| Assimalign.Cohesion.Http.ClientFactory.Tests | 13 |
| Assimalign.Cohesion.Http.Sessions.Tests | 8 |
| Assimalign.Cohesion.Http.Forms.Tests | 7 |
| Assimalign.Cohesion.Http.Transports.Tests | 22 (15 baseline + 7 new) |

## Out of scope

- **HTTP/2 / HTTP/3 paths** still use their own pseudo-header parsing (\`:path\`, \`:authority\`, \`:scheme\`). \`HttpRequestTarget\` is protocol-agnostic and the h2/h3 readers could adopt it for consistency, but that's a follow-up.
- **Path normalization** (RFC 3986 §6). The parser preserves wire bytes as-is; consumers normalize when they want stricter handling.

## Test plan

- [x] All 56 new parser tests pass locally
- [x] All 7 new transport tests pass locally
- [x] Pre-existing 178 tests across the Http family still pass
- [x] Full \`libraries/Http/Assimalign.Cohesion.Http.slnx\` builds + packs + tests in Release with 0 errors
- [ ] CI matrix green on ubuntu / windows / macos for all 5 Http assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)