### PR TITLE
feat(http): RFC 9110 §7.8/§9.3.6 HTTP/1.1 upgrade + CONNECT transitions (L01.01.11 PR5)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpContextSessionExtensionsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpContextSessionExtensionsTests.cs
@@ -86,6 +86,7 @@ public class HttpContextSessionExtensionsTests
         public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
         public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
         public CancellationToken RequestAborted => CancellationToken.None;
+        public IHttpProtocolUpgrade? Upgrade => null;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1ConnectionContext.cs
@@ -41,6 +41,15 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
             throw new System.InvalidOperationException("The supplied context does not belong to an HTTP/1.1 connection.");
         }
 
+        // RFC 9110 §7.8 / §9.3.6 — once a protocol upgrade or CONNECT tunnel has been
+        // accepted, the upgrade implementation has already written the response and
+        // surrendered the stream to the application. Writing again would corrupt the
+        // tunnel with a stale HTTP response.
+        if (http1Context.ResponseFinalized)
+        {
+            return ValueTask.CompletedTask;
+        }
+
         return Http1MessageWriter.WriteResponseAsync(Stream, http1Context, cancellationToken);
     }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1Context.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1Context.cs
@@ -1,14 +1,41 @@
+using System.IO;
 using System.Threading;
 
 namespace Assimalign.Cohesion.Http.Transports.Internal.Http1;
 
 internal sealed class Http1Context : TransportHttpContext
 {
-    public Http1Context(Http1Request request, Http1Response response, IHttpConnectionInfo connectionInfo, CancellationToken requestAborted, bool keepAlive)
+    private readonly Http1ProtocolUpgrade? _upgrade;
+
+    public Http1Context(
+        Http1Request request,
+        Http1Response response,
+        IHttpConnectionInfo connectionInfo,
+        CancellationToken requestAborted,
+        bool keepAlive,
+        Stream? transportStream = null,
+        HttpProtocolUpgradeKind upgradeKind = HttpProtocolUpgradeKind.None,
+        string? upgradeProtocol = null)
         : base(HttpVersion.Http11, request, response, connectionInfo, requestAborted)
     {
         KeepAlive = keepAlive;
+
+        if (upgradeKind != HttpProtocolUpgradeKind.None && transportStream is not null)
+        {
+            _upgrade = new Http1ProtocolUpgrade(this, transportStream, upgradeKind, upgradeProtocol);
+        }
     }
 
     public bool KeepAlive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a flag indicating whether <see cref="Http1ProtocolUpgrade"/> has
+    /// already emitted a response for this exchange. When <see langword="true"/>, the
+    /// connection-level <see cref="Http1ConnectionContext.SendAsync"/> path skips
+    /// writing so the upgrade response is not duplicated on the wire.
+    /// </summary>
+    public bool ResponseFinalized { get; set; }
+
+    /// <inheritdoc />
+    public override IHttpProtocolUpgrade? Upgrade => _upgrade;
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1MessageReader.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1MessageReader.cs
@@ -50,15 +50,34 @@ internal static class Http1MessageReader
         }
 
         HttpHeaderCollection headers = await ReadHeadersAsync(stream, cancellationToken).ConfigureAwait(false);
-        // RFC 9112 §6 / §7 — read the body using the framing rules signalled by the
-        // headers, rejecting ambiguous combinations and malformed Content-Length /
-        // chunked encodings.
-        Http1MessageBody messageBody = await Http1MessageBodyReader.ReadAsync(stream, headers, cancellationToken).ConfigureAwait(false);
-        byte[] bodyBytes = messageBody.Body;
-        // Trailers are parsed (and validated against the smuggling-vector header list)
-        // but not yet exposed on IHttpRequest — that wiring belongs to the .02
-        // field-section work.
-        _ = messageBody.Trailers;
+
+        // RFC 9110 §7.8 / §9.3.6 — classify the transition signal BEFORE consuming any
+        // body bytes. CONNECT in particular MUST NOT consume octets past the request
+        // headers; the bytes that follow belong to the tunnel.
+        (HttpProtocolUpgradeKind upgradeKind, string? upgradeProtocol) = ClassifyUpgrade(method, target, headers);
+
+        byte[] bodyBytes;
+        if (upgradeKind == HttpProtocolUpgradeKind.Connect)
+        {
+            // RFC 9110 §9.3.6 — a CONNECT request body is not framed by Content-Length
+            // or Transfer-Encoding. Anything after the headers is tunnel traffic, so
+            // we hand the application an empty body and let the upgrade hand over the
+            // raw stream when AcceptAsync is invoked.
+            bodyBytes = Array.Empty<byte>();
+        }
+        else
+        {
+            // RFC 9112 §6 / §7 — read the body using the framing rules signalled by the
+            // headers, rejecting ambiguous combinations and malformed Content-Length /
+            // chunked encodings.
+            Http1MessageBody messageBody = await Http1MessageBodyReader.ReadAsync(stream, headers, cancellationToken).ConfigureAwait(false);
+            bodyBytes = messageBody.Body;
+            // Trailers are parsed (and validated against the smuggling-vector header list)
+            // but not yet exposed on IHttpRequest — that wiring belongs to the .02
+            // field-section work.
+            _ = messageBody.Trailers;
+        }
+
         HttpQueryCollection queryCollection = new HttpQuery(target.Query.Value).Parse();
         HttpCookieCollection cookies = ParseCookies(headers);
 
@@ -94,7 +113,71 @@ internal static class Http1MessageReader
 
         bool keepAlive = !HeaderContainsToken(headers, HttpHeaderKey.Connection, "close");
 
-        return new Http1Context(request, response, connectionInfo, cancellationToken, keepAlive);
+        return new Http1Context(
+            request,
+            response,
+            connectionInfo,
+            cancellationToken,
+            keepAlive,
+            stream,
+            upgradeKind,
+            upgradeProtocol);
+    }
+
+    /// <summary>
+    /// Classifies whether the current request is a candidate for a connection
+    /// transition (HTTP/1.1 protocol upgrade or CONNECT tunnel) per RFC 9110 §7.8
+    /// and §9.3.6.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// CONNECT detection requires both the <c>CONNECT</c> method and the authority
+    /// request-target form (RFC 9112 §3.2.3); the request-target parser already
+    /// enforces this pairing, so the check here is defensive.
+    /// </para>
+    /// <para>
+    /// Upgrade detection requires <c>Connection: upgrade</c> (RFC 9110 §7.8.1 —
+    /// the Connection header is what makes Upgrade hop-by-hop and actionable;
+    /// presence of <c>Upgrade</c> alone is informational and is ignored). The
+    /// first protocol token in the <c>Upgrade</c> field is returned; further
+    /// tokens describe fallback preferences and are surfaced through the raw
+    /// header for the application to consult if needed.
+    /// </para>
+    /// </remarks>
+    private static (HttpProtocolUpgradeKind Kind, string? Protocol) ClassifyUpgrade(
+        HttpMethod method,
+        HttpRequestTarget target,
+        HttpHeaderCollection headers)
+    {
+        if (method == HttpMethod.Connect && target.Form == HttpRequestTargetForm.Authority)
+        {
+            return (HttpProtocolUpgradeKind.Connect, null);
+        }
+
+        if (!HeaderContainsToken(headers, HttpHeaderKey.Connection, "upgrade"))
+        {
+            return (HttpProtocolUpgradeKind.None, null);
+        }
+
+        if (!headers.TryGetValue(HttpHeaderKey.Upgrade, out HttpHeaderValue upgradeHeader))
+        {
+            // Connection: upgrade without an Upgrade header is a bare hop-by-hop
+            // signal with no protocol to negotiate — there is nothing to switch to.
+            return (HttpProtocolUpgradeKind.None, null);
+        }
+
+        // The Upgrade field is a comma-separated protocol list; the first token is
+        // the highest-priority protocol the client wants to switch to.
+        string raw = upgradeHeader.Value ?? string.Empty;
+        int comma = raw.IndexOf(',');
+        string firstProtocol = (comma < 0 ? raw : raw[..comma]).Trim();
+
+        if (firstProtocol.Length == 0)
+        {
+            return (HttpProtocolUpgradeKind.None, null);
+        }
+
+        return (HttpProtocolUpgradeKind.Upgrade, firstProtocol);
     }
 
     private static async ValueTask<HttpHeaderCollection> ReadHeadersAsync(Stream stream, CancellationToken cancellationToken)

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1ProtocolUpgrade.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http1/Http1ProtocolUpgrade.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http1;
+
+/// <summary>
+/// HTTP/1.1 implementation of <see cref="IHttpProtocolUpgrade"/>. Owns the response
+/// transition for both <c>Connection: upgrade</c> + <c>Upgrade</c> (101 Switching
+/// Protocols) and <c>CONNECT</c> tunnels (200 OK).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The instance is constructed by <see cref="Http1MessageReader"/> when a request
+/// matches the upgrade or CONNECT signalling rules. <see cref="AcceptAsync"/> may
+/// be invoked at most once per exchange — a second call surfaces as
+/// <see cref="InvalidOperationException"/> instead of producing a second response
+/// on the wire.
+/// </para>
+/// <para>
+/// Acceptance writes the appropriate status line and the connection-specific
+/// response headers (<c>Connection: Upgrade</c> + <c>Upgrade: &lt;protocol&gt;</c>
+/// for an upgrade) and explicitly omits any framing headers (RFC 9110 §9.3.6
+/// forbids <c>Content-Length</c> / <c>Transfer-Encoding</c> on a successful
+/// CONNECT response, and a 1xx response has no body framing of its own). Any
+/// other response headers and cookies the application set on the
+/// <see cref="Http1Response"/> are emitted; the framing-related keys are
+/// scrubbed unconditionally so the tunnel does not start with stale framing
+/// metadata.
+/// </para>
+/// </remarks>
+internal sealed class Http1ProtocolUpgrade : IHttpProtocolUpgrade
+{
+    private static readonly HttpHeaderKey[] ForbiddenResponseHeaders =
+    {
+        HttpHeaderKey.ContentLength,
+        HttpHeaderKey.TransferEncoding,
+    };
+
+    private readonly Http1Context _context;
+    private readonly Stream _stream;
+    private int _accepted;
+
+    public Http1ProtocolUpgrade(
+        Http1Context context,
+        Stream stream,
+        HttpProtocolUpgradeKind kind,
+        string? protocol)
+    {
+        _context = context;
+        _stream = stream;
+        Kind = kind;
+        Protocol = protocol;
+    }
+
+    /// <inheritdoc />
+    public HttpProtocolUpgradeKind Kind { get; }
+
+    /// <inheritdoc />
+    public string? Protocol { get; }
+
+    /// <inheritdoc />
+    public async ValueTask<Stream> AcceptAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _accepted, 1) == 1)
+        {
+            throw new InvalidOperationException(
+                "The protocol upgrade has already been accepted for this exchange.");
+        }
+
+        Http1Response response = (Http1Response)_context.Response;
+        HttpHeaderCollection headers = (HttpHeaderCollection)response.Headers;
+
+        // RFC 9110 §9.3.6 — a successful CONNECT response MUST NOT include
+        // Content-Length or Transfer-Encoding; the tunnel carries opaque octets.
+        // For a 101 the response is body-less by definition, so the same scrub
+        // applies. Strip both unconditionally so neither leaks into the wire.
+        foreach (HttpHeaderKey key in ForbiddenResponseHeaders)
+        {
+            headers.Remove(key);
+        }
+
+        switch (Kind)
+        {
+            case HttpProtocolUpgradeKind.Upgrade:
+                response.StatusCode = HttpStatusCode.SwitchingProtocols;
+                // RFC 9110 §7.8 — a 101 response signals that the connection is
+                // switching to the listed protocol. The Connection header MUST list
+                // Upgrade as a connection-specific token; the Upgrade header MUST
+                // name the accepted protocol.
+                headers[HttpHeaderKey.Connection] = "Upgrade";
+                if (!string.IsNullOrEmpty(Protocol))
+                {
+                    headers[HttpHeaderKey.Upgrade] = Protocol;
+                }
+                break;
+
+            case HttpProtocolUpgradeKind.Connect:
+                if (response.StatusCode.Value == 0)
+                {
+                    response.StatusCode = HttpStatusCode.Ok;
+                }
+                // RFC 9110 §9.3.6 — once the 2xx response is sent, the connection
+                // becomes a tunnel and persists for the lifetime of the request.
+                // We must not advertise close here even though KeepAlive will be
+                // false on the parent context (close applies to HTTP framing, not
+                // the tunnel).
+                headers.Remove(HttpHeaderKey.Connection);
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Cannot accept a protocol upgrade of kind '{Kind}'.");
+        }
+
+        await WriteHeadersAsync(headers, response, cancellationToken).ConfigureAwait(false);
+
+        _context.KeepAlive = false;
+        _context.ResponseFinalized = true;
+        return _stream;
+    }
+
+    private async ValueTask WriteHeadersAsync(
+        HttpHeaderCollection headers,
+        Http1Response response,
+        CancellationToken cancellationToken)
+    {
+        StringBuilder builder = new();
+        // HttpStatusCode has an implicit conversion to int, which would steer the
+        // overload resolution toward StringBuilder.Append(int) and drop the reason
+        // phrase. Explicitly stringify to preserve "101 Switching Protocols" /
+        // "200 Ok" on the status line.
+        builder.Append("HTTP/1.1 ").Append(response.StatusCode.ToString()).Append("\r\n");
+
+        foreach (System.Collections.Generic.KeyValuePair<HttpHeaderKey, HttpHeaderValue> header in headers)
+        {
+            builder.Append(header.Key.ToString())
+                .Append(": ")
+                .Append(header.Value.ToString())
+                .Append("\r\n");
+        }
+
+        foreach (HttpCookie cookie in response.Cookies)
+        {
+            builder.Append(HttpHeaderKey.SetCookie.ToString())
+                .Append(": ")
+                .Append(cookie.ToString())
+                .Append("\r\n");
+        }
+
+        builder.Append("\r\n");
+
+        byte[] bytes = Encoding.ASCII.GetBytes(builder.ToString());
+        await _stream.WriteAsync(bytes.AsMemory(0, bytes.Length), cancellationToken).ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http1TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http1TransportTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -396,6 +397,226 @@ public class Http1TransportTests
             $"POST /upload HTTP/1.1\r\nHost: api.test\r\nContent-Length: {oversize}\r\n\r\n");
 
         await Should.ThrowAsync<InvalidDataException>(async () => await ReceiveFirstContextAsync(payload));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should not expose an upgrade feature on a normal request")]
+    public async Task Http1_OnNormalRequest_UpgradeShouldBeNull()
+    {
+        // A plain request with no Connection: upgrade and no CONNECT method must NOT
+        // expose IHttpProtocolUpgrade — the feature is gated behind explicit wire signals.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should ignore Upgrade header when Connection: upgrade is absent")]
+    public async Task Http1_OnUpgradeHeaderWithoutConnectionUpgrade_ShouldNotExposeUpgrade()
+    {
+        // RFC 9110 §7.8 — the Upgrade header is hop-by-hop and only takes effect when
+        // the connection-specific Connection: upgrade token is also present. A bare
+        // Upgrade header without that activation MUST be ignored.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\nUpgrade: websocket\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should expose Upgrade feature when Connection: upgrade + Upgrade are present")]
+    public async Task Http1_OnUpgradeRequest_ShouldExposeUpgradeFeature()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET /chat HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldNotBeNull();
+        httpContext.Upgrade!.Kind.ShouldBe(HttpProtocolUpgradeKind.Upgrade);
+        httpContext.Upgrade.Protocol.ShouldBe("websocket");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should pick the first protocol from a comma-separated Upgrade list")]
+    public async Task Http1_OnUpgradeRequestWithMultipleProtocols_ShouldPickFirst()
+    {
+        // RFC 9110 §7.8 — the Upgrade field is an ordered list of preferences; the
+        // first token is the protocol the client most wants to switch to.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET /chat HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\nUpgrade: websocket, h2c\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldNotBeNull();
+        httpContext.Upgrade!.Protocol.ShouldBe("websocket");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should ignore Connection: upgrade when Upgrade header is missing or empty")]
+    public async Task Http1_OnConnectionUpgradeWithoutUpgradeHeader_ShouldNotExposeUpgrade()
+    {
+        // Connection: upgrade is the activation token; without an Upgrade header there
+        // is no protocol to switch to, so the transition signal collapses.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET /chat HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should write 101 Switching Protocols and surrender the stream on Upgrade accept")]
+    public async Task Http1_OnUpgradeAccept_ShouldWrite101AndYieldStream()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET /chat HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        IHttpProtocolUpgrade upgrade = httpContext.Upgrade.ShouldNotBeNull();
+        Stream tunnel = await upgrade.AcceptAsync();
+
+        // The application writes its protocol-specific bytes into the tunnel; they
+        // should land on the transport after the 101 response.
+        byte[] tunnelPayload = Encoding.ASCII.GetBytes("ws-frame");
+        await tunnel.WriteAsync(tunnelPayload);
+        await tunnel.FlushAsync();
+
+        string responseText = Encoding.ASCII.GetString(await transportContext.ReadOutputAsync());
+        responseText.ShouldStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+        responseText.ShouldContain("Connection: Upgrade\r\n");
+        responseText.ShouldContain("Upgrade: websocket\r\n");
+        // The 101 response is body-less by definition — no Content-Length or
+        // Transfer-Encoding allowed.
+        responseText.ShouldNotContain("Content-Length:");
+        responseText.ShouldNotContain("Transfer-Encoding:");
+        responseText.ShouldEndWith("ws-frame");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should reject a second Upgrade accept on the same exchange")]
+    public async Task Http1_OnUpgradeAcceptedTwice_ShouldThrow()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        IHttpProtocolUpgrade upgrade = httpContext.Upgrade.ShouldNotBeNull();
+        await upgrade.AcceptAsync();
+
+        await Should.ThrowAsync<System.InvalidOperationException>(async () => await upgrade.AcceptAsync());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should suppress SendAsync after Upgrade accept")]
+    public async Task Http1_OnSendAsyncAfterUpgradeAccept_ShouldNoOp()
+    {
+        // Once the upgrade has emitted its 101 response and handed over the stream,
+        // the connection-level SendAsync MUST NOT write a second HTTP response — that
+        // would corrupt the tunnel.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        await httpContext.Upgrade!.AcceptAsync();
+
+        httpContext.Response.StatusCode = HttpStatusCode.Ok;
+        httpContext.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes("not-tunnel"));
+        await httpConnectionContext.SendAsync(httpContext);
+
+        string responseText = Encoding.ASCII.GetString(await transportContext.ReadOutputAsync());
+        responseText.ShouldStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+        responseText.ShouldNotContain("HTTP/1.1 200");
+        responseText.ShouldNotContain("not-tunnel");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should expose Connect feature on a CONNECT request")]
+    public async Task Http1_OnConnectRequest_ShouldExposeConnectFeature()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "CONNECT origin.example.com:443 HTTP/1.1\r\nHost: origin.example.com:443\r\n\r\n");
+        IHttpContext httpContext = await ReceiveFirstContextAsync(payload);
+
+        httpContext.Upgrade.ShouldNotBeNull();
+        httpContext.Upgrade!.Kind.ShouldBe(HttpProtocolUpgradeKind.Connect);
+        httpContext.Upgrade.Protocol.ShouldBeNull();
+        httpContext.Request.Method.ShouldBe(HttpMethod.Connect);
+        httpContext.Request.Host.Value.ShouldBe("origin.example.com:443");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should write 200 OK with no framing headers on CONNECT accept")]
+    public async Task Http1_OnConnectAccept_ShouldWrite200WithoutFraming()
+    {
+        // RFC 9110 §9.3.6 — a 2xx response to CONNECT MUST NOT include Content-Length
+        // or Transfer-Encoding, because the connection has become an opaque tunnel.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "CONNECT origin.example.com:443 HTTP/1.1\r\nHost: origin.example.com:443\r\n\r\n");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        Stream tunnel = await httpContext.Upgrade!.AcceptAsync();
+        await tunnel.WriteAsync(Encoding.ASCII.GetBytes("upstream-bytes"));
+        await tunnel.FlushAsync();
+
+        string responseText = Encoding.ASCII.GetString(await transportContext.ReadOutputAsync());
+        responseText.ShouldStartWith("HTTP/1.1 200 OK\r\n");
+        responseText.ShouldNotContain("Content-Length:");
+        responseText.ShouldNotContain("Transfer-Encoding:");
+        responseText.ShouldEndWith("upstream-bytes");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http1: Should not consume tunnel octets when reading a CONNECT request")]
+    public async Task Http1_OnConnectRequest_ShouldNotConsumeTunnelOctets()
+    {
+        // RFC 9110 §9.3.6 — the tunnel begins immediately after the CONNECT request
+        // headers. The HTTP/1.1 reader MUST NOT consume any octets past the CRLF
+        // CRLF that terminates the request — they belong to the tunnel.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "CONNECT origin.example.com:443 HTTP/1.1\r\nHost: origin.example.com:443\r\n\r\nCLIENT-TUNNEL-PROBE");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http11, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        // The request body must be empty — CONNECT does not frame a body, and the
+        // reader must not have eaten the tunnel probe bytes as a body.
+        using StreamReader bodyReader = new(httpContext.Request.Body);
+        (await bodyReader.ReadToEndAsync()).ShouldBe(string.Empty);
+
+        // After acceptance, the application can read the tunnel probe bytes that the
+        // client already buffered behind the CONNECT request.
+        Stream tunnel = await httpContext.Upgrade!.AcceptAsync();
+        byte[] probe = new byte[19]; // "CLIENT-TUNNEL-PROBE".Length
+        int read = 0;
+        while (read < probe.Length)
+        {
+            int n = await tunnel.ReadAsync(probe.AsMemory(read, probe.Length - read));
+            if (n == 0)
+            {
+                break;
+            }
+
+            read += n;
+        }
+
+        Encoding.ASCII.GetString(probe, 0, read).ShouldBe("CLIENT-TUNNEL-PROBE");
     }
 
     private static async Task<IHttpContext> ReceiveFirstContextAsync(byte[] payload)

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpContext.cs
@@ -50,4 +50,22 @@ public interface IHttpContext : IAsyncDisposable
     /// Gets the cancellation token that signals when the request has been aborted.
     /// </summary>
     CancellationToken RequestAborted { get; }
+
+    /// <summary>
+    /// Gets the protocol-upgrade feature for this exchange, or <see langword="null"/>
+    /// when the exchange is not a candidate for a connection transition.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A non-null value indicates that the request matches either the RFC 9110 §7.8
+    /// upgrade signal (<c>Connection: upgrade</c> + <c>Upgrade</c>) or the
+    /// RFC 9110 §9.3.6 <c>CONNECT</c> tunnel shape. Inspect
+    /// <see cref="IHttpProtocolUpgrade.Kind"/> to disambiguate.
+    /// </para>
+    /// <para>
+    /// Most exchanges are normal request/response and this property returns
+    /// <see langword="null"/>.
+    /// </para>
+    /// </remarks>
+    IHttpProtocolUpgrade? Upgrade { get; }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpProtocolUpgrade.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpProtocolUpgrade.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Represents an HTTP/1.1 connection transition (protocol upgrade or CONNECT tunnel)
+/// available on the current exchange.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations of this interface are produced by the transport when an incoming
+/// request matches the wire-level conditions for a transition (RFC 9110 §7.8 for
+/// <c>Upgrade</c>, RFC 9110 §9.3.6 + RFC 9112 §3.2.3 for <c>CONNECT</c>). Application
+/// code obtains the feature from <see cref="IHttpContext.Upgrade"/>:
+/// </para>
+/// <code>
+/// if (context.Upgrade is { Kind: HttpProtocolUpgradeKind.Upgrade } upgrade)
+/// {
+///     Stream tunnel = await upgrade.AcceptAsync(context.RequestAborted);
+///     // ...use tunnel...
+/// }
+/// </code>
+/// <para>
+/// Calling <see cref="AcceptAsync"/> writes the appropriate status line
+/// (<c>101 Switching Protocols</c> for an Upgrade, <c>200 OK</c> for a CONNECT) and
+/// any required <c>Connection</c> / <c>Upgrade</c> response headers, then surrenders
+/// the underlying transport stream to the caller. After acceptance, the regular
+/// response pipeline is suppressed — calling
+/// <see cref="IHttpConnectionContext.SendAsync"/> for the same exchange becomes a
+/// no-op so the framework does not double-write the response.
+/// </para>
+/// </remarks>
+public interface IHttpProtocolUpgrade
+{
+    /// <summary>
+    /// Gets the kind of transition the request is asking for.
+    /// </summary>
+    HttpProtocolUpgradeKind Kind { get; }
+
+    /// <summary>
+    /// Gets the protocol token requested for an <see cref="HttpProtocolUpgradeKind.Upgrade"/>
+    /// transition (for example <c>"websocket"</c>). Returns <see langword="null"/>
+    /// for <see cref="HttpProtocolUpgradeKind.Connect"/>.
+    /// </summary>
+    string? Protocol { get; }
+
+    /// <summary>
+    /// Accepts the transition. Writes the appropriate status response and returns
+    /// the underlying duplex transport stream so the caller can read and write
+    /// raw bytes for the negotiated protocol or tunneled connection.
+    /// </summary>
+    /// <param name="cancellationToken">A token that signals when acceptance should
+    /// be cancelled.</param>
+    /// <returns>The duplex transport stream. The caller assumes ownership and is
+    /// responsible for closing it when the transition completes.</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown when the
+    /// transition has already been accepted on this exchange.</exception>
+    ValueTask<Stream> AcceptAsync(CancellationToken cancellationToken = default);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpContext.cs
@@ -32,6 +32,9 @@ public abstract class HttpContext : IHttpContext
     public abstract CancellationToken RequestAborted { get; }
 
     /// <inheritdoc />
+    public virtual IHttpProtocolUpgrade? Upgrade => null;
+
+    /// <inheritdoc />
     public abstract ValueTask DisposeAsync();
 
     IHttpRequest IHttpContext.Request => Request;

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpProtocolUpgradeKind.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpProtocolUpgradeKind.cs
@@ -1,0 +1,46 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Identifies the kind of HTTP/1.1 connection transition signalled by a request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// HTTP/1.1 defines two ways for a single connection to leave the request/response
+/// loop and become something else:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="Upgrade"/> — the request carries
+///   <c>Connection: upgrade</c> together with an <c>Upgrade</c> header listing a
+///   protocol token (RFC 9110 §7.8). When the server accepts, it responds with
+///   <c>101 Switching Protocols</c> and the connection becomes the negotiated
+///   protocol.</description></item>
+///   <item><description><see cref="Connect"/> — the request uses the
+///   <c>CONNECT</c> method with an authority-form request-target (RFC 9112 §3.2.3
+///   and RFC 9110 §9.3.6). When the server accepts, it responds with a 2xx and the
+///   connection becomes a tunnel carrying opaque octets between the client and the
+///   target authority.</description></item>
+/// </list>
+/// <para>
+/// <see cref="None"/> means the request is a normal request/response exchange and
+/// no transition is available.
+/// </para>
+/// </remarks>
+public enum HttpProtocolUpgradeKind
+{
+    /// <summary>
+    /// No connection transition is available for the current exchange.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The request asked for a protocol upgrade through <c>Connection: upgrade</c>
+    /// and the <c>Upgrade</c> header. Accepting writes <c>101 Switching Protocols</c>.
+    /// </summary>
+    Upgrade = 1,
+
+    /// <summary>
+    /// The request used the <c>CONNECT</c> method to open a tunnel to an authority.
+    /// Accepting writes a 2xx response and the connection becomes opaque.
+    /// </summary>
+    Connect = 2,
+}


### PR DESCRIPTION
PR 5 of the L01.01.11 Foundation - Http epic. Models HTTP/1.1 protocol-upgrade (101 Switching Protocols) and CONNECT tunnel transitions explicitly so the transport can hand the application a raw duplex stream once the request/response loop ends.

Closes #330 [.05].

## Summary

- New `IHttpProtocolUpgrade` feature on `IHttpContext.Upgrade` — non-null when the request matches an Upgrade or CONNECT wire signal.
- `Http1MessageReader` classifies the transition (CONNECT vs Upgrade) before body framing; CONNECT skips body reading so post-header octets stay in the tunnel.
- `Http1ProtocolUpgrade.AcceptAsync` writes `101 Switching Protocols` / `200 OK`, scrubs framing headers, and surrenders the raw duplex stream.
- After acceptance, `SendAsync` is a no-op and the receive loop exits.
- 11 new tests covering detection, acceptance, double-accept, framing-header scrubbing, tunnel-octet preservation, and SendAsync suppression.

## RFC coverage

| Behavior | RFC | Implementation |
|----------|-----|----------------|
| `Upgrade` requires `Connection: upgrade` activation | §7.8.1 | bare `Upgrade:` header is ignored |
| `CONNECT` requires authority-form target | §9.3.6 / §3.2.3 | enforced by request-target parser; classifier checks again |
| First `Upgrade` token wins | §7.8 | classifier splits comma list and trims |
| CONNECT body is not framed | §9.3.6 | body reader bypassed; tunnel octets stay on wire |
| 101 response carries `Connection: Upgrade` + `Upgrade: <proto>` | §7.8 | `AcceptAsync` sets both headers |
| 2xx CONNECT MUST NOT include `Content-Length` / `Transfer-Encoding` | §9.3.6 | scrubbed unconditionally before writing |
| Single-use accept | (idempotency) | `Interlocked.Exchange` guard |
| No double-write after upgrade | (correctness) | `ResponseFinalized` gates `Http1ConnectionContext.SendAsync` |

## Application surface

```csharp
if (context.Upgrade is { Kind: HttpProtocolUpgradeKind.Upgrade } upgrade
    && upgrade.Protocol == "websocket")
{
    Stream tunnel = await upgrade.AcceptAsync(context.RequestAborted);
    // ...drive the WebSocket protocol over `tunnel`...
}

if (context.Upgrade is { Kind: HttpProtocolUpgradeKind.Connect } connect)
{
    Stream tunnel = await connect.AcceptAsync(context.RequestAborted);
    // ...bridge `tunnel` to the upstream authority...
}
```

The duplex `Stream` is the actual transport pipe, so reads see exactly the bytes the client has already buffered after the CONNECT request and writes go straight onto the wire.

## Out of scope

- HTTP/2 extended CONNECT (RFC 8441) — `Http2Context` / `Http3Context` inherit the abstract default that returns `null`. Wiring those is a follow-up.
- Per-application protocol allowlists or WebSocket key-exchange helpers (`Sec-WebSocket-Accept`) — those layer above the transport. PR 5 hands over the raw stream; protocol-specific handshakes are application code.

## Test plan

- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http.Transports/tests/...csproj -c Release` → 56/56
- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http/tests/...csproj -c Release` → 192/192
- [x] Sessions / Forms / ClientFactory tests still pass → 28/28
- [x] CI green across ubuntu / windows / macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)