### PR TITLE
feat(http): RFC 9113 §3.4/§6.5 HTTP/2 preface + SETTINGS engine (L01.01.11 PR1 — HTTP/2)

### DIFF
--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -29,16 +29,16 @@
 	<!-- #endregion -->
 
 	<!-- #region Packaging (Nuget): README-->
-	<PropertyGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md')">
+	<PropertyGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md') and $([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\README.md')) != ''">
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	<ItemGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md')">
+	<ItemGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md') and $([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\README.md')) != ''">
 		<None Include="..\README.md">
 			<Pack>true</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
-	
+
 	<!-- #endregion -->
 
 	<!-- #region Packaging (Nuget): License File -->

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Exceptions/Http2ConnectionException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Exceptions/Http2ConnectionException.cs
@@ -1,9 +1,20 @@
 namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
 
-internal class Http2ConnectionException : HttpException
+/// <summary>
+/// Connection-level HTTP/2 protocol error. The error code travels back
+/// to the peer in a <c>GOAWAY</c> frame before the underlying transport
+/// is torn down (RFC 9113 §6.8).
+/// </summary>
+internal sealed class Http2ConnectionException : HttpException
 {
-    public Http2ConnectionException(string message)
+    public Http2ConnectionException(Http2ErrorCode errorCode, string message)
         : base(message)
     {
+        ErrorCode = errorCode;
     }
+
+    /// <summary>
+    /// The error code carried in the outbound <c>GOAWAY</c> frame.
+    /// </summary>
+    public Http2ErrorCode ErrorCode { get; }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
@@ -18,17 +18,24 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
     private readonly HPackDecoder _headerDecoder;
     private readonly Dictionary<int, Http2Stream> _streams;
+    // RFC 9113 §6.5 — local settings are what we (the server) advertised
+    // to the peer; remote settings are what the peer advertised to us.
+    // Inbound frame parsing is bounded by the local cap; outbound frame
+    // writing is bounded by the remote cap.
+    private readonly Http2ConnectionSettings _localSettings;
+    private readonly Http2ConnectionSettings _remoteSettings;
     private int? _continuationStreamId;
     private bool _initialized;
     private bool _receivedClientSettings;
-    private uint _maxFrameSize;
+    private int _lastInboundStreamId;
 
     public Http2ConnectionContext(ITransportConnectionContext transportContext, bool isSecure)
         : base(transportContext, isSecure)
     {
         _headerDecoder = new HPackDecoder();
         _streams = new Dictionary<int, Http2Stream>();
-        _maxFrameSize = 16_384;
+        _localSettings = BuildLocalSettings();
+        _remoteSettings = new Http2ConnectionSettings();
     }
 
     public override async IAsyncEnumerable<IHttpContext> ReceiveAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -37,14 +44,35 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            ReceivedFrame? receivedFrame = await ReadFrameAsync(Stream, _maxFrameSize, cancellationToken).ConfigureAwait(false);
+            ReceivedFrame? receivedFrame;
+            try
+            {
+                receivedFrame = await ReadFrameAsync(Stream, _localSettings.MaxFrameSize, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Http2ConnectionException error)
+            {
+                await EmitGoAwayAsync(error.ErrorCode, cancellationToken).ConfigureAwait(false);
+                throw;
+            }
 
             if (receivedFrame is null)
             {
                 yield break;
             }
 
-            Http2Context? completedContext = await ProcessFrameAsync(receivedFrame.Value, cancellationToken).ConfigureAwait(false);
+            Http2Context? completedContext;
+            try
+            {
+                completedContext = await ProcessFrameAsync(receivedFrame.Value, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Http2ConnectionException error)
+            {
+                // RFC 9113 §6.8 — every connection-level failure MUST be
+                // signalled to the peer with a GOAWAY carrying the offending
+                // error code, before the underlying transport is torn down.
+                await EmitGoAwayAsync(error.ErrorCode, cancellationToken).ConfigureAwait(false);
+                throw;
+            }
 
             if (completedContext is not null)
             {
@@ -77,16 +105,28 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
             return;
         }
 
+        // RFC 9113 §3.4 — the connection preface MUST appear before any
+        // other client data. A mismatch is a connection error with code
+        // PROTOCOL_ERROR.
         byte[] preface = await ReadExactOrThrowAsync(Stream, ClientPreface.Length, cancellationToken).ConfigureAwait(false);
 
         if (!preface.AsSpan().SequenceEqual(ClientPreface))
         {
-            throw new InvalidDataException("The HTTP/2 connection preface is invalid.");
+            await EmitGoAwayAsync(Http2ErrorCode.ProtocolError, cancellationToken).ConfigureAwait(false);
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "The HTTP/2 connection preface did not match the expected sequence.");
         }
 
+        // RFC 9113 §3.4 + §6.5 — immediately after sending or receiving
+        // the preface, both peers send a SETTINGS frame (possibly empty)
+        // as the first connection frame. We advertise the parameters
+        // built from our local defaults instead of an empty payload so
+        // the peer sees what we actually want.
+        byte[] settingsPayload = EncodeLocalSettings();
         Http2Frame settingsFrame = new();
         settingsFrame.PrepareSettings(Http2SettingsFrameFlags.None);
-        await Http2FrameWriter.WriteAsync(Stream, settingsFrame, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+        await Http2FrameWriter.WriteAsync(Stream, settingsFrame, settingsPayload, cancellationToken).ConfigureAwait(false);
         await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         _initialized = true;
@@ -94,9 +134,20 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
     private async Task<Http2Context?> ProcessFrameAsync(ReceivedFrame receivedFrame, CancellationToken cancellationToken)
     {
+        // RFC 9113 §3.4 — the first frame the client sends after the
+        // preface MUST be SETTINGS. Anything else is a PROTOCOL_ERROR.
+        if (!_receivedClientSettings && receivedFrame.Frame.Type != Http2FrameType.Settings)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"Expected the HTTP/2 client SETTINGS frame as the first frame after the preface, but received '{receivedFrame.Frame.Type}'.");
+        }
+
         if (_continuationStreamId.HasValue && receivedFrame.Frame.Type != Http2FrameType.Continuation)
         {
-            throw new InvalidDataException("Expected an HTTP/2 CONTINUATION frame before receiving another frame type.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "Expected an HTTP/2 CONTINUATION frame before receiving another frame type.");
         }
 
         switch (receivedFrame.Frame.Type)
@@ -127,22 +178,57 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
     private async Task ProcessSettingsFrameAsync(ReceivedFrame receivedFrame, CancellationToken cancellationToken)
     {
+        // RFC 9113 §6.5.1 — SETTINGS frames MUST be sent on stream 0.
         if (receivedFrame.Frame.StreamId != 0)
         {
-            throw new InvalidDataException("The HTTP/2 SETTINGS frame must be sent on stream 0.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"SETTINGS frame received on stream {receivedFrame.Frame.StreamId}; SETTINGS frames MUST use stream 0.");
         }
 
         if (receivedFrame.Frame.SettingsAck)
         {
+            // RFC 9113 §6.5 — an ACK frame MUST have an empty payload. A
+            // non-empty payload is a connection error with code
+            // FRAME_SIZE_ERROR.
+            if (receivedFrame.Payload.Length != 0)
+            {
+                throw new Http2ConnectionException(
+                    Http2ErrorCode.FrameSizeError,
+                    $"SETTINGS ACK frame must have an empty payload, but received {receivedFrame.Payload.Length} octets.");
+            }
+
             return;
         }
 
-        foreach (Http2PeerSetting setting in Http2FrameReader.ReadSettings(new ReadOnlySequence<byte>(receivedFrame.Payload)))
+        // RFC 9113 §6.5.1 — a non-ACK SETTINGS frame's payload must be a
+        // multiple of 6 octets (each setting is 16-bit identifier + 32-bit
+        // value). A non-multiple is a FRAME_SIZE_ERROR.
+        if (receivedFrame.Payload.Length % Http2FrameReader.SettingSize != 0)
         {
-            if (setting.Parameter == Http2SettingsParameter.SETTINGS_MAX_FRAME_SIZE)
+            throw new Http2ConnectionException(
+                Http2ErrorCode.FrameSizeError,
+                $"SETTINGS frame payload of {receivedFrame.Payload.Length} octets is not a multiple of {Http2FrameReader.SettingSize}.");
+        }
+
+        // Validate every parameter before applying any. RFC 9113 §6.5.2
+        // — an invalid value is a connection error with the per-parameter
+        // code listed in the spec (PROTOCOL_ERROR or FLOW_CONTROL_ERROR).
+        System.Collections.Generic.IList<Http2PeerSetting> settings =
+            Http2FrameReader.ReadSettings(new ReadOnlySequence<byte>(receivedFrame.Payload));
+
+        foreach (Http2PeerSetting setting in settings)
+        {
+            (Http2ErrorCode errorCode, string? message) = Http2ConnectionSettings.Validate(setting);
+            if (errorCode != Http2ErrorCode.NoError)
             {
-                _maxFrameSize = setting.Value;
+                throw new Http2ConnectionException(errorCode, message ?? $"Invalid HTTP/2 SETTINGS value for {setting.Parameter}.");
             }
+        }
+
+        foreach (Http2PeerSetting setting in settings)
+        {
+            _remoteSettings.Apply(setting);
         }
 
         _receivedClientSettings = true;
@@ -157,10 +243,13 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
     {
         if (!_receivedClientSettings)
         {
-            throw new InvalidDataException("The HTTP/2 client SETTINGS frame must be received before HEADERS.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "The HTTP/2 client SETTINGS frame must be received before HEADERS.");
         }
 
         Http2Frame frame = receivedFrame.Frame;
+        _lastInboundStreamId = Math.Max(_lastInboundStreamId, frame.StreamId);
         Http2Stream stream = GetOrCreateStream(frame.StreamId);
         stream.AppendHeaders(receivedFrame.Payload, frame.HeadersEndHeaders);
 
@@ -182,7 +271,9 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
     {
         if (_continuationStreamId is null || _continuationStreamId.Value != receivedFrame.Frame.StreamId)
         {
-            throw new InvalidDataException("The HTTP/2 CONTINUATION frame did not match the active header block stream.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "The HTTP/2 CONTINUATION frame did not match the active header block stream.");
         }
 
         Http2Stream stream = GetOrCreateStream(receivedFrame.Frame.StreamId);
@@ -200,7 +291,9 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
     {
         if (!_streams.TryGetValue(receivedFrame.Frame.StreamId, out Http2Stream? stream))
         {
-            throw new InvalidDataException("The HTTP/2 DATA frame was received for an unknown stream.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "The HTTP/2 DATA frame was received for an unknown stream.");
         }
 
         stream.AppendBody(receivedFrame.Payload, receivedFrame.Frame.DataEndStream);
@@ -250,7 +343,7 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         do
         {
             int remaining = headerBlock.Length - offset;
-            int chunkLength = remaining > 0 ? Math.Min((int)_maxFrameSize, remaining) : 0;
+            int chunkLength = remaining > 0 ? Math.Min((int)_remoteSettings.MaxFrameSize, remaining) : 0;
             Http2Frame frame = new();
 
             if (firstFrame)
@@ -289,7 +382,7 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
         while (offset < bodyBytes.Length)
         {
-            int chunkLength = Math.Min((int)_maxFrameSize, bodyBytes.Length - offset);
+            int chunkLength = Math.Min((int)_remoteSettings.MaxFrameSize, bodyBytes.Length - offset);
             Http2Frame frame = new();
             frame.PrepareData(streamId);
 
@@ -362,6 +455,17 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         }
 
         int payloadLength = (header[0] << 16) | (header[1] << 8) | header[2];
+
+        // RFC 9113 §4.2 — a frame whose length exceeds the receiver's
+        // advertised MAX_FRAME_SIZE is a connection error with code
+        // FRAME_SIZE_ERROR.
+        if (payloadLength > maxFrameSize)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.FrameSizeError,
+                $"HTTP/2 frame payload length {payloadLength} exceeded the advertised maximum {maxFrameSize}.");
+        }
+
         byte[] buffer = new byte[Http2FrameReader.HeaderLength + payloadLength];
         Buffer.BlockCopy(header, 0, buffer, 0, header.Length);
 
@@ -376,10 +480,89 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
         if (!Http2FrameReader.TryReadFrame(ref sequence, frame, maxFrameSize, out ReadOnlySequence<byte> payloadSequence))
         {
-            throw new InvalidDataException("The HTTP/2 frame could not be parsed from the buffered payload.");
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "The HTTP/2 frame could not be parsed from the buffered payload.");
         }
 
         return new ReceivedFrame(frame, payloadSequence.IsEmpty ? Array.Empty<byte>() : payloadSequence.ToArray());
+    }
+
+    /// <summary>
+    /// Emits a <c>GOAWAY</c> frame on stream 0 carrying
+    /// <paramref name="errorCode"/> and the highest stream ID we have
+    /// observed so far (RFC 9113 §6.8). The receive loop then propagates
+    /// the exception so the listener can tear the connection down.
+    /// </summary>
+    private async Task EmitGoAwayAsync(Http2ErrorCode errorCode, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Http2Frame goAway = new();
+            goAway.PrepareGoAway(_lastInboundStreamId, errorCode);
+            await Http2FrameWriter.WriteAsync(Stream, goAway, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort: if the wire is already dead we can't deliver
+            // the GOAWAY. The connection error will still surface to the
+            // listener through the original exception.
+        }
+    }
+
+    /// <summary>
+    /// Builds the explicit server-side initial <see cref="Http2ConnectionSettings"/>
+    /// we advertise to peers. The defaults mostly track the RFC 9113
+    /// initial values except for ENABLE_PUSH (0 — Cohesion does not
+    /// implement server push) and MAX_HEADER_LIST_SIZE (a 16 KB DoS
+    /// guard instead of "unlimited").
+    /// </summary>
+    private static Http2ConnectionSettings BuildLocalSettings()
+    {
+        return new Http2ConnectionSettings
+        {
+            HeaderTableSize = Http2ConnectionSettings.InitialHeaderTableSize,
+            EnablePush = 0,
+            MaxConcurrentStreams = 100,
+            InitialWindowSize = Http2ConnectionSettings.InitialInitialWindowSize,
+            MaxFrameSize = Http2ConnectionSettings.InitialMaxFrameSize,
+            MaxHeaderListSize = 16_384,
+            EnableConnectProtocol = 0,
+        };
+    }
+
+    /// <summary>
+    /// Serialises <see cref="_localSettings"/> as a SETTINGS-frame
+    /// payload (6 octets per parameter; identifier first, then value;
+    /// both big-endian per RFC 9113 §6.5.1).
+    /// </summary>
+    private byte[] EncodeLocalSettings()
+    {
+        // Six parameters that change from the spec's initial values OR are
+        // explicit choices we want the peer to see. We emit all of them
+        // every time so the peer never has to guess our intent.
+        (Http2SettingsParameter Parameter, uint Value)[] entries =
+        {
+            (Http2SettingsParameter.SETTINGS_HEADER_TABLE_SIZE, _localSettings.HeaderTableSize),
+            (Http2SettingsParameter.SETTINGS_ENABLE_PUSH, _localSettings.EnablePush),
+            (Http2SettingsParameter.SETTINGS_MAX_CONCURRENT_STREAMS, _localSettings.MaxConcurrentStreams),
+            (Http2SettingsParameter.SETTINGS_INITIAL_WINDOW_SIZE, _localSettings.InitialWindowSize),
+            (Http2SettingsParameter.SETTINGS_MAX_FRAME_SIZE, _localSettings.MaxFrameSize),
+            (Http2SettingsParameter.SETTINGS_MAX_HEADER_LIST_SIZE, _localSettings.MaxHeaderListSize),
+        };
+
+        byte[] payload = new byte[entries.Length * Http2FrameReader.SettingSize];
+        Span<byte> span = payload;
+
+        for (int index = 0; index < entries.Length; index++)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(span, (ushort)entries[index].Parameter);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(span.Slice(2), entries[index].Value);
+            span = span.Slice(Http2FrameReader.SettingSize);
+        }
+
+        return payload;
     }
 
     private readonly struct ReceivedFrame

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionSettings.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionSettings.cs
@@ -1,0 +1,177 @@
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
+
+/// <summary>
+/// Snapshot of an HTTP/2 endpoint's negotiated SETTINGS parameters
+/// (RFC 9113 §6.5.2 + RFC 8441 §3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two instances live on every connection: one tracks the parameters
+/// <em>we</em> advertised to the peer (the server's local settings), the
+/// other tracks the parameters the peer advertised to <em>us</em> (the
+/// client's remote settings). The remote settings govern how we write
+/// outbound frames (max frame size, max header list size); the local
+/// settings govern how we read inbound frames (the maximum we will
+/// accept).
+/// </para>
+/// <para>
+/// Unknown setting identifiers MUST be ignored per RFC 9113 §6.5.2 so
+/// new parameters defined by future extensions do not cause connection
+/// failure. <see cref="TryApply"/> implements that rule along with the
+/// per-parameter range checks defined by the spec.
+/// </para>
+/// </remarks>
+internal sealed class Http2ConnectionSettings
+{
+    /// <summary>Default HEADER_TABLE_SIZE (RFC 9113 §6.5.2).</summary>
+    public const uint InitialHeaderTableSize = 4096;
+
+    /// <summary>Default ENABLE_PUSH (RFC 9113 §6.5.2). 1 = enabled.</summary>
+    public const uint InitialEnablePush = 1;
+
+    /// <summary>
+    /// Default MAX_CONCURRENT_STREAMS (RFC 9113 §6.5.2). The spec uses
+    /// "no limit" as the default; <see cref="uint.MaxValue"/> is the
+    /// sentinel.
+    /// </summary>
+    public const uint InitialMaxConcurrentStreams = uint.MaxValue;
+
+    /// <summary>Default INITIAL_WINDOW_SIZE (RFC 9113 §6.5.2).</summary>
+    public const uint InitialInitialWindowSize = 65535;
+
+    /// <summary>
+    /// Default MAX_FRAME_SIZE (RFC 9113 §6.5.2). Equal to the minimum
+    /// the spec allows endpoints to advertise.
+    /// </summary>
+    public const uint InitialMaxFrameSize = 16_384;
+
+    /// <summary>
+    /// Default MAX_HEADER_LIST_SIZE (RFC 9113 §6.5.2). The spec uses
+    /// "unlimited" as the default; <see cref="uint.MaxValue"/> is the
+    /// sentinel.
+    /// </summary>
+    public const uint InitialMaxHeaderListSize = uint.MaxValue;
+
+    /// <summary>Default ENABLE_CONNECT_PROTOCOL (RFC 8441 §3). 0 = disabled.</summary>
+    public const uint InitialEnableConnectProtocol = 0;
+
+    /// <summary>Minimum legal MAX_FRAME_SIZE (RFC 9113 §6.5.2). 2^14.</summary>
+    public const uint MinMaxFrameSize = 16_384;
+
+    /// <summary>Maximum legal MAX_FRAME_SIZE (RFC 9113 §6.5.2). 2^24 - 1.</summary>
+    public const uint MaxMaxFrameSize = 16_777_215;
+
+    /// <summary>Maximum legal INITIAL_WINDOW_SIZE (RFC 9113 §6.5.2). 2^31 - 1.</summary>
+    public const uint MaxInitialWindowSize = int.MaxValue;
+
+    /// <summary>HEADER_TABLE_SIZE — HPACK dynamic table cap advertised to the peer.</summary>
+    public uint HeaderTableSize { get; set; } = InitialHeaderTableSize;
+
+    /// <summary>ENABLE_PUSH — server push toggle. Must be 0 or 1.</summary>
+    public uint EnablePush { get; set; } = InitialEnablePush;
+
+    /// <summary>MAX_CONCURRENT_STREAMS — peer's max concurrent stream cap.</summary>
+    public uint MaxConcurrentStreams { get; set; } = InitialMaxConcurrentStreams;
+
+    /// <summary>
+    /// INITIAL_WINDOW_SIZE — initial flow-control window for new streams.
+    /// Must not exceed <see cref="MaxInitialWindowSize"/>.
+    /// </summary>
+    public uint InitialWindowSize { get; set; } = InitialInitialWindowSize;
+
+    /// <summary>
+    /// MAX_FRAME_SIZE — largest frame payload the peer accepts. Must lie
+    /// in [<see cref="MinMaxFrameSize"/>, <see cref="MaxMaxFrameSize"/>].
+    /// </summary>
+    public uint MaxFrameSize { get; set; } = InitialMaxFrameSize;
+
+    /// <summary>MAX_HEADER_LIST_SIZE — advisory cap on uncompressed header list size.</summary>
+    public uint MaxHeaderListSize { get; set; } = InitialMaxHeaderListSize;
+
+    /// <summary>ENABLE_CONNECT_PROTOCOL — RFC 8441 extended CONNECT toggle. Must be 0 or 1.</summary>
+    public uint EnableConnectProtocol { get; set; } = InitialEnableConnectProtocol;
+
+    /// <summary>
+    /// Validates a single peer-advertised setting per RFC 9113 §6.5.2
+    /// and RFC 8441 §3 without applying it. Returns
+    /// <see cref="Http2ErrorCode.NoError"/> on success.
+    /// </summary>
+    /// <remarks>
+    /// Unknown parameter IDs return <see cref="Http2ErrorCode.NoError"/>
+    /// per RFC 9113 §6.5.2 — they MUST be ignored, not rejected, so
+    /// future settings defined by extensions do not break this endpoint.
+    /// </remarks>
+    public static (Http2ErrorCode ErrorCode, string? Message) Validate(in Http2PeerSetting setting)
+    {
+        switch (setting.Parameter)
+        {
+            case Http2SettingsParameter.SETTINGS_ENABLE_PUSH:
+                if (setting.Value > 1)
+                {
+                    return (Http2ErrorCode.ProtocolError,
+                        $"SETTINGS_ENABLE_PUSH must be 0 or 1; got {setting.Value}.");
+                }
+                break;
+
+            case Http2SettingsParameter.SETTINGS_INITIAL_WINDOW_SIZE:
+                if (setting.Value > MaxInitialWindowSize)
+                {
+                    return (Http2ErrorCode.FlowControlError,
+                        $"SETTINGS_INITIAL_WINDOW_SIZE must not exceed {MaxInitialWindowSize}; got {setting.Value}.");
+                }
+                break;
+
+            case Http2SettingsParameter.SETTINGS_MAX_FRAME_SIZE:
+                if (setting.Value < MinMaxFrameSize || setting.Value > MaxMaxFrameSize)
+                {
+                    return (Http2ErrorCode.ProtocolError,
+                        $"SETTINGS_MAX_FRAME_SIZE must be in [{MinMaxFrameSize}, {MaxMaxFrameSize}]; got {setting.Value}.");
+                }
+                break;
+
+            case Http2SettingsParameter.SETTINGS_ENABLE_CONNECT_PROTOCOL:
+                if (setting.Value > 1)
+                {
+                    return (Http2ErrorCode.ProtocolError,
+                        $"SETTINGS_ENABLE_CONNECT_PROTOCOL must be 0 or 1; got {setting.Value}.");
+                }
+                break;
+        }
+
+        return (Http2ErrorCode.NoError, null);
+    }
+
+    /// <summary>
+    /// Applies a peer setting to this snapshot. Caller MUST have already
+    /// validated the setting via <see cref="Validate"/>. Unknown
+    /// parameter IDs are silently ignored per RFC 9113 §6.5.2.
+    /// </summary>
+    public void Apply(in Http2PeerSetting setting)
+    {
+        switch (setting.Parameter)
+        {
+            case Http2SettingsParameter.SETTINGS_HEADER_TABLE_SIZE:
+                HeaderTableSize = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_ENABLE_PUSH:
+                EnablePush = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_MAX_CONCURRENT_STREAMS:
+                MaxConcurrentStreams = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_INITIAL_WINDOW_SIZE:
+                InitialWindowSize = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_MAX_FRAME_SIZE:
+                MaxFrameSize = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_MAX_HEADER_LIST_SIZE:
+                MaxHeaderListSize = setting.Value;
+                break;
+            case Http2SettingsParameter.SETTINGS_ENABLE_CONNECT_PROTOCOL:
+                EnableConnectProtocol = setting.Value;
+                break;
+            // Unknown parameter IDs are intentionally ignored (RFC 9113 §6.5.2).
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Properties/AssemblyInfo.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Assimalign.Cohesion.Http.Transports.Tests")]

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Assimalign.Cohesion.Http.Transports.Internal.Http2;
 using Assimalign.Cohesion.Http.Transports.Tests.TestObjects;
 using Assimalign.Cohesion.Transports;
 
@@ -176,6 +177,198 @@ public class Http2TransportTests
         observedPaths.Count.ShouldBe(2);
         observedPaths[0].ShouldBe("/one");
         observedPaths[1].ShouldBe("/two");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should advertise explicit server SETTINGS after the preface")]
+    public async Task Http2_OnInitialization_ShouldEmitExplicitServerSettings()
+    {
+        // RFC 9113 §3.4 — the server's first frame after the preface MUST be a
+        // SETTINGS frame. We advertise our local defaults so the peer never has
+        // to guess; the most important one is ENABLE_PUSH=0 because the server
+        // does not implement push.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+        httpContext.Response.StatusCode = HttpStatusCode.Ok;
+        await httpConnectionContext.SendAsync(httpContext);
+
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(await transportContext.ReadOutputAsync());
+
+        // First frame must be the server SETTINGS (frame type 0x4).
+        frames.Count.ShouldBeGreaterThanOrEqualTo(1);
+        frames[0].FrameType.ShouldBe(4);
+        (frames[0].Payload.Length % 6).ShouldBe(0);
+
+        Dictionary<Http2TestSettings.Parameter, uint> declared = Http2TestSettings.ReadSettings(frames[0].Payload);
+        declared[Http2TestSettings.Parameter.EnablePush].ShouldBe(0u);
+        declared[Http2TestSettings.Parameter.HeaderTableSize].ShouldBe(4096u);
+        declared[Http2TestSettings.Parameter.MaxFrameSize].ShouldBe(16384u);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject an invalid connection preface with PROTOCOL_ERROR")]
+    public async Task Http2_OnInvalidPreface_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §3.4 — a preface mismatch is a connection error and MUST
+        // surface to the peer as GOAWAY(PROTOCOL_ERROR) before the transport
+        // is torn down.
+        byte[] payload = Encoding.ASCII.GetBytes("NOT THE PRI * PREFACE\r\n\r\n");
+        await AssertGoAwayAsync(payload, Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject a non-SETTINGS first client frame with PROTOCOL_ERROR")]
+    public async Task Http2_OnFirstClientFrameNotSettings_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §3.4 — the first client frame after the preface MUST be a
+        // SETTINGS frame. Any other frame type is a PROTOCOL_ERROR.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] pingFrame = Http2TestSettings.RawFrame(frameType: 0x6, flags: 0, streamId: 0, payload: new byte[8]);
+        await AssertGoAwayAsync(Combine(preface, pingFrame), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject SETTINGS on a non-zero stream with PROTOCOL_ERROR")]
+    public async Task Http2_OnSettingsOnNonZeroStream_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §6.5.1 — SETTINGS frames MUST be sent on stream 0.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settingsOnStream1 = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 1, payload: Array.Empty<byte>());
+        await AssertGoAwayAsync(Combine(preface, settingsOnStream1), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject a SETTINGS ACK that carries a payload with FRAME_SIZE_ERROR")]
+    public async Task Http2_OnSettingsAckWithPayload_ShouldGoAwayFrameSizeError()
+    {
+        // RFC 9113 §6.5 — an ACK SETTINGS frame MUST have an empty payload.
+        // Receiving an ACK with any payload is a FRAME_SIZE_ERROR.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] ackWithPayload = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0x1, streamId: 0, payload: new byte[6]);
+        await AssertGoAwayAsync(Combine(preface, ackWithPayload), Http2ErrorCode.FrameSizeError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject SETTINGS payload not a multiple of 6 with FRAME_SIZE_ERROR")]
+    public async Task Http2_OnSettingsPayloadNotMultipleOfSix_ShouldGoAwayFrameSizeError()
+    {
+        // RFC 9113 §6.5.1 — each setting is 6 octets (16-bit id + 32-bit value).
+        // A non-multiple-of-six payload is a FRAME_SIZE_ERROR.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: new byte[5]);
+        await AssertGoAwayAsync(Combine(preface, settings), Http2ErrorCode.FrameSizeError);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject MAX_FRAME_SIZE outside [2^14, 2^24-1] with PROTOCOL_ERROR")]
+    [InlineData(16_383u)]      // one below minimum (2^14 = 16384)
+    [InlineData(16_777_216u)]  // one above maximum (2^24 - 1 = 16777215)
+    [InlineData(0u)]
+    [InlineData(uint.MaxValue)]
+    public async Task Http2_OnInvalidMaxFrameSize_ShouldGoAwayProtocolError(uint value)
+    {
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] payload = Http2TestSettings.SettingsPayload((Http2TestSettings.Parameter.MaxFrameSize, value));
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: payload);
+        await AssertGoAwayAsync(Combine(preface, settings), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject INITIAL_WINDOW_SIZE above 2^31-1 with FLOW_CONTROL_ERROR")]
+    public async Task Http2_OnInvalidInitialWindowSize_ShouldGoAwayFlowControlError()
+    {
+        // RFC 9113 §6.5.2 — a value greater than 2^31-1 is a FLOW_CONTROL_ERROR.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] payload = Http2TestSettings.SettingsPayload((Http2TestSettings.Parameter.InitialWindowSize, (uint)int.MaxValue + 1u));
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: payload);
+        await AssertGoAwayAsync(Combine(preface, settings), Http2ErrorCode.FlowControlError);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject ENABLE_PUSH not in {0,1} with PROTOCOL_ERROR")]
+    [InlineData(2u)]
+    [InlineData(uint.MaxValue)]
+    public async Task Http2_OnInvalidEnablePush_ShouldGoAwayProtocolError(uint value)
+    {
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] payload = Http2TestSettings.SettingsPayload((Http2TestSettings.Parameter.EnablePush, value));
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: payload);
+        await AssertGoAwayAsync(Combine(preface, settings), Http2ErrorCode.ProtocolError);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject ENABLE_CONNECT_PROTOCOL not in {0,1} with PROTOCOL_ERROR")]
+    [InlineData(2u)]
+    [InlineData(uint.MaxValue)]
+    public async Task Http2_OnInvalidEnableConnectProtocol_ShouldGoAwayProtocolError(uint value)
+    {
+        // RFC 8441 §3 — the value MUST be 0 or 1.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] payload = Http2TestSettings.SettingsPayload((Http2TestSettings.Parameter.EnableConnectProtocol, value));
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: payload);
+        await AssertGoAwayAsync(Combine(preface, settings), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should silently ignore unknown SETTINGS parameters")]
+    public async Task Http2_OnUnknownSettingsParameter_ShouldIgnore()
+    {
+        // RFC 9113 §6.5.2 — an endpoint MUST ignore unknown setting identifiers
+        // so future-defined parameters do not break a compliant endpoint.
+        const ushort unknownParameter = 0xFEED;
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] payload = Http2TestSettings.SettingsPayloadRaw((unknownParameter, 1234u));
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: payload);
+        // Follow with a valid request so we can confirm the connection continued.
+        byte[] request = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        byte[] requestWithoutPreface = new byte[request.Length - preface.Length];
+        Array.Copy(request, preface.Length, requestWithoutPreface, 0, requestWithoutPreface.Length);
+
+        TestTransportConnectionContext transportContext = new(Combine(preface, settings, requestWithoutPreface));
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        httpContext.Request.Path.Value.ShouldBe("/");
+    }
+
+    /// <summary>
+    /// Drives the receive loop on a server with the supplied bytes and asserts
+    /// that the output stream contains a GOAWAY frame whose error code matches
+    /// <paramref name="expectedErrorCode"/>. The receive loop is expected to
+    /// throw <see cref="Http2ConnectionException"/> carrying the same code.
+    /// </summary>
+    private static async Task AssertGoAwayAsync(byte[] payload, Http2ErrorCode expectedErrorCode)
+    {
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        Exception? captured = null;
+        try
+        {
+            await foreach (IHttpContext _ in httpConnectionContext.ReceiveAsync())
+            {
+                // Should not yield — these payloads are all malformed.
+            }
+        }
+        catch (Exception error)
+        {
+            captured = error;
+        }
+
+        captured.ShouldNotBeNull();
+        captured.ShouldBeOfType<Http2ConnectionException>();
+        ((Http2ConnectionException)captured!).ErrorCode.ShouldBe(expectedErrorCode);
+
+        // The peer must have observed a GOAWAY frame on the wire carrying the
+        // same error code as the exception.
+        byte[] output = await transportContext.ReadOutputAsync();
+        Http2TestSettings.AssertContainsGoAway(output, expectedErrorCode);
     }
 
     private static byte[] Combine(params byte[][] buffers)

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/Http2TestSettings.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/Http2TestSettings.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Assimalign.Cohesion.Http.Transports.Internal.Http2;
+
+using Shouldly;
+
+namespace Assimalign.Cohesion.Http.Transports.Tests.TestObjects;
+
+/// <summary>
+/// Low-level HTTP/2 frame and SETTINGS payload helpers for transport-level tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tests use these to construct intentionally malformed wire bytes (invalid
+/// SETTINGS values, off-stream frames, ACK frames with payload, etc.) so the
+/// server's validation paths and GOAWAY emission can be exercised without
+/// depending on a real HTTP/2 client.
+/// </para>
+/// </remarks>
+internal static class Http2TestSettings
+{
+    /// <summary>
+    /// HTTP/2 SETTINGS parameter identifiers (mirrors
+    /// <c>Http2SettingsParameter</c> in the transport so the tests can build
+    /// raw payloads without depending on internals).
+    /// </summary>
+    public enum Parameter : ushort
+    {
+        HeaderTableSize = 0x1,
+        EnablePush = 0x2,
+        MaxConcurrentStreams = 0x3,
+        InitialWindowSize = 0x4,
+        MaxFrameSize = 0x5,
+        MaxHeaderListSize = 0x6,
+        EnableConnectProtocol = 0x8,
+    }
+
+    /// <summary>The HTTP/2 client preface (RFC 9113 §3.4).</summary>
+    public static byte[] Preface()
+        => Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+
+    /// <summary>
+    /// Builds a raw HTTP/2 frame with the supplied header fields and payload.
+    /// Format: 24-bit length, 8-bit type, 8-bit flags, 31-bit stream id (high
+    /// bit reserved), then the payload.
+    /// </summary>
+    public static byte[] RawFrame(byte frameType, byte flags, int streamId, byte[] payload)
+    {
+        byte[] frame = new byte[9 + payload.Length];
+        frame[0] = (byte)((payload.Length >> 16) & 0xFF);
+        frame[1] = (byte)((payload.Length >> 8) & 0xFF);
+        frame[2] = (byte)(payload.Length & 0xFF);
+        frame[3] = frameType;
+        frame[4] = flags;
+        frame[5] = (byte)((streamId >> 24) & 0x7F);
+        frame[6] = (byte)((streamId >> 16) & 0xFF);
+        frame[7] = (byte)((streamId >> 8) & 0xFF);
+        frame[8] = (byte)(streamId & 0xFF);
+
+        if (payload.Length > 0)
+        {
+            Buffer.BlockCopy(payload, 0, frame, 9, payload.Length);
+        }
+
+        return frame;
+    }
+
+    /// <summary>
+    /// Builds a SETTINGS frame payload (6 octets per entry: 16-bit identifier,
+    /// 32-bit value, big-endian).
+    /// </summary>
+    public static byte[] SettingsPayload(params (Parameter Parameter, uint Value)[] entries)
+    {
+        byte[] payload = new byte[entries.Length * 6];
+        Span<byte> span = payload;
+
+        foreach ((Parameter parameter, uint value) in entries)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(span, (ushort)parameter);
+            BinaryPrimitives.WriteUInt32BigEndian(span.Slice(2), value);
+            span = span.Slice(6);
+        }
+
+        return payload;
+    }
+
+    /// <summary>
+    /// Same as <see cref="SettingsPayload"/> but accepts a raw 16-bit parameter
+    /// identifier so tests can build payloads for unknown settings the
+    /// strongly-typed enum does not name.
+    /// </summary>
+    public static byte[] SettingsPayloadRaw(params (ushort Parameter, uint Value)[] entries)
+    {
+        byte[] payload = new byte[entries.Length * 6];
+        Span<byte> span = payload;
+
+        foreach ((ushort parameter, uint value) in entries)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(span, parameter);
+            BinaryPrimitives.WriteUInt32BigEndian(span.Slice(2), value);
+            span = span.Slice(6);
+        }
+
+        return payload;
+    }
+
+    /// <summary>
+    /// Parses a SETTINGS-frame payload into a dictionary keyed by
+    /// <see cref="Parameter"/>. Unknown parameter IDs are dropped.
+    /// </summary>
+    public static Dictionary<Parameter, uint> ReadSettings(byte[] payload)
+    {
+        if (payload.Length % 6 != 0)
+        {
+            throw new InvalidDataException($"SETTINGS payload size {payload.Length} is not a multiple of 6.");
+        }
+
+        Dictionary<Parameter, uint> result = new();
+        Span<byte> span = payload;
+
+        while (span.Length >= 6)
+        {
+            ushort parameter = BinaryPrimitives.ReadUInt16BigEndian(span);
+            uint value = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+
+            if (Enum.IsDefined((Parameter)parameter))
+            {
+                result[(Parameter)parameter] = value;
+            }
+
+            span = span.Slice(6);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Asserts that the supplied byte stream contains a GOAWAY frame (type 7)
+    /// carrying <paramref name="expectedErrorCode"/> in its last 4 octets.
+    /// </summary>
+    public static void AssertContainsGoAway(byte[] output, Http2ErrorCode expectedErrorCode)
+    {
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+        (long FrameType, byte[] Payload) goAway = frames.FirstOrDefault(frame => frame.FrameType == 7);
+
+        goAway.Payload.ShouldNotBeNull();
+        goAway.Payload.Length.ShouldBe(8);
+
+        uint errorCode = BinaryPrimitives.ReadUInt32BigEndian(goAway.Payload.AsSpan(4, 4));
+        errorCode.ShouldBe((uint)expectedErrorCode);
+    }
+}

--- a/resources/Directory.Build.props
+++ b/resources/Directory.Build.props
@@ -28,10 +28,10 @@
 	<!-- #endregion -->
 
 	<!-- #region Packaging (Nuget): README-->
-	<PropertyGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md')">
+	<PropertyGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md') and $([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\README.md')) != ''">
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	<ItemGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md')">
+	<ItemGroup Condition="$(IsSourceProject) and Exists('$(MSBuildProjectDirectory)\..\README.md') and $([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\README.md')) != ''">
 		<None Include="..\README.md">
 			<Pack>true</Pack>
 			<PackagePath>\</PackagePath>


### PR DESCRIPTION
PR 1 of the HTTP/2 work in the L01.01.11 epic. Promotes the existing HTTP/2 preface + SETTINGS scaffold to a compliance-grade engine: every parameter is validated per RFC 9113 §6.5.2 / RFC 8441 §3, every frame-structure rule from §6.5.1 / §6.5 is enforced, the §3.4 first-frame-MUST-be-SETTINGS rule is enforced, and any connection-level failure produces a `GOAWAY` carrying the right error code before the transport is torn down.

Closes #331 [.06].

## Summary

- New `Http2ConnectionSettings` snapshot — tracks all seven RFC 9113 + RFC 8441 parameters, plus a `Validate(in setting)` static that returns the RFC-mandated error code.
- `Http2ConnectionException` now carries `ErrorCode` so the receive loop can build the right `GOAWAY` automatically.
- `Http2ConnectionContext` rewrite — splits `_localSettings` (what we advertised) from `_remoteSettings` (what the peer advertised); inbound parsing uses local cap, outbound chunking uses remote cap.
- Server emits explicit initial SETTINGS (`ENABLE_PUSH = 0`, `MAX_HEADER_LIST_SIZE = 16 KB`) instead of an empty SETTINGS frame.
- All connection-level errors now emit `GOAWAY(error_code)` before terminating; no more bare `InvalidDataException`s.
- 16 new compliance tests + 1 new test helper (`Http2TestSettings`).
- `InternalsVisibleTo` plumbing for the transport library, matching the established pattern.

## RFC coverage

| Behavior | RFC | Result |
|----------|-----|--------|
| Invalid preface | 9113 §3.4 | `GOAWAY(PROTOCOL_ERROR)` |
| First client frame not SETTINGS | 9113 §3.4 | `GOAWAY(PROTOCOL_ERROR)` |
| SETTINGS on non-zero stream | 9113 §6.5.1 | `GOAWAY(PROTOCOL_ERROR)` |
| SETTINGS ACK with payload | 9113 §6.5 | `GOAWAY(FRAME_SIZE_ERROR)` |
| SETTINGS payload not multiple of 6 | 9113 §6.5.1 | `GOAWAY(FRAME_SIZE_ERROR)` |
| MAX_FRAME_SIZE outside [2^14, 2^24−1] | 9113 §6.5.2 | `GOAWAY(PROTOCOL_ERROR)` |
| INITIAL_WINDOW_SIZE > 2^31−1 | 9113 §6.5.2 | `GOAWAY(FLOW_CONTROL_ERROR)` |
| ENABLE_PUSH ∉ {0, 1} | 9113 §6.5.2 | `GOAWAY(PROTOCOL_ERROR)` |
| ENABLE_CONNECT_PROTOCOL ∉ {0, 1} | 8441 §3 | `GOAWAY(PROTOCOL_ERROR)` |
| Unknown parameter ID | 9113 §6.5.2 | silently ignored |
| Oversize frame payload | 9113 §4.2 | `GOAWAY(FRAME_SIZE_ERROR)` |

## Test plan

- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http.Transports/tests/...csproj -c Release` → 72/72 (HTTP/2 portion is 19 cases, was 3)
- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http/tests/...csproj -c Release` → 192/192
- [x] Sessions / Forms / ClientFactory tests still pass → 28/28
- [x] CI green across ubuntu / windows / macos

## Out of scope

- Stream-level state machine + flow control window accounting → PR 3 (#332). PR 1 only tracks the SETTINGS values the FSM will consume.
- `SendAsync` flush-vs-return defect → PR 2 (#686).
- HPACK + field-section compliance → PR 4 (#333).
- Routing `_localSettings` through `HttpConnectionListenerOptions` for per-deployment tuning — a follow-up after the FSM lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)