### PR TITLE
fix(http): close the HTTP/2 SendAsync flush-vs-return race (L01.01.11 PR2 — HTTP/2)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Connection.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+
 using Assimalign.Cohesion.Transports;
 
 namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
@@ -34,8 +35,86 @@ internal sealed class Http2Connection : HttpConnection
         return _context;
     }
 
-    public override ValueTask DisposeAsync()
+    /// <summary>
+    /// Performs an orderly HTTP/2 connection teardown (RFC 9113 §6.8):
+    /// </summary>
+    /// <remarks>
+    /// <list type="number">
+    ///   <item><description>Run the HTTP/2 graceful close on the context
+    ///   — emits a <c>GOAWAY</c> frame and completes the transport's
+    ///   send-pipe writer so the transport's send task drains any
+    ///   remaining buffered frames and performs its final
+    ///   <c>Socket.SendAsync</c>.</description></item>
+    ///   <item><description>Wait for the transport to transition out of
+    ///   <see cref="ConnectionState.Open"/>. The transport's send task
+    ///   calls <c>Abort()</c> in its own <c>finally</c> after the last
+    ///   Socket.SendAsync completes; that state transition is our signal
+    ///   that all queued bytes are on the wire.</description></item>
+    ///   <item><description>Dispose the underlying transport to release
+    ///   socket / pool resources (idempotent after the transport's own
+    ///   Abort).</description></item>
+    /// </list>
+    /// <para>
+    /// Fixes #686 — previously this method called
+    /// <c>Connection.DisposeAsync()</c> directly, which aborts the socket
+    /// immediately and can race the send task's in-flight
+    /// <c>Socket.SendAsync</c>. The graceful close + state wait closes
+    /// that gap so the response bytes a server's <c>SendAsync</c> just
+    /// committed are durably on the wire before the socket is torn down.
+    /// </para>
+    /// </remarks>
+    public override async ValueTask DisposeAsync()
     {
-        return Connection.DisposeAsync();
+        if (_context is not null)
+        {
+            try
+            {
+                await _context.GracefulCloseAsync().ConfigureAwait(false);
+                await WaitForTransportDrainAsync(_connection).ConfigureAwait(false);
+            }
+            finally
+            {
+                await _context.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Polls <see cref="ITransportConnection.State"/> for a transition
+    /// out of <see cref="ConnectionState.Open"/>. Bounded to avoid
+    /// hanging on a stuck transport.
+    /// </summary>
+    /// <remarks>
+    /// For a real socket transport (e.g. <c>SocketTransportConnectionContext</c>),
+    /// the send task closes the socket in its own <c>finally</c> after the
+    /// final <c>Socket.SendAsync</c> completes — the state transition is our
+    /// signal that the buffered bytes are on the wire. In localhost loopback
+    /// scenarios this happens within milliseconds.
+    ///
+    /// For transports that don't operate a background send task (e.g. in-memory
+    /// test pipes), the state never transitions until <c>DisposeAsync</c> is
+    /// invoked. The timeout here is sized so those scenarios complete quickly:
+    /// 200ms is comfortably above the localhost send latency and short enough
+    /// that test-transport disposals don't accumulate.
+    /// </remarks>
+    private static async ValueTask WaitForTransportDrainAsync(ITransportConnection connection, int timeoutMs = 200)
+    {
+        using CancellationTokenSource cts = new(timeoutMs);
+
+        try
+        {
+            while (connection.State == ConnectionState.Open)
+            {
+                await Task.Delay(1, cts.Token).ConfigureAwait(false);
+            }
+        }
+        catch (System.OperationCanceledException)
+        {
+            // Best-effort: if the transport has not drained within the
+            // timeout, fall through to disposal. The connection will be
+            // aborted regardless.
+        }
     }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
@@ -12,7 +12,7 @@ using Assimalign.Cohesion.Transports;
 
 namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
 
-internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
+internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsyncDisposable
 {
     private static readonly byte[] ClientPreface = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
@@ -24,10 +24,18 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
     // writing is bounded by the remote cap.
     private readonly Http2ConnectionSettings _localSettings;
     private readonly Http2ConnectionSettings _remoteSettings;
+    // RFC 9113 §4.1 + §6.8 — a single TCP connection multiplexes many
+    // logical streams. Frames from concurrent senders MUST NOT interleave
+    // on the wire, or the peer's parser will see a corrupted frame
+    // sequence. This semaphore serializes every outbound frame write on
+    // the connection, regardless of whether it originated from a
+    // SendAsync, a SETTINGS/PING ACK, a GOAWAY, or graceful shutdown.
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
     private int? _continuationStreamId;
     private bool _initialized;
     private bool _receivedClientSettings;
     private int _lastInboundStreamId;
+    private int _gracefulCloseStarted;
 
     public Http2ConnectionContext(ITransportConnectionContext transportContext, bool isSecure)
         : base(transportContext, isSecure)
@@ -93,9 +101,27 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         byte[] bodyBytes = await ReadBodyAsync(http2Context.Response.Body, cancellationToken).ConfigureAwait(false);
         byte[] headerBlock = HPackEncoder.EncodeResponseHeaders(http2Context.Response.StatusCode, http2Context.Response.Headers, http2Context.Response.Cookies, bodyBytes.Length);
 
-        await WriteHeaderBlockAsync(http2Context.StreamId, headerBlock, endStream: bodyBytes.Length == 0, cancellationToken).ConfigureAwait(false);
-        await WriteBodyAsync(http2Context.StreamId, bodyBytes, cancellationToken).ConfigureAwait(false);
-        await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        // RFC 9113 §4.1 — frames from concurrent senders MUST NOT interleave.
+        // The whole HEADERS [+ CONTINUATION...] [+ DATA...] sequence MUST be
+        // emitted contiguously on the wire. Hold the connection write lock
+        // for the duration so concurrent SendAsync calls and receive-loop
+        // ACK frames cannot tear the frame sequence.
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await WriteHeaderBlockAsync(http2Context.StreamId, headerBlock, endStream: bodyBytes.Length == 0, cancellationToken).ConfigureAwait(false);
+            await WriteBodyAsync(http2Context.StreamId, bodyBytes, cancellationToken).ConfigureAwait(false);
+            // RFC 9113 §6.8 / #686 — the caller MUST observe a guarantee that
+            // the response bytes have been handed off to the transport pipe
+            // before SendAsync returns. Flush the pipe writer here so the
+            // bytes are durably committed to the send-side of the underlying
+            // transport before the lock is released.
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -126,8 +152,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         byte[] settingsPayload = EncodeLocalSettings();
         Http2Frame settingsFrame = new();
         settingsFrame.PrepareSettings(Http2SettingsFrameFlags.None);
-        await Http2FrameWriter.WriteAsync(Stream, settingsFrame, settingsPayload, cancellationToken).ConfigureAwait(false);
-        await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await Http2FrameWriter.WriteAsync(Stream, settingsFrame, settingsPayload, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
 
         _initialized = true;
     }
@@ -235,8 +269,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
         Http2Frame acknowledgement = new();
         acknowledgement.PrepareSettings(Http2SettingsFrameFlags.Acknowledge);
-        await Http2FrameWriter.WriteAsync(Stream, acknowledgement, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
-        await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await Http2FrameWriter.WriteAsync(Stream, acknowledgement, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private Http2Context? ProcessHeadersFrame(ReceivedFrame receivedFrame)
@@ -309,8 +351,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
 
         Http2Frame acknowledgement = new();
         acknowledgement.PreparePing(Http2PingFrameFlags.Acknowledge);
-        await Http2FrameWriter.WriteAsync(Stream, acknowledgement, receivedFrame.Payload, cancellationToken).ConfigureAwait(false);
-        await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await Http2FrameWriter.WriteAsync(Stream, acknowledgement, receivedFrame.Payload, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private Http2Context? TryCompleteStream(Http2Stream stream)
@@ -500,8 +550,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         {
             Http2Frame goAway = new();
             goAway.PrepareGoAway(_lastInboundStreamId, errorCode);
-            await Http2FrameWriter.WriteAsync(Stream, goAway, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
-            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await Http2FrameWriter.WriteAsync(Stream, goAway, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+                await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
         }
         catch
         {
@@ -563,6 +621,83 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext
         }
 
         return payload;
+    }
+
+    /// <summary>
+    /// Performs an RFC 9113 §6.8 graceful close: emits a <c>GOAWAY</c>
+    /// frame carrying <see cref="Http2ErrorCode.NoError"/>, then signals
+    /// the transport's send pipeline that no further bytes will be
+    /// written. The transport's send task reads the remaining bytes,
+    /// performs its final <c>Socket.SendAsync</c> (which waits for the
+    /// kernel to accept the bytes), then exits — at which point the
+    /// underlying socket is torn down through the transport's own
+    /// teardown path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Closes the gap identified by #686: previously, <see cref="Http2Connection.DisposeAsync"/>
+    /// invoked <c>ITransportConnection.DisposeAsync</c> directly, which
+    /// aborts the socket immediately and can race the send task's
+    /// in-flight <c>Socket.SendAsync</c>. Completing the pipe writer
+    /// here lets the send task drain naturally; the caller then waits
+    /// for the connection state to transition out of <c>Open</c> before
+    /// declaring the close complete.
+    /// </para>
+    /// <para>
+    /// Idempotent — repeated invocations after the first are no-ops.
+    /// </para>
+    /// </remarks>
+    public async ValueTask GracefulCloseAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _gracefulCloseStarted, 1) == 1)
+        {
+            return;
+        }
+
+        // EnsureInitializedAsync may not have run if the receive loop was
+        // never started. Skip GOAWAY in that case; the peer has not seen
+        // any HTTP/2 traffic from us yet, so closing the underlying socket
+        // is enough.
+        if (!_initialized)
+        {
+            await CompleteOutputAsync().ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            await EmitGoAwayAsync(Http2ErrorCode.NoError, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await CompleteOutputAsync().ConfigureAwait(false);
+        }
+    }
+
+    private ValueTask CompleteOutputAsync()
+    {
+        try
+        {
+            // RFC 9113 §6.8 — completing the pipe writer signals the
+            // transport's send loop that no further bytes will be queued.
+            // The send loop processes its remaining backlog (one final
+            // Socket.SendAsync, which waits for the kernel to ACK) and
+            // then exits — closing the socket cleanly.
+            return Pipe.Output.CompleteAsync();
+        }
+        catch
+        {
+            // The writer may already be completed if a teardown ran
+            // concurrently. Idempotent.
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await GracefulCloseAsync().ConfigureAwait(false);
+        _writeLock.Dispose();
     }
 
     private readonly struct ReceivedFrame

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
@@ -95,6 +95,107 @@ public class Http2TransportTests
         secondPath.ShouldBe("/two");
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should emit a graceful GOAWAY on connection disposal")]
+    public async Task Http2_OnDispose_ShouldEmitGracefulGoAway()
+    {
+        // RFC 9113 §6.8 — a server initiating an orderly connection close MUST
+        // emit a GOAWAY frame carrying NO_ERROR before tearing down the wire.
+        // This fixes #686: without the graceful close, Http2Connection.Dispose
+        // can race the underlying socket's send task and lose buffered bytes.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestTransportConnectionContext transportContext = new(payload);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+
+        await using (IHttpConnection httpConnection = await listener.AcceptOrListenAsync())
+        {
+            IHttpConnectionContext httpConnectionContext = await httpConnection.OpenAsync();
+            IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+            httpContext.Response.StatusCode = HttpStatusCode.Ok;
+            await httpConnectionContext.SendAsync(httpContext);
+        }
+
+        // Read the full output of the connection — the last frame should be a
+        // GOAWAY(NO_ERROR) carrying the highest observed inbound stream ID.
+        byte[] output = await transportContext.ReadOutputAsync();
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+        (long FrameType, byte[] Payload) goAway = frames[frames.Count - 1];
+
+        goAway.FrameType.ShouldBe(7L); // GOAWAY frame type
+        goAway.Payload.Length.ShouldBe(8);
+        // Last 4 octets carry the error code; NO_ERROR = 0x0.
+        uint errorCode = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(goAway.Payload.AsSpan(4, 4));
+        errorCode.ShouldBe(0u);
+        // First 4 octets carry the last-stream-id; we processed stream 1.
+        uint lastStreamId = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(goAway.Payload.AsSpan(0, 4));
+        lastStreamId.ShouldBe(1u);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should serialize concurrent SendAsync writes without frame interleaving")]
+    public async Task Http2_OnConcurrentSendAsync_ShouldNotInterleaveFrames()
+    {
+        // RFC 9113 §4.1 — frames from concurrent senders MUST NOT interleave on
+        // the wire. PR #686 added a per-connection write semaphore so two
+        // SendAsync calls cannot tear each other's HEADERS+DATA sequence even
+        // when invoked from racing tasks. This test confirms each DATA frame
+        // carries a contiguous response body (no split / interleave).
+        byte[] firstRequest = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/one", "https", "api.test");
+        byte[] secondRequest = HttpProtocolPayloadFactory.CreateHttp2Request(3, "GET", "/two", "https", "api.test");
+        byte[] secondRequestWithoutPreface = new byte[secondRequest.Length - 24];
+        Array.Copy(secondRequest, 24, secondRequestWithoutPreface, 0, secondRequestWithoutPreface.Length);
+        byte[] combined = Combine(firstRequest, secondRequestWithoutPreface);
+
+        TestTransportConnectionContext transportContext = new(combined);
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext firstContext = enumerator.Current;
+        const string firstBody = "AAAAAAAAAAAAAAAA";
+        firstContext.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes(firstBody));
+
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext secondContext = enumerator.Current;
+        const string secondBody = "BBBBBBBBBBBBBBBB";
+        secondContext.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes(secondBody));
+
+        // Drive both SendAsync calls concurrently. Without the write lock, the
+        // resulting DATA frame payloads could be split / interleaved across
+        // the two streams; with the lock each stream's HEADERS+DATA sequence
+        // is atomic.
+        Task firstSend = httpConnectionContext.SendAsync(firstContext).AsTask();
+        Task secondSend = httpConnectionContext.SendAsync(secondContext).AsTask();
+        await Task.WhenAll(firstSend, secondSend);
+
+        // Drain the wire output exactly once and inspect every DATA frame.
+        byte[] output = await transportContext.ReadOutputAsync();
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+
+        List<string> dataPayloads = new();
+        foreach ((long frameType, byte[] payload) in frames)
+        {
+            if (frameType == 0) // DATA
+            {
+                dataPayloads.Add(Encoding.ASCII.GetString(payload));
+            }
+        }
+
+        // Exactly two DATA frames, each carrying its full response body
+        // contiguously. Interleaving would split the body across multiple
+        // DATA payloads or mix the two bodies into a single payload.
+        dataPayloads.Count.ShouldBe(2);
+        dataPayloads.ShouldContain(firstBody);
+        dataPayloads.ShouldContain(secondBody);
+    }
+
     [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should keep a localhost connection open for sequential requests")]
     public async Task Http2_OnSequentialLocalhostRequests_ShouldKeepConnectionOpen()
     {
@@ -106,15 +207,12 @@ public class Http2TransportTests
         int port = GetAvailablePort();
         List<string> observedPaths = new();
 
-        // Synchronizes the server task's connection teardown with the client side.
-        // Without this, the server breaks out of the receive loop as soon as it has
-        // dispatched both responses; the resulting `await using IHttpConnection`
-        // disposal closes the H2 connection and can race the client's final frame
-        // read on slow runners (predominantly macOS), surfacing as
-        // "response ended prematurely". The signal lets the test code release the
-        // server only after both response bodies have been fully consumed.
-        TaskCompletionSource clientFinishedReading = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
+        // No client-side handshake to gate teardown — #686 fixed the race where
+        // Http2Connection.DisposeAsync could close the socket before the send
+        // task had moved the response bytes from the pipe to the wire. With the
+        // graceful close in place, the server task can `break` out of its
+        // receive loop the moment SendAsync returns and the test still passes
+        // deterministically.
         await using HttpConnectionListener listener = HttpConnectionListener.Create(options =>
         {
             options.UseHttp2(transport =>
@@ -147,11 +245,6 @@ public class Http2TransportTests
 
                 if (observedPaths.Count >= 2)
                 {
-                    // Hold the receive loop open until the client confirms both
-                    // responses were fully read. This blocks the `await using
-                    // IHttpConnection` disposal until the H2 conversation has
-                    // wound down on the client side.
-                    await clientFinishedReading.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
                     break;
                 }
             }
@@ -166,9 +259,6 @@ public class Http2TransportTests
         string firstBody = await SendHttp2RequestAsync(client, new Uri($"http://127.0.0.1:{port}/one"), cancellationToken);
         string secondBody = await SendHttp2RequestAsync(client, new Uri($"http://127.0.0.1:{port}/two"), cancellationToken);
 
-        // Both response bodies fully consumed — release the server task so it can
-        // tear down the connection cleanly.
-        clientFinishedReading.SetResult();
         await serverTask;
 
         // Assert


### PR DESCRIPTION
PR 2 of the HTTP/2 work in the L01.01.11 epic. Closes the real transport defect identified in #686: `Http2ConnectionContext.SendAsync` returned to the caller before the response's frames were durably committed to the transport's send pipeline, leaving a window where a subsequent connection teardown could close the socket while bytes were still buffered.

Closes #686 [.07.04].

## Summary

- New per-connection write lock (`SemaphoreSlim _writeLock`) on `Http2ConnectionContext` — serialises every outbound frame write so concurrent SendAsync calls and receive-loop ACKs cannot interleave on the wire (RFC 9113 §4.1).
- New `Http2ConnectionContext.GracefulCloseAsync` — emits `GOAWAY(NO_ERROR)` then completes the transport's send-pipe writer so the send task drains naturally.
- `Http2Connection.DisposeAsync` rewrite — orchestrates graceful close → bounded poll for transport state transition → underlying dispose. Replaces the previous bare `Connection.DisposeAsync()` that aborted the socket immediately.
- Existing `Http2_OnSequentialLocalhostRequests` test had a `TaskCompletionSource clientFinishedReading` handshake; the handshake is now removed and the test still passes deterministically (5/5 locally).
- New `Http2_OnDispose_ShouldEmitGracefulGoAway` test — verifies the wire ends with `GOAWAY(0, NO_ERROR)` carrying the last observed inbound stream ID.
- New `Http2_OnConcurrentSendAsync_ShouldNotInterleaveFrames` test — drives two `SendAsync` calls concurrently and asserts each response body lands in its own contiguous DATA frame.

## Root cause

The wire chain `app → PipeStream → clientPipe.Writer → SocketTransport.Send task → Socket.SendAsync` had an async gap between the pipe and the send task. After `SendAsync` returned, the bytes were in `clientPipe` but the send task may not have yet called `Socket.SendAsync` and waited for the kernel ACK. If the caller then disposed the connection, the abort closed the socket while bytes were still in transit. The graceful close (`Pipe.Output.CompleteAsync()` + state-transition wait) is what lets the send task drain naturally before the abort path runs.

## Test plan

- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http.Transports/tests/...csproj -c Release` → 74/74
- [x] `Http2_OnSequentialLocalhostRequests` passes 5/5 locally with the synchronization handshake removed
- [x] HTTP family in Release → 294/294
- [x] CI green on the macOS runner where the original flake surfaced

## Out of scope

- Batching frames into a single `GetSpan`/`Advance` pair to eliminate the per-frame `PipeWriter.FlushAsync` — purely a CPU optimisation; correctness is fine today.
- HTTP/3 send pipeline review — should happen once `.09` / `.10` flesh out the H3 send path. HTTP/1.1 is request-framed so the race profile differs; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)