### PR TITLE
feat(http): RFC 9113 §5.1 HTTP/2 stream lifecycle state machine (L01.01.11 PR3a — HTTP/2)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Exceptions/Http2StreamException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Exceptions/Http2StreamException.cs
@@ -1,0 +1,29 @@
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
+
+/// <summary>
+/// Stream-level HTTP/2 protocol error. Unlike <see cref="Http2ConnectionException"/>
+/// (which forces the entire connection to terminate with a <c>GOAWAY</c>),
+/// a stream error is recoverable: the offending stream is reset with
+/// <c>RST_STREAM</c> carrying <see cref="ErrorCode"/>, and the connection
+/// keeps processing other streams (RFC 9113 §5.4.2).
+/// </summary>
+internal sealed class Http2StreamException : HttpException
+{
+    public Http2StreamException(int streamId, Http2ErrorCode errorCode, string message)
+        : base(message)
+    {
+        StreamId = streamId;
+        ErrorCode = errorCode;
+    }
+
+    /// <summary>
+    /// The stream the error applies to. Carried in the outbound
+    /// <c>RST_STREAM</c> frame.
+    /// </summary>
+    public int StreamId { get; }
+
+    /// <summary>
+    /// The error code carried in the outbound <c>RST_STREAM</c> frame.
+    /// </summary>
+    public Http2ErrorCode ErrorCode { get; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
@@ -73,6 +73,14 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             {
                 completedContext = await ProcessFrameAsync(receivedFrame.Value, cancellationToken).ConfigureAwait(false);
             }
+            catch (Http2StreamException streamError)
+            {
+                // RFC 9113 §5.4.2 — a stream error is recoverable: emit a
+                // RST_STREAM carrying the error code and continue processing
+                // other streams on the same connection.
+                await EmitRstStreamAsync(streamError.StreamId, streamError.ErrorCode, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
             catch (Http2ConnectionException error)
             {
                 // RFC 9113 §6.8 — every connection-level failure MUST be
@@ -122,6 +130,13 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         {
             _writeLock.Release();
         }
+
+        // RFC 9113 §5.1 — every server response ends with END_STREAM (either
+        // on a body-less HEADERS frame or on the trailing DATA frame). After
+        // a successful send the stream's local half is closed; if the peer
+        // already closed its half (the normal request/response case) the
+        // stream transitions to Closed.
+        http2Context.Stream.SendEndStream();
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -199,14 +214,77 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
                 await ProcessPingFrameAsync(receivedFrame, cancellationToken).ConfigureAwait(false);
                 return null;
             case Http2FrameType.RstStream:
-                _streams.Remove(receivedFrame.Frame.StreamId);
-                if (_continuationStreamId == receivedFrame.Frame.StreamId)
-                {
-                    _continuationStreamId = null;
-                }
+                ProcessRstStreamFrame(receivedFrame);
                 return null;
             default:
                 return null;
+        }
+    }
+
+    private void ProcessRstStreamFrame(ReceivedFrame receivedFrame)
+    {
+        // RFC 9113 §6.4 — RST_STREAM frames MUST be associated with a
+        // specific stream (stream 0 is illegal) and MUST carry a 4-octet
+        // error code payload.
+        if (receivedFrame.Frame.StreamId == 0)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "HTTP/2 RST_STREAM frame received on stream 0.");
+        }
+
+        if (_streams.TryGetValue(receivedFrame.Frame.StreamId, out Http2Stream? stream))
+        {
+            stream.ReceiveReset();
+            _streams.Remove(receivedFrame.Frame.StreamId);
+        }
+        else if (receivedFrame.Frame.StreamId > _lastInboundStreamId)
+        {
+            // RST_STREAM on an idle stream (one whose ID we have never
+            // observed an in-bound frame for) is a connection error per
+            // RFC 9113 §6.4.
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 RST_STREAM received for idle stream {receivedFrame.Frame.StreamId}.");
+        }
+
+        if (_continuationStreamId == receivedFrame.Frame.StreamId)
+        {
+            _continuationStreamId = null;
+        }
+    }
+
+    /// <summary>
+    /// Validates a client-initiated stream identifier per RFC 9113 §5.1.1:
+    /// MUST be odd, MUST be non-zero, MUST be greater than every previously
+    /// observed client-initiated stream identifier. Violations are
+    /// connection-level PROTOCOL_ERROR.
+    /// </summary>
+    private void ValidateInboundStreamId(int streamId)
+    {
+        if (streamId == 0)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                "HTTP/2 stream-bearing frame received on stream 0.");
+        }
+
+        if ((streamId & 1) == 0)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 client-initiated stream id {streamId} must be odd.");
+        }
+
+        // Re-using a stream id is legal if the stream is still tracked
+        // (continuation of HEADERS, body DATA, etc.). It is only an
+        // ordering violation when opening a NEW stream with a smaller id
+        // than the previously highest one.
+        if (streamId < _lastInboundStreamId && !_streams.ContainsKey(streamId))
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 stream id {streamId} is lower than the highest previously seen client-initiated stream id {_lastInboundStreamId}.");
         }
     }
 
@@ -291,14 +369,20 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         }
 
         Http2Frame frame = receivedFrame.Frame;
+
+        // RFC 9113 §5.1.1 — client-initiated streams MUST use odd-numbered
+        // identifiers, and stream IDs MUST increase monotonically. The server
+        // never initiates a stream (PUSH_PROMISE is disabled), so we treat any
+        // even ID as a connection-level PROTOCOL_ERROR.
+        ValidateInboundStreamId(frame.StreamId);
+
         _lastInboundStreamId = Math.Max(_lastInboundStreamId, frame.StreamId);
         Http2Stream stream = GetOrCreateStream(frame.StreamId);
-        stream.AppendHeaders(receivedFrame.Payload, frame.HeadersEndHeaders);
 
-        if (frame.HeadersEndStream)
-        {
-            stream.CompleteInput();
-        }
+        // Hand the HEADERS frame to the state machine — it folds the payload
+        // into the accumulating header block AND updates the stream's
+        // lifecycle state (idle → open or idle → half-closed-remote).
+        stream.ReceiveHeaders(receivedFrame.Payload, frame.HeadersEndHeaders, frame.HeadersEndStream);
 
         if (!frame.HeadersEndHeaders)
         {
@@ -318,8 +402,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
                 "The HTTP/2 CONTINUATION frame did not match the active header block stream.");
         }
 
-        Http2Stream stream = GetOrCreateStream(receivedFrame.Frame.StreamId);
-        stream.AppendHeaders(receivedFrame.Payload, receivedFrame.Frame.HeadersEndHeaders);
+        if (!_streams.TryGetValue(receivedFrame.Frame.StreamId, out Http2Stream? stream))
+        {
+            // The leading HEADERS frame must have created the stream entry;
+            // an orphan CONTINUATION is a protocol error.
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 CONTINUATION frame received on unknown stream {receivedFrame.Frame.StreamId}.");
+        }
+
+        stream.ReceiveContinuation(receivedFrame.Payload, receivedFrame.Frame.HeadersEndHeaders);
 
         if (receivedFrame.Frame.HeadersEndHeaders)
         {
@@ -331,14 +423,38 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
 
     private Http2Context? ProcessDataFrame(ReceivedFrame receivedFrame)
     {
-        if (!_streams.TryGetValue(receivedFrame.Frame.StreamId, out Http2Stream? stream))
+        // RFC 9113 §6.1 — DATA frames MUST be associated with a stream;
+        // stream 0 is reserved for connection-level frames.
+        if (receivedFrame.Frame.StreamId == 0)
         {
             throw new Http2ConnectionException(
                 Http2ErrorCode.ProtocolError,
-                "The HTTP/2 DATA frame was received for an unknown stream.");
+                "HTTP/2 DATA frame received on stream 0.");
         }
 
-        stream.AppendBody(receivedFrame.Payload, receivedFrame.Frame.DataEndStream);
+        if (!_streams.TryGetValue(receivedFrame.Frame.StreamId, out Http2Stream? stream))
+        {
+            // Disambiguate idle vs. recently-closed streams (RFC 9113 §5.1):
+            //   - id > highest observed → truly idle stream, never opened
+            //     → connection error PROTOCOL_ERROR.
+            //   - id ≤ highest observed → previously opened stream we have
+            //     since retired (END_STREAM + END_STREAM, or RST_STREAM)
+            //     → stream error STREAM_CLOSED, reset the stream so the
+            //     peer learns it cannot continue using that id.
+            if (receivedFrame.Frame.StreamId > _lastInboundStreamId)
+            {
+                throw new Http2ConnectionException(
+                    Http2ErrorCode.ProtocolError,
+                    $"HTTP/2 DATA frame received on idle stream {receivedFrame.Frame.StreamId}.");
+            }
+
+            throw new Http2StreamException(
+                receivedFrame.Frame.StreamId,
+                Http2ErrorCode.StreamClosed,
+                $"HTTP/2 DATA frame received on closed stream {receivedFrame.Frame.StreamId}.");
+        }
+
+        stream.ReceiveData(receivedFrame.Payload, receivedFrame.Frame.DataEndStream);
         return TryCompleteStream(stream);
     }
 
@@ -536,6 +652,48 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         }
 
         return new ReceivedFrame(frame, payloadSequence.IsEmpty ? Array.Empty<byte>() : payloadSequence.ToArray());
+    }
+
+    /// <summary>
+    /// Emits a <c>RST_STREAM</c> frame for <paramref name="streamId"/> with
+    /// <paramref name="errorCode"/> (RFC 9113 §6.4 / §5.4.2). Removes the
+    /// stream from our active map so subsequent frames on it surface as
+    /// "unknown stream" errors at the connection level.
+    /// </summary>
+    private async Task EmitRstStreamAsync(int streamId, Http2ErrorCode errorCode, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Http2Frame rstStream = new();
+            rstStream.PrepareRstStream(streamId, errorCode);
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await Http2FrameWriter.WriteAsync(Stream, rstStream, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+                await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+        catch
+        {
+            // Best-effort: stream errors are recoverable, and if the wire
+            // is already in trouble the next connection-level read will
+            // surface that via GOAWAY.
+        }
+
+        if (_streams.TryGetValue(streamId, out Http2Stream? stream))
+        {
+            stream.SendReset();
+            _streams.Remove(streamId);
+        }
+
+        if (_continuationStreamId == streamId)
+        {
+            _continuationStreamId = null;
+        }
     }
 
     /// <summary>

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Stream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Stream.cs
@@ -9,6 +9,21 @@ using Assimalign.Cohesion.Http.Transports.Internal.Http2.HPack;
 
 namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
 
+/// <summary>
+/// Server-side HTTP/2 stream — tracks the RFC 9113 §5.1 lifecycle state
+/// plus the accumulating header block and body bytes received from the
+/// peer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// State transitions are explicit and enforced by the <c>Receive*</c> /
+/// <c>Send*</c> methods on this type. Any frame that is illegal in the
+/// current state surfaces as either a
+/// <see cref="Http2StreamException"/> (stream-level — RST_STREAM keeps
+/// the connection alive) or an <see cref="Http2ConnectionException"/>
+/// (connection-level — GOAWAY tears the connection down).
+/// </para>
+/// </remarks>
 internal sealed class Http2Stream
 {
     private readonly MemoryStream _headerBlock;
@@ -19,34 +34,86 @@ internal sealed class Http2Stream
         StreamId = streamId;
         _headerBlock = new MemoryStream();
         _body = new MemoryStream();
+        State = Http2StreamState.Idle;
     }
 
+    /// <summary>The stream identifier (RFC 9113 §5.1.1).</summary>
     public int StreamId { get; }
 
+    /// <summary>Current lifecycle state per RFC 9113 §5.1.</summary>
+    public Http2StreamState State { get; private set; }
+
+    /// <summary><see langword="true"/> once <c>END_HEADERS</c> has been observed across HEADERS/CONTINUATION.</summary>
     public bool HeadersCompleted { get; private set; }
 
+    /// <summary><see langword="true"/> once the request side has been closed (END_STREAM from the peer or RST_STREAM).</summary>
     public bool InputCompleted { get; private set; }
 
-    public bool IsRequestReady => HeadersCompleted && InputCompleted;
+    /// <summary>The stream is ready to materialise as an <c>IHttpContext</c> once both halves are present.</summary>
+    public bool IsRequestReady => HeadersCompleted && InputCompleted && State != Http2StreamState.Closed;
 
-    public void AppendHeaders(ReadOnlySpan<byte> payload, bool endHeaders)
+    /// <summary>
+    /// Whether the stream has reached the terminal <see cref="Http2StreamState.Closed"/>
+    /// state.
+    /// </summary>
+    public bool IsClosed => State == Http2StreamState.Closed;
+
+    /// <summary>
+    /// Folds an inbound HEADERS / CONTINUATION payload into the accumulating header
+    /// block, applies the RFC 9113 §5.1 state transition driven by HEADERS, and
+    /// returns when the header block has been fully assembled.
+    /// </summary>
+    /// <param name="payload">The decoded payload bytes (no padding / no priority data).</param>
+    /// <param name="endHeaders">Whether the inbound frame carried the END_HEADERS flag.</param>
+    /// <param name="endStream">
+    /// Whether the inbound frame carried the END_STREAM flag. Only meaningful on
+    /// the leading HEADERS frame; CONTINUATION frames do not carry END_STREAM.
+    /// </param>
+    /// <exception cref="Http2ConnectionException">
+    /// Thrown when HEADERS is received on a stream that is in a state where
+    /// HEADERS is illegal (e.g. <see cref="Http2StreamState.Closed"/> after a
+    /// reset that was not initiated by the peer).
+    /// </exception>
+    public void ReceiveHeaders(ReadOnlySpan<byte> payload, bool endHeaders, bool endStream)
     {
-        if (!payload.IsEmpty)
+        // RFC 9113 §5.1 — HEADERS is legal in:
+        //   - Idle: opens the stream (→ Open or → HalfClosedRemote if END_STREAM)
+        //   - Open / HalfClosedLocal: continuation of the request (trailers)
+        // Anything else is a connection error per RFC 9113 §5.1 (PROTOCOL_ERROR
+        // for an unexpected HEADERS on a closed stream, STREAM_CLOSED for one
+        // on a stream we already saw END_STREAM for).
+        switch (State)
         {
-            _headerBlock.Write(payload);
+            case Http2StreamState.Idle:
+                State = endStream ? Http2StreamState.HalfClosedRemote : Http2StreamState.Open;
+                break;
+            case Http2StreamState.Open:
+            case Http2StreamState.HalfClosedLocal:
+                // Trailers — the peer is wrapping up its half. END_STREAM
+                // must be set on a trailing HEADERS frame (RFC 9113 §8.1).
+                if (!endStream)
+                {
+                    throw new Http2ConnectionException(
+                        Http2ErrorCode.ProtocolError,
+                        $"HTTP/2 trailing HEADERS on stream {StreamId} must carry END_STREAM.");
+                }
+
+                State = State == Http2StreamState.Open
+                    ? Http2StreamState.HalfClosedRemote
+                    : Http2StreamState.Closed;
+                break;
+            case Http2StreamState.HalfClosedRemote:
+            case Http2StreamState.Closed:
+                throw new Http2ConnectionException(
+                    Http2ErrorCode.StreamClosed,
+                    $"HTTP/2 HEADERS frame received on stream {StreamId} in state {State}; the peer has already closed its half.");
         }
+
+        AppendHeaderBytes(payload);
 
         if (endHeaders)
         {
             HeadersCompleted = true;
-        }
-    }
-
-    public void AppendBody(ReadOnlySpan<byte> payload, bool endStream)
-    {
-        if (!payload.IsEmpty)
-        {
-            _body.Write(payload);
         }
 
         if (endStream)
@@ -55,9 +122,149 @@ internal sealed class Http2Stream
         }
     }
 
+    /// <summary>
+    /// Folds an inbound CONTINUATION payload into the accumulating header block.
+    /// CONTINUATION cannot change stream state — it only continues a header block
+    /// that an earlier HEADERS frame opened (RFC 9113 §6.10).
+    /// </summary>
+    /// <exception cref="Http2ConnectionException">
+    /// Thrown when CONTINUATION is received on a stream that is not currently in
+    /// a state that expects continuation frames.
+    /// </exception>
+    public void ReceiveContinuation(ReadOnlySpan<byte> payload, bool endHeaders)
+    {
+        // CONTINUATION is only legal mid-header-block on a stream that has
+        // already received its leading HEADERS frame. The connection-level
+        // continuation tracking guards the cross-stream rule; here we just
+        // assert that the stream itself is in a sane state.
+        if (State == Http2StreamState.Idle || State == Http2StreamState.Closed)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 CONTINUATION frame received on stream {StreamId} in state {State}.");
+        }
+
+        AppendHeaderBytes(payload);
+
+        if (endHeaders)
+        {
+            HeadersCompleted = true;
+        }
+    }
+
+    /// <summary>
+    /// Folds an inbound DATA payload into the accumulating body and applies the
+    /// END_STREAM transition.
+    /// </summary>
+    /// <exception cref="Http2StreamException">
+    /// Thrown when DATA is received on a stream that has already had its remote
+    /// half closed (STREAM_CLOSED — RFC 9113 §5.1).
+    /// </exception>
+    /// <exception cref="Http2ConnectionException">
+    /// Thrown when DATA is received on a stream in <see cref="Http2StreamState.Idle"/>
+    /// (no HEADERS yet) — that is a PROTOCOL_ERROR connection-level fault.
+    /// </exception>
+    public void ReceiveData(ReadOnlySpan<byte> payload, bool endStream)
+    {
+        switch (State)
+        {
+            case Http2StreamState.Idle:
+                throw new Http2ConnectionException(
+                    Http2ErrorCode.ProtocolError,
+                    $"HTTP/2 DATA frame received on stream {StreamId} before HEADERS.");
+            case Http2StreamState.Open:
+                if (endStream)
+                {
+                    State = Http2StreamState.HalfClosedRemote;
+                    InputCompleted = true;
+                }
+                break;
+            case Http2StreamState.HalfClosedLocal:
+                if (endStream)
+                {
+                    State = Http2StreamState.Closed;
+                    InputCompleted = true;
+                }
+                break;
+            case Http2StreamState.HalfClosedRemote:
+            case Http2StreamState.Closed:
+                // The peer is forbidden from sending DATA after it sent
+                // END_STREAM or after we reset the stream.
+                throw new Http2StreamException(
+                    StreamId,
+                    Http2ErrorCode.StreamClosed,
+                    $"HTTP/2 DATA frame received on stream {StreamId} in state {State}.");
+        }
+
+        if (!payload.IsEmpty)
+        {
+            _body.Write(payload);
+        }
+    }
+
+    /// <summary>
+    /// Applies an inbound RST_STREAM — moves the stream to
+    /// <see cref="Http2StreamState.Closed"/> and marks both halves as
+    /// finalised so any downstream consumer terminates promptly.
+    /// </summary>
+    /// <exception cref="Http2ConnectionException">
+    /// RST_STREAM on an idle stream is a connection error
+    /// (RFC 9113 §6.4).
+    /// </exception>
+    public void ReceiveReset()
+    {
+        if (State == Http2StreamState.Idle)
+        {
+            throw new Http2ConnectionException(
+                Http2ErrorCode.ProtocolError,
+                $"HTTP/2 RST_STREAM received on idle stream {StreamId}.");
+        }
+
+        State = Http2StreamState.Closed;
+        InputCompleted = true;
+    }
+
+    /// <summary>
+    /// Marks the stream's local half as closed because the server is about
+    /// to send a frame carrying END_STREAM (the typical case is the response
+    /// body's terminating DATA frame, or a header-only response).
+    /// </summary>
+    public void SendEndStream()
+    {
+        State = State switch
+        {
+            Http2StreamState.Open => Http2StreamState.HalfClosedLocal,
+            Http2StreamState.HalfClosedRemote => Http2StreamState.Closed,
+            // Idempotent / no-op for already-closed states.
+            _ => State,
+        };
+    }
+
+    /// <summary>
+    /// Marks the stream as closed because the server emitted a RST_STREAM.
+    /// </summary>
+    public void SendReset()
+    {
+        State = Http2StreamState.Closed;
+        InputCompleted = true;
+    }
+
+    /// <summary>
+    /// Marks the request side as complete without consuming additional bytes.
+    /// Used when an inbound HEADERS frame carries END_STREAM (a request with
+    /// no body).
+    /// </summary>
     public void CompleteInput()
     {
         InputCompleted = true;
+    }
+
+    private void AppendHeaderBytes(ReadOnlySpan<byte> payload)
+    {
+        if (!payload.IsEmpty)
+        {
+            _headerBlock.Write(payload);
+        }
     }
 
     public Http2Context CreateContext(HPackDecoder decoder, IHttpConnectionInfo connectionInfo, HttpScheme fallbackScheme, CancellationToken requestAborted)
@@ -141,5 +348,4 @@ internal sealed class Http2Stream
 
         return cookies;
     }
-
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2StreamState.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2StreamState.cs
@@ -1,0 +1,55 @@
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http2;
+
+/// <summary>
+/// Lifecycle state of an HTTP/2 stream, as defined by RFC 9113 §5.1.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The full state diagram includes <c>reserved (local)</c> and
+/// <c>reserved (remote)</c> for server-push (PUSH_PROMISE) flows. Cohesion's
+/// HTTP/2 server does not implement push (it advertises
+/// <c>SETTINGS_ENABLE_PUSH = 0</c> in its initial SETTINGS), so the reserved
+/// states are intentionally omitted — any path that would reach them is
+/// instead a protocol error.
+/// </para>
+/// <para>
+/// Transitions on a server, summarised from RFC 9113 §5.1:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="Idle"/>: stream id has never been
+///   referenced. Only <c>HEADERS</c> and <c>PRIORITY</c> are legal in this
+///   state.</description></item>
+///   <item><description><see cref="Open"/>: <c>HEADERS</c> has been
+///   received without <c>END_STREAM</c>. Both peers may send.</description></item>
+///   <item><description><see cref="HalfClosedRemote"/>: the peer (client)
+///   has closed its half by sending <c>END_STREAM</c>. The server may still
+///   send response frames; the client may only send
+///   <c>WINDOW_UPDATE</c>, <c>PRIORITY</c>, or
+///   <c>RST_STREAM</c>.</description></item>
+///   <item><description><see cref="HalfClosedLocal"/>: the server has sent
+///   <c>END_STREAM</c> on its response. Reserved for symmetry; uncommon on
+///   the server side where the request body usually arrives before the
+///   response is generated.</description></item>
+///   <item><description><see cref="Closed"/>: terminal state. Any frame
+///   other than <c>PRIORITY</c> is treated as either <c>STREAM_CLOSED</c>
+///   (stream error) or <c>PROTOCOL_ERROR</c> (connection error) depending
+///   on how the stream was closed.</description></item>
+/// </list>
+/// </remarks>
+internal enum Http2StreamState
+{
+    /// <summary>The stream id has never been referenced on this connection.</summary>
+    Idle = 0,
+
+    /// <summary>HEADERS without END_STREAM has been observed.</summary>
+    Open = 1,
+
+    /// <summary>The remote (client) half is closed; the server may still send.</summary>
+    HalfClosedRemote = 2,
+
+    /// <summary>The local (server) half is closed; the client may still send.</summary>
+    HalfClosedLocal = 3,
+
+    /// <summary>The stream is terminated — gracefully (END_STREAM both ways) or via reset.</summary>
+    Closed = 4,
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
@@ -461,6 +461,146 @@ public class Http2TransportTests
         Http2TestSettings.AssertContainsGoAway(output, expectedErrorCode);
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject HEADERS on stream 0 with PROTOCOL_ERROR")]
+    public async Task Http2_OnHeadersOnStreamZero_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §5.1.1 — stream 0 is reserved for connection-control
+        // frames. HEADERS on stream 0 is a connection error.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] headersOnStreamZero = Http2TestSettings.RawFrame(0x1, 0x4 /* END_HEADERS */, 0, Array.Empty<byte>());
+        await AssertGoAwayAsync(Combine(preface, settings, headersOnStreamZero), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject HEADERS on an even stream ID with PROTOCOL_ERROR")]
+    public async Task Http2_OnHeadersOnEvenStreamId_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §5.1.1 — client-initiated streams MUST use odd
+        // identifiers. Server-initiated (even) ids are only legal when
+        // produced by the server itself via PUSH_PROMISE, which Cohesion
+        // disables. An even client-initiated id is a connection error.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] headersOnEvenId = Http2TestSettings.RawFrame(0x1, 0x4, 2, Array.Empty<byte>());
+        await AssertGoAwayAsync(Combine(preface, settings, headersOnEvenId), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject HEADERS on a stream id lower than the highest previously seen")]
+    public async Task Http2_OnHeadersOnDecreasingStreamId_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §5.1.1 — newly opened client streams MUST use a
+        // strictly higher id than every previously opened client stream.
+        byte[] firstRequest = HttpProtocolPayloadFactory.CreateHttp2Request(3, "GET", "/three", "https", "api.test");
+        // Build a HEADERS frame on stream 1 (lower) — the connection has
+        // already seen stream 3, so opening stream 1 now is an ordering
+        // violation.
+        byte[] lowerIdHeaders = Http2TestSettings.RawFrame(0x1, 0x4 | 0x1 /* END_HEADERS + END_STREAM */, 1, Array.Empty<byte>());
+        await AssertGoAwayAsync(Combine(firstRequest, lowerIdHeaders), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject DATA on stream 0 with PROTOCOL_ERROR")]
+    public async Task Http2_OnDataOnStreamZero_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §6.1 — DATA frames MUST be associated with a non-zero
+        // stream.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] dataOnStreamZero = Http2TestSettings.RawFrame(0x0, 0, 0, new byte[] { 1, 2, 3 });
+        await AssertGoAwayAsync(Combine(preface, settings, dataOnStreamZero), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject DATA on an unknown/idle stream with PROTOCOL_ERROR")]
+    public async Task Http2_OnDataOnIdleStream_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §5.1 — DATA on an idle stream (no HEADERS observed) is
+        // a connection error.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] dataOnIdle = Http2TestSettings.RawFrame(0x0, 0, 5, new byte[] { 1, 2, 3 });
+        await AssertGoAwayAsync(Combine(preface, settings, dataOnIdle), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject RST_STREAM on stream 0 with PROTOCOL_ERROR")]
+    public async Task Http2_OnRstStreamOnStreamZero_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §6.4 — RST_STREAM frames MUST be associated with a
+        // specific stream; stream 0 is illegal.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] rstOnStreamZero = Http2TestSettings.RawFrame(0x3, 0, 0, new byte[4]);
+        await AssertGoAwayAsync(Combine(preface, settings, rstOnStreamZero), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject RST_STREAM on an idle stream with PROTOCOL_ERROR")]
+    public async Task Http2_OnRstStreamOnIdleStream_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §6.4 — RST_STREAM on a stream that has never been
+        // opened is a connection error.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        byte[] rstOnIdle = Http2TestSettings.RawFrame(0x3, 0, 7, new byte[4]);
+        await AssertGoAwayAsync(Combine(preface, settings, rstOnIdle), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reset a stream that receives DATA after END_STREAM")]
+    public async Task Http2_OnDataAfterEndStream_ShouldEmitRstStream()
+    {
+        // RFC 9113 §5.1 — DATA on a stream that has already had its remote
+        // half closed is a stream error (STREAM_CLOSED). The connection
+        // stays alive; the offending stream is reset.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>());
+        // Build a HEADERS+END_STREAM for stream 1 by reusing the factory
+        // (which produces a complete preface + SETTINGS + HEADERS bundle)
+        // and stripping the preface — we already have one above.
+        byte[] requestWithBody = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        byte[] requestWithoutPreface = new byte[requestWithBody.Length - Http2TestSettings.Preface().Length];
+        Array.Copy(requestWithBody, Http2TestSettings.Preface().Length, requestWithoutPreface, 0, requestWithoutPreface.Length);
+        // Now a DATA frame on the just-closed stream.
+        byte[] dataAfterClose = Http2TestSettings.RawFrame(0x0, 0, 1, new byte[] { 1, 2, 3 });
+
+        TestTransportConnectionContext transportContext = new(Combine(requestWithoutPreface, dataAfterClose));
+        // Inject our own preface + SETTINGS in front so the connection
+        // initialises cleanly.
+        transportContext = new(Combine(preface, settings, requestWithoutPreface, dataAfterClose));
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new ITransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        // Drive the receive loop. The first iteration produces the valid
+        // request. The second MoveNextAsync drives the loop past the
+        // DATA-after-END_STREAM frame — the state machine raises a stream
+        // error which the loop catches, emits a RST_STREAM, and continues.
+        // The pipe is finite, so the next ReadFrameAsync returns null and
+        // the loop yields break.
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext first = enumerator.Current;
+        first.Response.StatusCode = HttpStatusCode.Ok;
+        await httpConnectionContext.SendAsync(first);
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+
+        byte[] output = await transportContext.ReadOutputAsync();
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+
+        bool foundRstStream = false;
+        foreach ((long frameType, byte[] payload) in frames)
+        {
+            if (frameType == 3) // RST_STREAM
+            {
+                foundRstStream = true;
+                payload.Length.ShouldBe(4);
+                uint code = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(payload);
+                code.ShouldBe((uint)Http2ErrorCode.StreamClosed);
+            }
+        }
+
+        foundRstStream.ShouldBeTrue();
+    }
+
     private static byte[] Combine(params byte[][] buffers)
     {
         using MemoryStream stream = new();


### PR DESCRIPTION
PR 3a of the L01.01.11.07 family. Formalises HTTP/2 stream state transitions inside `Http2Stream` so frames cannot be accepted in illegal lifecycle states, and surfaces stream-level errors as `RST_STREAM` (recoverable) versus connection-level errors as `GOAWAY` (terminal) per RFC 9113 §5.4.

Closes #359 [.07.01]. Sets up #360 (flow control — PR 3b) and #361 (GOAWAY/reset compliance — PR 3c) which build on this engine.

## Summary

- New `Http2StreamState` enum (Idle / Open / HalfClosedRemote / HalfClosedLocal / Closed) per RFC 9113 §5.1.
- New `Http2StreamException` carrying `StreamId` + `ErrorCode` — receive loop catches it and emits `RST_STREAM` while keeping the connection alive (RFC 9113 §5.4.2).
- `Http2Stream` rewritten with explicit `Receive*` / `Send*` methods enforcing the legal-state matrix.
- `Http2ConnectionContext` integration: stream-ID validation (odd, non-zero, monotonically increasing — RFC §5.1.1), idle-vs-closed disambiguation via `_lastInboundStreamId`, proper `RST_STREAM` emission path.
- `SendAsync` now calls `Stream.SendEndStream()` after the response, transitioning the stream's local half closed.
- 8 new compliance tests.

## State matrix enforced

| Inbound frame | Idle | Open | HalfClosedRemote | HalfClosedLocal | Closed |
|---------------|------|------|------------------|-----------------|--------|
| HEADERS (open) | → Open / HCR (END_STREAM) | trailers (must carry END_STREAM) | reject STREAM_CLOSED | trailers | reject STREAM_CLOSED |
| DATA | reject PROTOCOL_ERROR | consume / → HCR (END_STREAM) | reject STREAM_CLOSED | consume / → Closed | reject STREAM_CLOSED |
| RST_STREAM | reject PROTOCOL_ERROR | → Closed | → Closed | → Closed | (no-op) |
| CONTINUATION | reject PROTOCOL_ERROR | continue header block | continue trailer block | continue header block | reject PROTOCOL_ERROR |

## Tests

| Scenario | Outcome |
|----------|---------|
| HEADERS on stream 0 | GOAWAY(PROTOCOL_ERROR) |
| HEADERS on even stream id | GOAWAY(PROTOCOL_ERROR) |
| HEADERS on decreasing stream id | GOAWAY(PROTOCOL_ERROR) |
| DATA on stream 0 | GOAWAY(PROTOCOL_ERROR) |
| DATA on idle stream (id > highest) | GOAWAY(PROTOCOL_ERROR) |
| DATA on closed stream (id ≤ highest) | RST_STREAM(STREAM_CLOSED) |
| RST_STREAM on stream 0 | GOAWAY(PROTOCOL_ERROR) |
| RST_STREAM on idle stream | GOAWAY(PROTOCOL_ERROR) |

## Test plan

- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http.Transports/tests/...csproj -c Release` → 82/82 (HTTP/2 portion: 21 → 29 cases)
- [x] `dotnet test libraries/Http/Assimalign.Cohesion.Http/tests/...csproj -c Release` → 192/192
- [x] Sessions / Forms / ClientFactory tests still pass → 28/28
- [x] HTTP family total → 302/302

## Out of scope

- Flow control window accounting → PR 3b (#360)
- GOAWAY semantics + graceful shutdown tests → PR 3c (#361)
- `MAX_CONCURRENT_STREAMS` enforcement — the local setting is advertised but not yet enforced by refusing streams beyond the cap
- Trailer field surfacing through `IHttpRequest` — trailing HEADERS are recognised by the state machine but not yet exposed to the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)