### PR TITLE
feat(http): antiforgery (CSRF) signed double-submit protection (L01.01.11.16)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/README.md
@@ -1,0 +1,72 @@
+# Assimalign.Cohesion.Http.Antiforgery
+
+Server-side cross-site request forgery (CSRF) protection for the Cohesion
+HTTP family. Implements `IHttpAntiforgery` with a **signed double-submit**
+token model built on BCL cryptography (HMAC-SHA256) — no
+`Microsoft.Extensions.*` and no external data-protection dependency.
+
+## Why a separate package
+
+The HTTP protocol core (`Assimalign.Cohesion.Http`) deliberately knows
+nothing about CSRF. Antiforgery is a server-side application concern that
+needs cookies and form parsing, so it layers on top of the protocol core via
+`Assimalign.Cohesion.Http.Cookies` (cookie-token storage) and
+`Assimalign.Cohesion.Http.Forms` (form-field token extraction). Protocol-only
+consumers (clients, proxies, edge caches) should not reference this package.
+
+## Surface
+
+| Type | Role |
+| --- | --- |
+| `IHttpAntiforgery` | The antiforgery service contract. |
+| `HttpAntiforgery` | Static factory: `HttpAntiforgery.Create(...)`. |
+| `HttpAntiforgeryOptions` | Cookie/form/header names, cookie attributes, HMAC key. |
+| `HttpAntiforgeryTokenSet` | The cookie + request token pair returned to callers. |
+| `IHttpAntiforgeryFeature` | Carries the service on an `IHttpContext`. |
+| `AntiforgeryValidationException` | Thrown by `ValidateRequestAsync` on failure. |
+| `context.Antiforgery` / `context.RequireAntiforgery` | Ergonomic context access. |
+
+## Usage
+
+Create one service per application (it is stateless and shareable). For
+multi-instance or restart-stable deployments, set a shared `Key`.
+
+```csharp
+IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options =>
+{
+    options.Key = sharedKeyBytes;          // omit for a per-process random key
+    options.CookieSecure = true;            // production
+});
+
+// Render path: mint + store the cookie token, hand the request token to the view.
+HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(context);
+// tokens.RequestToken  -> put in a hidden form field (tokens.FormFieldName) or send to the SPA
+// tokens.CookieToken   -> already queued as a Set-Cookie on the response
+
+// Submit path: validate the unsafe request.
+await antiforgery.ValidateRequestAsync(context); // throws AntiforgeryValidationException on failure
+// or, non-throwing:
+bool ok = await antiforgery.IsRequestValidAsync(context);
+```
+
+The request token is read from the configured form field
+(`__RequestVerificationToken` by default, requires the body to have been
+parsed by the Forms layer) or the configured header (`X-CSRF-TOKEN` by
+default, always available). Safe methods (GET, HEAD, OPTIONS, TRACE) skip
+validation.
+
+## Token model
+
+- Cookie token: `base64url(secret ‖ HMAC(key, 0x01 ‖ secret))`
+- Request token: `base64url(nonce ‖ HMAC(key, 0x02 ‖ nonce ‖ secret))`
+
+The request token is cryptographically bound to its cookie token and signed
+with the application key, so it cannot be forged or replayed across cookie
+tokens. See `docs/DESIGN.md` for the full rationale, the key-management
+posture, and non-goals.
+
+## Standards
+
+Follows OWASP CSRF prevention guidance (signed double-submit cookie,
+constant-time comparison). Safe-method classification follows RFC 9110
+§9.2.1.

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/docs/DESIGN.md
@@ -1,0 +1,128 @@
+# Assimalign.Cohesion.Http.Antiforgery — Design
+
+Server-side cross-site request forgery (CSRF) protection for the Cohesion
+HTTP family. This document captures the design intent so future readers do
+not have to re-derive it from the code.
+
+## Design intent
+
+Restore the familiar antiforgery ergonomics (`GetAndStoreTokens`,
+`ValidateRequestAsync`) on top of the Cohesion HTTP protocol core, which
+deliberately knows nothing about CSRF. The package realizes the
+`IHttpAntiforgery` / `IHttpAntiforgeryFeature` abstractions and the
+`HttpAntiforgeryTokenSet` model using only BCL cryptography — no
+`Microsoft.Extensions.*`, no external data-protection stack.
+
+## Token model: signed double-submit
+
+The classic double-submit cookie defense puts a random value in a cookie and
+requires the same value to be echoed in a header or form field. Its weakness
+is integrity: an attacker who can set a cookie (subdomain takeover, "cookie
+tossing") can also supply the matching request value. This package closes
+that gap by signing both halves with an application HMAC key:
+
+- **Cookie token** = `base64url(secret ‖ HMAC(key, 0x01 ‖ secret))`, where
+  `secret` is 32 random bytes. The signature lets the server detect an
+  injected/forged cookie token.
+- **Request token** = `base64url(nonce ‖ HMAC(key, 0x02 ‖ nonce ‖ secret))`,
+  where `nonce` is 16 random bytes and `secret` is the cookie token's secret.
+  The HMAC binds the request token to one specific cookie token and cannot be
+  produced without the key.
+
+The two HMAC uses are **domain-separated** by a leading byte (`0x01` cookie,
+`0x02` request) so a cookie token can never be replayed as a request token.
+
+Validation recomputes each HMAC and compares with
+`CryptographicOperations.FixedTimeEquals` to avoid timing side channels. A
+forged, truncated, or wrong-key token is treated as a validation failure
+(return `false` / throw `AntiforgeryValidationException`), never as an
+exception bubbling out of the read path — `Base64Url` decode failures on
+untrusted input are caught and mapped to "invalid".
+
+## Why an application key, and the default
+
+Signing requires a key. `HttpAntiforgeryOptions.Key` defaults to a fresh
+32-byte random value per `HttpAntiforgeryOptions` instance. That default is
+correct and zero-config for a single process, but it has two consequences
+that are documented on the type:
+
+- Tokens minted before a process restart will not validate afterward.
+- Multiple instances behind a load balancer reject each other's tokens.
+
+Cross-process / restart-stable deployments **must** set a shared `Key`. We
+chose a secure-by-default-but-explicit-for-scale posture over silently
+persisting a key somewhere, because key storage is a deployment decision the
+library should not make.
+
+## Service shape: stateless singleton over a passed-in context
+
+`IHttpAntiforgery` methods each take the `IHttpContext` they operate on, so
+the implementation (`HttpAntiforgeryService`) is stateless aside from its
+options + engine and is safe to share across requests. `HttpAntiforgery.Create`
+is the public factory; the internal service stays hidden behind the
+interface (interface-first). The `IHttpAntiforgeryFeature` carries the shared
+service on a context so downstream handlers resolve the *same* configured
+service — and therefore the same signing key — via
+`context.Antiforgery` / `context.RequireAntiforgery`.
+
+## Dependency direction
+
+```
+Assimalign.Cohesion.Http              (protocol core: request/response/headers)
+        ▲
+        │
+Assimalign.Cohesion.Http.Cookies      (cookie-token storage: request/response cookies)
+Assimalign.Cohesion.Http.Forms        (form-field request-token extraction)
+        ▲
+        │
+Assimalign.Cohesion.Http.Antiforgery  (this package)
+```
+
+The package reads the cookie token from `request.Cookies` and writes it to
+`response.Cookies` (Cookies package). It reads the request token from
+`request.Form[field]` (Forms package) and falls back to
+`request.Headers[header]`. It does not re-implement cookie parsing or form
+parsing.
+
+A note on the form path: `request.Form` returns the *already-parsed* form.
+Antiforgery does not itself trigger body parsing — that is the Forms layer's
+job (a forms middleware, or an explicit `ReadFormAsync`). When the form has
+not been parsed, the form-token path yields nothing and the header path is
+used. The header path is therefore always available; the form path requires
+the body to have been parsed first.
+
+## Safe-method skip
+
+`IsRequestValidAsync` returns `true` for GET, HEAD, OPTIONS, and TRACE
+without inspecting tokens, per RFC 9110 §9.2.1 (safe methods are not
+state-changing). Only unsafe methods require a valid pair.
+
+## Response side effects
+
+`GetAndStoreTokens` / `SetCookieTokenAndHeader` set the cookie token through
+the response cookie feature and apply `Cache-Control: no-cache, no-store`,
+`Pragma: no-cache`, and `X-Frame-Options: SAMEORIGIN`. A page carrying a
+token must not be cached or a shared cache could serve one user's token to
+another; `X-Frame-Options` reduces clickjacking that could drive token
+submission.
+
+## AOT posture
+
+No reflection, no runtime code generation, no dynamic serialization. All
+crypto is BCL (`HMACSHA256.HashData`, `RandomNumberGenerator`,
+`CryptographicOperations.FixedTimeEquals`, `Base64Url`). Token payloads are
+small and use stack buffers, so the hot paths are allocation-light.
+
+## Non-goals
+
+- **Key management / rotation.** The package consumes a key; it does not
+  persist, rotate, or distribute one. That belongs to the host.
+- **Identity binding.** ASP.NET Core's antiforgery can embed the
+  authenticated username/claims in the token. This package binds the request
+  token to the cookie token only. Identity binding can layer on later without
+  changing the wire shape.
+- **Triggering form parsing.** Reading the request token from a form relies
+  on the Forms layer having parsed the body; antiforgery does not own that.
+- **Middleware.** This package provides the service, feature, and ergonomics.
+  A pipeline that auto-validates every unsafe request is a higher-layer
+  concern.

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Assimalign.Cohesion.Http.Antiforgery.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Assimalign.Cohesion.Http.Antiforgery.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<RootNamespace>Assimalign.Cohesion.Http</RootNamespace>
+		<Description>HTTP antiforgery (CSRF) protection for the Cohesion HTTP family. Layered on top of Assimalign.Cohesion.Http; implements IHttpAntiforgery using a signed double-submit token model (HMAC-SHA256) over Assimalign.Cohesion.Http.Cookies (cookie-token storage) and Assimalign.Cohesion.Http.Forms (form-field request-token extraction). Server-side only; protocol-only consumers (clients, proxies, edge caches) should not reference this package.</Description>
 	</PropertyGroup>
 	<ItemGroup>
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Cookies" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Forms" />
 	</ItemGroup>
 </Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Exceptions/AntiforgeryValidationException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Exceptions/AntiforgeryValidationException.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Thrown when a request fails antiforgery validation &#8212; the required
+/// antiforgery token was missing, malformed, unsigned, or not bound to the
+/// presented cookie token.
+/// </summary>
+/// <remarks>
+/// Surfaced by <see cref="IHttpAntiforgery.ValidateRequestAsync"/>. Scoped to
+/// the HTTP area through the <see cref="HttpException"/> root rather than a
+/// framework-wide exception ancestry.
+/// </remarks>
+public sealed class AntiforgeryValidationException : HttpException
+{
+    /// <summary>
+    /// Initializes a new antiforgery validation failure.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    public AntiforgeryValidationException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.ProtocolViolation;
+    }
+
+    /// <summary>
+    /// Initializes a new antiforgery validation failure with an inner cause.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="inner">The inner exception.</param>
+    public AntiforgeryValidationException(string message, Exception inner)
+        : base(message, inner)
+    {
+        Code = HttpErrorCode.ProtocolViolation;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Extensions/HttpContextAntiforgeryExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Extensions/HttpContextAntiforgeryExtensions.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Surfaces the antiforgery service for the current exchange on
+/// <see cref="IHttpContext"/>, backed by an
+/// <see cref="IHttpAntiforgeryFeature"/> stored in the context's feature
+/// collection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The antiforgery service is stateless and created once per application via
+/// <see cref="HttpAntiforgery.Create(System.Action{HttpAntiforgeryOptions})"/>.
+/// Assigning it through <see cref="Antiforgery"/> installs a feature so
+/// downstream handlers can resolve the same configured service without
+/// re-creating it (and therefore validate against the same signing key).
+/// </para>
+/// </remarks>
+public static class HttpContextAntiforgeryExtensions
+{
+    extension(IHttpContext context)
+    {
+        /// <summary>
+        /// Gets or sets the antiforgery service attached to the current
+        /// exchange. Returns <see langword="null"/> when no
+        /// <see cref="IHttpAntiforgeryFeature"/> has been installed.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// On read: <paramref name="context"/> is <see langword="null"/>.
+        /// On write: <paramref name="context"/> or the assigned value is
+        /// <see langword="null"/>.
+        /// </exception>
+        public IHttpAntiforgery? Antiforgery
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(context);
+                return context.Features.Get<IHttpAntiforgeryFeature>()?.Antiforgery;
+            }
+            set
+            {
+                ArgumentNullException.ThrowIfNull(context);
+                ArgumentNullException.ThrowIfNull(value);
+                context.Features.Set<IHttpAntiforgeryFeature>(new HttpAntiforgeryFeature(value));
+            }
+        }
+
+        /// <summary>
+        /// Gets the antiforgery service attached to the current exchange,
+        /// throwing when none has been installed.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// No <see cref="IHttpAntiforgeryFeature"/> has been attached. Assign
+        /// <see cref="Antiforgery"/> before requiring it.
+        /// </exception>
+        public IHttpAntiforgery RequireAntiforgery
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(context);
+                return context.Features.Get<IHttpAntiforgeryFeature>()?.Antiforgery
+                    ?? throw new InvalidOperationException(
+                        "No IHttpAntiforgeryFeature has been attached to the HTTP context. Assign Antiforgery before requiring it.");
+            }
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/HttpAntiforgery.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/HttpAntiforgery.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Factory for the antiforgery service. Create one instance per application
+/// (it is stateless and safe to share across requests) and either invoke it
+/// directly or attach it to a context through
+/// <see cref="HttpContextAntiforgeryExtensions"/>.
+/// </summary>
+public static class HttpAntiforgery
+{
+    /// <summary>
+    /// Creates an antiforgery service with default options, optionally
+    /// customized by <paramref name="configure"/>.
+    /// </summary>
+    /// <param name="configure">An optional callback to adjust the
+    /// <see cref="HttpAntiforgeryOptions"/> before the service is built.</param>
+    /// <returns>A shareable <see cref="IHttpAntiforgery"/> instance.</returns>
+    public static IHttpAntiforgery Create(Action<HttpAntiforgeryOptions>? configure = null)
+    {
+        HttpAntiforgeryOptions options = new();
+        configure?.Invoke(options);
+        return new HttpAntiforgeryService(options);
+    }
+
+    /// <summary>
+    /// Creates an antiforgery service from the supplied options.
+    /// </summary>
+    /// <param name="options">The antiforgery options.</param>
+    /// <returns>A shareable <see cref="IHttpAntiforgery"/> instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    public static IHttpAntiforgery Create(HttpAntiforgeryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new HttpAntiforgeryService(options);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/HttpAntiforgeryOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/HttpAntiforgeryOptions.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Configures the antiforgery token names, cookie attributes, and the
+/// application HMAC key used to sign request tokens.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="Key"/> defaults to a fresh 32-byte cryptographically random
+/// value generated when the options are constructed. That default is suitable
+/// for a single process: tokens minted before a restart will not validate
+/// afterward, and multiple instances behind a load balancer will reject each
+/// other's tokens. Deployments that span processes or restarts MUST set
+/// <see cref="Key"/> to a shared, securely stored value.
+/// </para>
+/// </remarks>
+public sealed class HttpAntiforgeryOptions
+{
+    /// <summary>
+    /// Gets or sets the name of the cookie that stores the cookie token.
+    /// Defaults to <c>__cohesion-antiforgery</c>.
+    /// </summary>
+    public string CookieName { get; set; } = "__cohesion-antiforgery";
+
+    /// <summary>
+    /// Gets or sets the form field that carries the request token for
+    /// classic <c>&lt;form&gt;</c> posts. Defaults to
+    /// <c>__RequestVerificationToken</c>.
+    /// </summary>
+    public string FormFieldName { get; set; } = "__RequestVerificationToken";
+
+    /// <summary>
+    /// Gets or sets the request header that carries the request token for
+    /// AJAX/SPA clients. Defaults to <c>X-CSRF-TOKEN</c>.
+    /// </summary>
+    public string HeaderName { get; set; } = "X-CSRF-TOKEN";
+
+    /// <summary>
+    /// Gets or sets the symmetric key used to sign request tokens with
+    /// HMAC-SHA256. Defaults to a per-process random 32-byte key; override for
+    /// multi-instance or restart-stable deployments.
+    /// </summary>
+    public byte[] Key { get; set; } = RandomNumberGenerator.GetBytes(32);
+
+    /// <summary>
+    /// Gets or sets whether the cookie token is marked <c>HttpOnly</c>.
+    /// Defaults to <see langword="true"/> so client script cannot read it.
+    /// </summary>
+    public bool CookieHttpOnly { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the cookie token is marked <c>Secure</c>.
+    /// Defaults to <see langword="false"/> so the cookie flows over plain HTTP
+    /// in development; set to <see langword="true"/> in production.
+    /// </summary>
+    public bool CookieSecure { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <c>SameSite</c> mode applied to the cookie token.
+    /// Defaults to <see cref="HttpCookieSameSiteMode.Strict"/>.
+    /// </summary>
+    public HttpCookieSameSiteMode CookieSameSite { get; set; } = HttpCookieSameSiteMode.Strict;
+
+    /// <summary>
+    /// Gets or sets the path scope applied to the cookie token. Defaults to
+    /// <c>/</c>.
+    /// </summary>
+    public string CookiePath { get; set; } = "/";
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryFeature.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryFeature.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Default <see cref="IHttpAntiforgeryFeature"/> implementation installed by
+/// <see cref="HttpContextAntiforgeryExtensions"/> to carry the resolved
+/// <see cref="IHttpAntiforgery"/> service on an exchange.
+/// </summary>
+internal sealed class HttpAntiforgeryFeature : IHttpAntiforgeryFeature
+{
+    public HttpAntiforgeryFeature(IHttpAntiforgery antiforgery)
+    {
+        ArgumentNullException.ThrowIfNull(antiforgery);
+        Antiforgery = antiforgery;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(HttpAntiforgeryFeature);
+
+    /// <inheritdoc />
+    public IHttpAntiforgery Antiforgery { get; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryService.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryService.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Default <see cref="IHttpAntiforgery"/> implementation. A stateless,
+/// singleton-friendly service that operates on whatever
+/// <see cref="IHttpContext"/> is passed: it reads/writes the cookie token via
+/// the Cookies package, reads the request token from the configured form field
+/// (Forms package) or header, and signs/verifies the pair through
+/// <see cref="HttpAntiforgeryTokenEngine"/>.
+/// </summary>
+internal sealed class HttpAntiforgeryService : IHttpAntiforgery
+{
+    private static readonly HttpHeaderKey CacheControlHeader = "Cache-Control";
+    private static readonly HttpHeaderKey PragmaHeader = "Pragma";
+    private static readonly HttpHeaderKey XFrameOptionsHeader = "X-Frame-Options";
+
+    private readonly HttpAntiforgeryOptions _options;
+    private readonly HttpAntiforgeryTokenEngine _engine;
+
+    public HttpAntiforgeryService(HttpAntiforgeryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
+        _engine = new HttpAntiforgeryTokenEngine(options.Key);
+    }
+
+    /// <inheritdoc />
+    public HttpAntiforgeryTokenSet GetTokens(IHttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        CookieTokenResolution cookie = ResolveCookieToken(httpContext);
+        string requestToken = _engine.GenerateRequestToken(cookie.Secret);
+
+        return new HttpAntiforgeryTokenSet(requestToken, cookie.Token, _options.FormFieldName, _options.HeaderName);
+    }
+
+    /// <inheritdoc />
+    public HttpAntiforgeryTokenSet GetAndStoreTokens(IHttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        CookieTokenResolution cookie = ResolveCookieToken(httpContext);
+        if (cookie.IsNew)
+        {
+            StoreCookieToken(httpContext, cookie.Token);
+        }
+
+        ApplyNoCacheHeaders(httpContext);
+        string requestToken = _engine.GenerateRequestToken(cookie.Secret);
+
+        return new HttpAntiforgeryTokenSet(requestToken, cookie.Token, _options.FormFieldName, _options.HeaderName);
+    }
+
+    /// <inheritdoc />
+    public void SetCookieTokenAndHeader(IHttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        CookieTokenResolution cookie = ResolveCookieToken(httpContext);
+        if (cookie.IsNew)
+        {
+            StoreCookieToken(httpContext, cookie.Token);
+        }
+
+        ApplyNoCacheHeaders(httpContext);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsRequestValidAsync(IHttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // RFC 9110 §9.2.1 — safe methods are not state-changing and are not
+        // validated.
+        if (IsSafeMethod(httpContext.Request.Method))
+        {
+            return Task.FromResult(true);
+        }
+
+        byte[]? secret = _engine.ValidateCookieToken(ReadRequestCookieToken(httpContext));
+        if (secret is null)
+        {
+            return Task.FromResult(false);
+        }
+
+        bool valid = _engine.ValidateRequestToken(ReadRequestToken(httpContext), secret);
+        return Task.FromResult(valid);
+    }
+
+    /// <inheritdoc />
+    public async Task ValidateRequestAsync(IHttpContext httpContext)
+    {
+        if (!await IsRequestValidAsync(httpContext).ConfigureAwait(false))
+        {
+            throw new AntiforgeryValidationException(
+                "The required antiforgery token was missing or invalid.");
+        }
+    }
+
+    private CookieTokenResolution ResolveCookieToken(IHttpContext httpContext)
+    {
+        string? existing = ReadRequestCookieToken(httpContext);
+        byte[]? secret = _engine.ValidateCookieToken(existing);
+
+        if (secret is not null && existing is not null)
+        {
+            return new CookieTokenResolution(existing, secret, isNew: false);
+        }
+
+        string token = _engine.GenerateCookieToken(out byte[] freshSecret);
+        return new CookieTokenResolution(token, freshSecret, isNew: true);
+    }
+
+    private string? ReadRequestCookieToken(IHttpContext httpContext)
+    {
+        foreach (HttpCookie cookie in httpContext.Request.Cookies)
+        {
+            if (string.Equals(cookie.Name, _options.CookieName, StringComparison.Ordinal))
+            {
+                return cookie.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private string? ReadRequestToken(IHttpContext httpContext)
+    {
+        // Prefer the form field (classic <form> posts); the form is only
+        // populated when the body has already been parsed by the Forms layer.
+        IHttpFormCollection form = httpContext.Request.Form;
+        if (form.Count > 0
+            && form.TryGetValue(_options.FormFieldName, out HttpQueryValue formValue)
+            && !string.IsNullOrEmpty(formValue.Value))
+        {
+            return formValue.Value;
+        }
+
+        // Fall back to the header (AJAX/SPA clients).
+        if (httpContext.Request.Headers.TryGetValue(_options.HeaderName, out HttpHeaderValue headerValue)
+            && !string.IsNullOrEmpty(headerValue.Value))
+        {
+            return headerValue.Value;
+        }
+
+        return null;
+    }
+
+    private void StoreCookieToken(IHttpContext httpContext, string token)
+    {
+        IHttpCookieCollection cookies = httpContext.Response.Cookies;
+        RemoveByName(cookies, _options.CookieName);
+
+        cookies.Add(new HttpCookie(_options.CookieName, token, new HttpCookieOptions
+        {
+            HttpOnly = _options.CookieHttpOnly,
+            Secure = _options.CookieSecure,
+            SameSite = _options.CookieSameSite,
+            Path = _options.CookiePath,
+        }));
+    }
+
+    private static void ApplyNoCacheHeaders(IHttpContext httpContext)
+    {
+        IHttpHeaderCollection headers = httpContext.Response.Headers;
+
+        // A page carrying an antiforgery token must not be cached, or a shared
+        // cache could serve one user's token to another.
+        headers[CacheControlHeader] = "no-cache, no-store";
+        headers[PragmaHeader] = "no-cache";
+        headers[XFrameOptionsHeader] = "SAMEORIGIN";
+    }
+
+    private static void RemoveByName(IHttpCookieCollection cookies, string name)
+    {
+        HttpCookie? existing = null;
+        foreach (HttpCookie cookie in cookies)
+        {
+            if (string.Equals(cookie.Name, name, StringComparison.Ordinal))
+            {
+                existing = cookie;
+                break;
+            }
+        }
+
+        if (existing is not null)
+        {
+            cookies.Remove(existing);
+        }
+    }
+
+    private static bool IsSafeMethod(HttpMethod method)
+    {
+        return method == HttpMethod.Get
+            || method == HttpMethod.Head
+            || method == HttpMethod.Options
+            || method == HttpMethod.Trace;
+    }
+
+    private readonly struct CookieTokenResolution
+    {
+        public CookieTokenResolution(string token, byte[] secret, bool isNew)
+        {
+            Token = token;
+            Secret = secret;
+            IsNew = isNew;
+        }
+
+        public string Token { get; }
+
+        public byte[] Secret { get; }
+
+        public bool IsNew { get; }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryTokenEngine.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/src/Internal/HttpAntiforgeryTokenEngine.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Buffers.Text;
+using System.Security.Cryptography;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Mints and verifies the antiforgery cookie/request token pair using a
+/// signed double-submit model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cookie token is <c>base64url(secret ‖ HMAC(key, 0x01 ‖ secret))</c>
+/// where <c>secret</c> is 32 cryptographically random bytes. Signing the
+/// cookie token prevents an attacker from injecting an arbitrary cookie value
+/// ("cookie tossing").
+/// </para>
+/// <para>
+/// The request token is <c>base64url(nonce ‖ HMAC(key, 0x02 ‖ nonce ‖ secret))</c>
+/// where <c>nonce</c> is 16 random bytes and <c>secret</c> is the cookie
+/// token's secret. The HMAC binds the request token to one specific cookie
+/// token and cannot be forged without the application key. The two HMAC uses
+/// are domain-separated by a leading byte (<c>0x01</c> cookie, <c>0x02</c>
+/// request) so a cookie token can never be replayed as a request token.
+/// </para>
+/// <para>
+/// Verification recomputes the HMAC and compares it in fixed time via
+/// <see cref="CryptographicOperations.FixedTimeEquals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
+/// to avoid timing side channels. All primitives are BCL
+/// <see cref="System.Security.Cryptography"/>; the engine is allocation-light
+/// (stack buffers for the small token payloads) and AOT/trim safe.
+/// </para>
+/// </remarks>
+internal sealed class HttpAntiforgeryTokenEngine
+{
+    private const int SecretBytes = 32;
+    private const int NonceBytes = 16;
+    private const int MacBytes = 32;
+    private const byte CookieDomain = 0x01;
+    private const byte RequestDomain = 0x02;
+
+    private readonly byte[] _key;
+
+    public HttpAntiforgeryTokenEngine(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("The antiforgery HMAC key must not be empty.", nameof(key));
+        }
+
+        _key = key;
+    }
+
+    /// <summary>
+    /// Generates a new signed cookie token and returns the underlying secret
+    /// so a matching request token can be minted in the same operation.
+    /// </summary>
+    /// <param name="secret">The 32-byte cookie secret backing the token.</param>
+    /// <returns>The base64url cookie token string.</returns>
+    public string GenerateCookieToken(out byte[] secret)
+    {
+        secret = RandomNumberGenerator.GetBytes(SecretBytes);
+
+        Span<byte> token = stackalloc byte[SecretBytes + MacBytes];
+        secret.CopyTo(token);
+        ComputeMac(CookieDomain, secret, token.Slice(SecretBytes));
+
+        return Base64Url.EncodeToString(token);
+    }
+
+    /// <summary>
+    /// Validates a cookie token and returns its secret when the signature
+    /// checks out; otherwise returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="token">The base64url cookie token, or <see langword="null"/>.</param>
+    /// <returns>The cookie secret when valid; otherwise <see langword="null"/>.</returns>
+    public byte[]? ValidateCookieToken(string? token)
+    {
+        byte[]? raw = TryDecode(token);
+        if (raw is null || raw.Length != SecretBytes + MacBytes)
+        {
+            return null;
+        }
+
+        ReadOnlySpan<byte> secret = raw.AsSpan(0, SecretBytes);
+        ReadOnlySpan<byte> mac = raw.AsSpan(SecretBytes, MacBytes);
+
+        Span<byte> expected = stackalloc byte[MacBytes];
+        ComputeMac(CookieDomain, secret, expected);
+
+        return CryptographicOperations.FixedTimeEquals(mac, expected)
+            ? secret.ToArray()
+            : null;
+    }
+
+    /// <summary>
+    /// Generates a request token bound to the supplied cookie secret.
+    /// </summary>
+    /// <param name="cookieSecret">The secret from the paired cookie token.</param>
+    /// <returns>The base64url request token string.</returns>
+    public string GenerateRequestToken(ReadOnlySpan<byte> cookieSecret)
+    {
+        Span<byte> nonce = stackalloc byte[NonceBytes];
+        RandomNumberGenerator.Fill(nonce);
+
+        Span<byte> payload = stackalloc byte[NonceBytes + SecretBytes];
+        nonce.CopyTo(payload);
+        cookieSecret.CopyTo(payload.Slice(NonceBytes));
+
+        Span<byte> token = stackalloc byte[NonceBytes + MacBytes];
+        nonce.CopyTo(token);
+        ComputeMac(RequestDomain, payload, token.Slice(NonceBytes));
+
+        return Base64Url.EncodeToString(token);
+    }
+
+    /// <summary>
+    /// Validates a request token against the supplied cookie secret.
+    /// </summary>
+    /// <param name="token">The base64url request token, or <see langword="null"/>.</param>
+    /// <param name="cookieSecret">The secret from the validated cookie token.</param>
+    /// <returns><see langword="true"/> when the request token is well-formed,
+    /// correctly signed, and bound to <paramref name="cookieSecret"/>.</returns>
+    public bool ValidateRequestToken(string? token, ReadOnlySpan<byte> cookieSecret)
+    {
+        byte[]? raw = TryDecode(token);
+        if (raw is null || raw.Length != NonceBytes + MacBytes)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<byte> nonce = raw.AsSpan(0, NonceBytes);
+        ReadOnlySpan<byte> mac = raw.AsSpan(NonceBytes, MacBytes);
+
+        Span<byte> payload = stackalloc byte[NonceBytes + SecretBytes];
+        nonce.CopyTo(payload);
+        cookieSecret.CopyTo(payload.Slice(NonceBytes));
+
+        Span<byte> expected = stackalloc byte[MacBytes];
+        ComputeMac(RequestDomain, payload, expected);
+
+        return CryptographicOperations.FixedTimeEquals(mac, expected);
+    }
+
+    private void ComputeMac(byte domain, ReadOnlySpan<byte> data, Span<byte> destination)
+    {
+        Span<byte> buffer = stackalloc byte[1 + data.Length];
+        buffer[0] = domain;
+        data.CopyTo(buffer.Slice(1));
+        HMACSHA256.HashData(_key, buffer, destination);
+    }
+
+    private static byte[]? TryDecode(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Base64Url.DecodeFromChars(token);
+        }
+        catch (FormatException)
+        {
+            // Untrusted input — a malformed token is a validation failure,
+            // not an exceptional condition for the caller.
+            return null;
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/Assimalign.Cohesion.Http.Antiforgery.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/Assimalign.Cohesion.Http.Antiforgery.Tests.csproj
@@ -5,7 +5,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Antiforgery" />
-		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Transports" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Cookies" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Forms" />
 		<CohesionPackageReference Include="coverlet.collector" />
 		<CohesionPackageReference Include="Shouldly" />
 		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/Fixtures/TestHttpContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/Fixtures/TestHttpContext.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Antiforgery.Tests;
+
+/// <summary>
+/// Mutable <see cref="IHttpContext"/> test double: the request method is
+/// settable, request/response header collections are real (so the cookie and
+/// header extension paths work), and the feature collection is real (so the
+/// form feature and antiforgery feature can be installed).
+/// </summary>
+internal sealed class TestHttpContext : IHttpContext
+{
+    public TestHttpContext(HttpMethod? method = null)
+    {
+        Request = new TestHttpRequest(this, method ?? HttpMethod.Post);
+        Response = new TestHttpResponse(this);
+    }
+
+    public HttpVersion Version => HttpVersion.Http11;
+
+    public IHttpRequest Request { get; }
+
+    public IHttpResponse Response { get; }
+
+    public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
+
+    public IHttpFeatureCollection Features { get; } = new HttpFeatureCollection();
+
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+    public CancellationToken RequestAborted => CancellationToken.None;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    /// <summary>Sets the <c>Cookie</c> request header to <c>name=value</c>.</summary>
+    public void SetRequestCookie(string name, string value)
+    {
+        Request.Headers[HttpHeaderKey.Cookie] = $"{name}={value}";
+    }
+
+    /// <summary>Sets an arbitrary request header.</summary>
+    public void SetRequestHeader(string name, string value)
+    {
+        Request.Headers[name] = value;
+    }
+
+    /// <summary>Installs a parsed form feature carrying a single field.</summary>
+    public void SetFormField(string name, string value)
+    {
+        HttpFormCollection form = new();
+        form.Add(name, value);
+        Features.Set<IHttpFormFeature>(new TestFormFeature(form));
+    }
+
+    private sealed class TestHttpRequest : IHttpRequest
+    {
+        public TestHttpRequest(IHttpContext context, HttpMethod method)
+        {
+            HttpContext = context;
+            Method = method;
+        }
+
+        public HttpHost Host => HttpHost.Empty;
+        public HttpPath Path => HttpPath.Root;
+        public HttpMethod Method { get; set; }
+        public HttpScheme Scheme => HttpScheme.Http;
+        public IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+        public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+        public IHttpContext HttpContext { get; }
+        public Stream Body => Stream.Null;
+    }
+
+    private sealed class TestHttpResponse : IHttpResponse
+    {
+        public TestHttpResponse(IHttpContext context)
+        {
+            HttpContext = context;
+        }
+
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+        public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+        public IHttpContext HttpContext { get; }
+        public Stream Body { get; set; } = Stream.Null;
+    }
+
+    private sealed class TestFormFeature : IHttpFormFeature
+    {
+        private readonly IHttpFormCollection _form;
+
+        public TestFormFeature(IHttpFormCollection form)
+        {
+            _form = form;
+        }
+
+        public string Name => nameof(TestFormFeature);
+
+        public IHttpFormCollection? Form => _form;
+
+        public Task<IHttpFormCollection> ReadFormAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_form);
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/HttpAntiforgeryTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/HttpAntiforgeryTests.cs
@@ -1,0 +1,228 @@
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Antiforgery.Tests;
+
+public class HttpAntiforgeryTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should accept a freshly minted cookie + header token pair")]
+    public async Task ValidateRequest_OnValidPairViaHeader_ShouldPass()
+    {
+        // Arrange
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        TestHttpContext mint = new(HttpMethod.Get);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(mint);
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, tokens.CookieToken!);
+        post.SetRequestHeader(options.HeaderName, tokens.RequestToken!);
+
+        // Act
+        bool valid = await antiforgery.IsRequestValidAsync(post);
+
+        // Assert
+        valid.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should accept a valid token pair submitted via form field")]
+    public async Task ValidateRequest_OnValidPairViaForm_ShouldPass()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        TestHttpContext mint = new(HttpMethod.Get);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(mint);
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, tokens.CookieToken!);
+        post.SetFormField(options.FormFieldName, tokens.RequestToken!);
+
+        bool valid = await antiforgery.IsRequestValidAsync(post);
+
+        valid.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should skip validation for safe methods")]
+    public async Task ValidateRequest_OnSafeMethod_ShouldPassWithoutTokens()
+    {
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create();
+
+        foreach (HttpMethod method in new[] { HttpMethod.Get, HttpMethod.Head, HttpMethod.Options, HttpMethod.Trace })
+        {
+            TestHttpContext context = new(method);
+            (await antiforgery.IsRequestValidAsync(context)).ShouldBeTrue();
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject a tampered request token")]
+    public async Task ValidateRequest_OnTamperedRequestToken_ShouldFail()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        TestHttpContext mint = new(HttpMethod.Get);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(mint);
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, tokens.CookieToken!);
+        post.SetRequestHeader(options.HeaderName, Tamper(tokens.RequestToken!));
+
+        (await antiforgery.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject when the cookie token is missing")]
+    public async Task ValidateRequest_OnMissingCookie_ShouldFail()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestHeader(options.HeaderName, tokens.RequestToken!);
+        // No cookie installed.
+
+        (await antiforgery.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject when the request token is missing")]
+    public async Task ValidateRequest_OnMissingRequestToken_ShouldFail()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, tokens.CookieToken!);
+        // No request token in header or form.
+
+        (await antiforgery.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject a request token bound to a different cookie")]
+    public async Task ValidateRequest_OnMismatchedPair_ShouldFail()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+
+        HttpAntiforgeryTokenSet pairA = antiforgery.GetTokens(new TestHttpContext(HttpMethod.Get));
+        HttpAntiforgeryTokenSet pairB = antiforgery.GetTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, pairA.CookieToken!);   // cookie A
+        post.SetRequestHeader(options.HeaderName, pairB.RequestToken!);  // request token bound to B
+
+        (await antiforgery.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject garbage tokens without throwing")]
+    public async Task ValidateRequest_OnGarbageTokens_ShouldFail()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, "not-a-valid-token!!");
+        post.SetRequestHeader(options.HeaderName, "also-garbage");
+
+        (await antiforgery.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Validate: Should reject a pair minted under a different key")]
+    public async Task ValidateRequest_OnWrongKey_ShouldFail()
+    {
+        HttpAntiforgeryOptions optionsA = new();
+        HttpAntiforgeryOptions optionsB = new();
+        IHttpAntiforgery serviceA = HttpAntiforgery.Create(optionsA);
+        IHttpAntiforgery serviceB = HttpAntiforgery.Create(optionsB);
+
+        HttpAntiforgeryTokenSet tokens = serviceA.GetAndStoreTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(optionsA.CookieName, tokens.CookieToken!);
+        post.SetRequestHeader(optionsA.HeaderName, tokens.RequestToken!);
+
+        // serviceB has a different random key, so the cookie token's signature
+        // does not validate.
+        (await serviceB.IsRequestValidAsync(post)).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - ValidateRequestAsync: Should throw AntiforgeryValidationException on failure")]
+    public async Task ValidateRequestAsync_OnInvalid_ShouldThrow()
+    {
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create();
+        TestHttpContext post = new(HttpMethod.Post); // no tokens
+
+        await Should.ThrowAsync<AntiforgeryValidationException>(
+            async () => await antiforgery.ValidateRequestAsync(post));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - ValidateRequestAsync: Should complete silently on success")]
+    public async Task ValidateRequestAsync_OnValid_ShouldComplete()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, tokens.CookieToken!);
+        post.SetRequestHeader(options.HeaderName, tokens.RequestToken!);
+
+        await Should.NotThrowAsync(async () => await antiforgery.ValidateRequestAsync(post));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - GetAndStoreTokens: Should set the cookie token and anti-caching headers")]
+    public void GetAndStoreTokens_OnNewExchange_ShouldSetCookieAndSecurityHeaders()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+        TestHttpContext context = new(HttpMethod.Get);
+
+        HttpAntiforgeryTokenSet tokens = antiforgery.GetAndStoreTokens(context);
+
+        // The cookie token is queued on the response.
+        bool cookieStored = false;
+        foreach (HttpCookie cookie in context.Response.Cookies)
+        {
+            if (cookie.Name == options.CookieName && cookie.Value == tokens.CookieToken)
+            {
+                cookie.Options.HttpOnly.ShouldBeTrue();
+                cookieStored = true;
+            }
+        }
+        cookieStored.ShouldBeTrue();
+
+        // Anti-caching + framing headers are applied.
+        context.Response.Headers["Cache-Control"].Value.ShouldContain("no-cache");
+        context.Response.Headers["Pragma"].Value.ShouldBe("no-cache");
+        context.Response.Headers["X-Frame-Options"].Value.ShouldBe("SAMEORIGIN");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - GetTokens: Should reuse an existing valid cookie token")]
+    public void GetTokens_OnExistingValidCookie_ShouldReuseCookieToken()
+    {
+        HttpAntiforgeryOptions options = new();
+        IHttpAntiforgery antiforgery = HttpAntiforgery.Create(options);
+
+        HttpAntiforgeryTokenSet first = antiforgery.GetTokens(new TestHttpContext(HttpMethod.Get));
+
+        TestHttpContext second = new(HttpMethod.Get);
+        second.SetRequestCookie(options.CookieName, first.CookieToken!);
+        HttpAntiforgeryTokenSet reused = antiforgery.GetTokens(second);
+
+        reused.CookieToken.ShouldBe(first.CookieToken);
+        // A fresh request token is minted, still bound to the same cookie.
+        TestHttpContext post = new(HttpMethod.Post);
+        post.SetRequestCookie(options.CookieName, reused.CookieToken!);
+        post.SetRequestHeader(options.HeaderName, reused.RequestToken!);
+    }
+
+    private static string Tamper(string token)
+    {
+        char[] chars = token.ToCharArray();
+        int last = chars.Length - 1;
+        chars[last] = chars[last] == 'A' ? 'B' : 'A';
+        return new string(chars);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/HttpContextAntiforgeryExtensionsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Antiforgery/tests/HttpContextAntiforgeryExtensionsTests.cs
@@ -1,0 +1,73 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Antiforgery.Tests;
+
+public class HttpContextAntiforgeryExtensionsTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Antiforgery: Should return null before a feature is installed")]
+    public void Antiforgery_BeforeSet_ShouldReturnNull()
+    {
+        IHttpContext context = new TestHttpContext();
+
+        context.Antiforgery.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Antiforgery: Should round-trip through the setter")]
+    public void Antiforgery_Set_ShouldRoundTripViaGetter()
+    {
+        IHttpContext context = new TestHttpContext();
+        IHttpAntiforgery service = HttpAntiforgery.Create();
+
+        context.Antiforgery = service;
+
+        context.Antiforgery.ShouldBeSameAs(service);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Antiforgery: Should install an antiforgery feature on set")]
+    public void Antiforgery_Set_ShouldInstallFeature()
+    {
+        IHttpContext context = new TestHttpContext();
+
+        context.Antiforgery = HttpAntiforgery.Create();
+
+        context.Features.Get<IHttpAntiforgeryFeature>().ShouldNotBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Antiforgery: Should reject a null assignment")]
+    public void Antiforgery_SetNull_ShouldThrow()
+    {
+        IHttpContext context = new TestHttpContext();
+
+        Should.Throw<ArgumentNullException>(() => context.Antiforgery = null);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - RequireAntiforgery: Should throw before set")]
+    public void RequireAntiforgery_BeforeSet_ShouldThrow()
+    {
+        IHttpContext context = new TestHttpContext();
+
+        Should.Throw<InvalidOperationException>(() => _ = context.RequireAntiforgery);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - RequireAntiforgery: Should return the service after set")]
+    public void RequireAntiforgery_AfterSet_ShouldReturnService()
+    {
+        IHttpContext context = new TestHttpContext();
+        IHttpAntiforgery service = HttpAntiforgery.Create();
+        context.Antiforgery = service;
+
+        context.RequireAntiforgery.ShouldBeSameAs(service);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Antiforgery] - Antiforgery: Should throw on a null context")]
+    public void Antiforgery_OnNullContext_ShouldThrow()
+    {
+        IHttpContext context = null!;
+
+        Should.Throw<ArgumentNullException>(() => _ = context.Antiforgery);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `Assimalign.Cohesion.Http.Antiforgery` end to end — server-side
CSRF protection using a **signed double-submit** token model built on BCL
cryptography (HMAC-SHA256). No `Microsoft.Extensions.*`, no external
data-protection dependency.

The cookie token is a cryptographically random secret, signed; the request
token embeds a nonce plus an HMAC bound to the cookie secret, so a request
token cannot be forged without the application key and cannot be replayed
across cookie tokens. The two HMAC uses are domain-separated so a cookie
token can never be replayed as a request token.

## What's included

- **`HttpAntiforgeryOptions`** — cookie/form/header names, cookie attributes,
  and the application HMAC key (per-process random by default; override for
  multi-instance/restart-stable deployments).
- **`AntiforgeryValidationException`** — `HttpException`-rooted area exception.
- **`HttpAntiforgeryTokenEngine`** (internal) — HMAC-SHA256 signed token pair,
  base64url, constant-time (`CryptographicOperations.FixedTimeEquals`)
  verification; allocation-light stack buffers.
- **`HttpAntiforgeryService`** (`IHttpAntiforgery`) — `GetTokens`,
  `GetAndStoreTokens`, `IsRequestValidAsync`, `ValidateRequestAsync`,
  `SetCookieTokenAndHeader`. Cookie token via `Assimalign.Cohesion.Http.Cookies`;
  request token from a configured form field (`Assimalign.Cohesion.Http.Forms`)
  or header; safe-method skip (RFC 9110 §9.2.1); anti-cache +
  `X-Frame-Options: SAMEORIGIN` headers.
- **`HttpAntiforgery`** factory, **`HttpAntiforgeryFeature`** (internal), and
  **`context.Antiforgery` / `context.RequireAntiforgery`** extensions.
- **`docs/DESIGN.md`** + **`README.md`**.

## Tests

20 tests: token round-trip, tamper detection, mismatched pair, wrong-key,
garbage tokens, safe-method skip, form-vs-header extraction, response side
effects (cookie + anti-cache + framing headers), and the context extensions.
All green in Release.

## Notes

- `HttpAntiforgeryOptions.Key` defaults to a **per-process random key** —
  tokens do not survive a restart and multi-instance deployments must set a
  shared key. Documented on the type and in `DESIGN.md`.
- Adds `Assimalign.Cohesion.Http.Cookies` + `Assimalign.Cohesion.Http.Forms`
  project references to the package.

## Standards

OWASP CSRF prevention (signed double-submit, constant-time comparison);
safe-method classification per RFC 9110 §9.2.1; NativeAOT/trim safe.

Closes #704
Closes #705
Closes #706
Closes #707
Closes #708
Part of #701 (epic #314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
