### PR TITLE
feat(http): complete session surface to ISession parity (L01.01.11.17)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/README.md
@@ -21,8 +21,10 @@ stored in `IHttpContext.Features`.
 
 | Type | Role |
 |------|------|
-| `IHttpSession` | Abstract session contract &mdash; identifier, key/value bag, load/commit lifecycle |
+| `IHttpSession` | Abstract session contract &mdash; `Id`, `IsAvailable`, `Keys`, key/value bag, load/commit lifecycle |
 | `HttpSession` | In-memory implementation |
+| `HttpSessionExtensions` | Typed accessors over `IHttpSession`: `GetString`/`SetString`, `GetInt32`/`SetInt32`, `TryGetString`/`TryGetInt32` |
+| `HttpSessionOptions` | Session configuration (cookie name, idle timeout) |
 | `IHttpSessionFeature` | Per-exchange session state stored in `IHttpContext.Features` |
 | `HttpSessionFeature` | Default in-memory feature implementation (internal; constructed via the `Session` setter) |
 | `HttpContextSessionExtensions` | `context.Session` / `context.RequireSession` extension properties on `IHttpContext` |
@@ -47,6 +49,26 @@ When no session middleware has run, `context.Session` returns `null` and
 `context.RequireSession` throws `InvalidOperationException` &mdash; the
 distinction lets opt-in middleware peek without forcing every consumer
 into a try/catch.
+
+## Typed access
+
+The store is binary; typed accessors are extension members on
+`IHttpSession`, so they work for any implementation:
+
+```csharp
+session.SetString("user-id", "42");      // UTF-8
+session.SetInt32("cart-count", 3);       // big-endian Int32
+
+string? user = session.GetString("user-id");   // "42"
+int? count = session.GetInt32("cart-count");    // 3
+bool has = session.TryGetInt32("cart-count", out int n);
+
+foreach (string key in session.Keys) { /* ... */ }
+bool ready = session.IsAvailable;        // true once LoadAsync has completed
+```
+
+`GetInt32` returns `null` when the stored value is not exactly four bytes, so
+a string value is never silently reinterpreted as an int.
 
 ## Implementing a custom feature
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/docs/DESIGN.md
@@ -1,0 +1,88 @@
+# Assimalign.Cohesion.Http.Sessions — Design
+
+Per-exchange session state for the Cohesion HTTP family. This document
+captures the design intent so future readers do not have to re-derive it from
+the code.
+
+## Design intent
+
+Restore the familiar `ISession`-style ergonomics (`context.Session`, typed
+get/set, key enumeration) on top of the Cohesion HTTP protocol core, which
+deliberately omits sessions — they are an application-layer concept, not part
+of the wire protocol. The package attaches an `IHttpSessionFeature` to
+`IHttpContext.Features` and surfaces it through `context.Session` /
+`context.RequireSession`.
+
+## Surface shape: binary store + typed skin
+
+`IHttpSession` is a binary key/value store (`byte[]` values) plus lifecycle
+(`LoadAsync` / `CommitAsync`), availability (`IsAvailable`), and key
+enumeration (`Keys`). The binary core is the storage primitive; typed
+ergonomics (`GetString`/`SetString`, `GetInt32`/`SetInt32`, and their
+`TryGet` forms) are **extension members on `IHttpSession`**, not instance
+methods.
+
+Putting the typed accessors on the interface as extensions (rather than on
+the concrete `HttpSession`) means they apply to *every* session
+implementation — a future distributed or cookie-backed store inherits the
+exact same typed API for free, and the encoding rules live in one place.
+
+### Encoding rules
+
+- **Strings**: UTF-8.
+- **Int32**: fixed big-endian (network order) via
+  `BinaryPrimitives.WriteInt32BigEndian`. A stable, endian-independent byte
+  layout means a value written on one platform reads back identically on
+  another, and lets a different store interoperate by following the same
+  convention. `GetInt32` returns `null` when the stored value is not exactly
+  four bytes, so a string value is never silently reinterpreted as an int.
+
+## IsAvailable semantics
+
+`IsAvailable` follows the conventional `ISession` contract: it is `false`
+until `LoadAsync` completes, then `true`. The in-memory `HttpSession` imposes
+no real load step, so reads and writes succeed before `LoadAsync` is called;
+`IsAvailable` simply reports whether a load has occurred. A distributed store
+that genuinely needs an async fetch will gate readiness on the same flag
+without changing the contract.
+
+## Feature + context ergonomics
+
+`IHttpSessionFeature` carries the session on the context. The
+`context.Session` extension property reads through the feature (returns
+`null` when none is installed) and, on assignment, installs the internal
+`HttpSessionFeature`. `context.RequireSession` throws when no session has
+been attached, for call sites that treat the session as a hard dependency.
+Storage is the strongly-typed `IHttpContext.Features` collection (not the
+loose `Items` bag) so the feature can be observed or replaced by middleware.
+
+## Scope: in-process only
+
+This pass completes the **in-process** session surface. The package does not
+ship a backing-store abstraction, a session-id cookie, or middleware that
+resolves a session per request. `HttpSessionOptions` exists as the documented
+home for session configuration (cookie name, idle timeout) so those knobs
+have a stable place to live when store/cookie wiring lands, but the options
+do not bind the package to any store today.
+
+`LoadAsync` / `CommitAsync` are part of the contract precisely so a future
+distributed store can round-trip through a backend without changing callers;
+the in-memory implementation treats them as no-ops (aside from honoring
+cancellation and flipping `IsAvailable`).
+
+## AOT posture
+
+No reflection, no runtime code generation, no dynamic serialization. The
+store is a plain dictionary; typed accessors use `Encoding.UTF8` and
+`BinaryPrimitives`. Fully AOT/trim safe.
+
+## Non-goals
+
+- **Distributed / backing store.** No `IHttpSessionStore` abstraction in this
+  pass; the in-memory store is the only implementation.
+- **Session-id cookie establishment.** No cookie is read or written; the
+  Cookies dependency is intentionally not taken here.
+- **Per-request session middleware.** Resolving and committing a session
+  around each request is a higher-layer concern.
+- **Rich typed accessors beyond int/string.** Other scalar types can layer on
+  as additional extensions following the same encoding discipline.

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/Abstractions/IHttpSession.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/Abstractions/IHttpSession.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Threading;
@@ -11,9 +12,22 @@ namespace Assimalign.Cohesion.Http;
 public interface IHttpSession
 {
     /// <summary>
+    /// Gets a value indicating whether the session has been loaded and is
+    /// ready for use. Backing stores that require an asynchronous load set
+    /// this to <see langword="true"/> only after <see cref="LoadAsync"/>
+    /// completes.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
     /// Gets the unique session identifier.
     /// </summary>
     string Id { get; }
+
+    /// <summary>
+    /// Gets the keys currently present in the session.
+    /// </summary>
+    IEnumerable<string> Keys { get; }
 
     /// <summary>
     /// Loads the session state from the backing store.

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/Extensions/HttpSessionExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/Extensions/HttpSessionExtensions.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Typed get/set helpers over the binary <see cref="IHttpSession"/> store, so
+/// callers can persist common scalar types without hand-encoding bytes.
+/// </summary>
+/// <remarks>
+/// Strings use UTF-8; 32-bit integers use a fixed big-endian (network-order)
+/// encoding so the byte layout is stable and interoperable with any other
+/// store that follows the same convention. The helpers are extension members
+/// on <see cref="IHttpSession"/> so they apply to every session implementation,
+/// not just the in-memory <see cref="HttpSession"/>.
+/// </remarks>
+public static class HttpSessionExtensions
+{
+    extension(IHttpSession session)
+    {
+        /// <summary>
+        /// Stores a UTF-8 string value in the session.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <param name="value">The string value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public void SetString(string key, string value)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            ArgumentNullException.ThrowIfNull(value);
+
+            session.Set(key, Encoding.UTF8.GetBytes(value));
+        }
+
+        /// <summary>
+        /// Retrieves a UTF-8 string value, or <see langword="null"/> when the
+        /// key is not present.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <returns>The decoded string, or <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public string? GetString(string key)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+
+            return session.TryGetValue(key, out byte[]? bytes)
+                ? Encoding.UTF8.GetString(bytes)
+                : null;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve a UTF-8 string value from the session.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <param name="value">The decoded string when found.</param>
+        /// <returns><see langword="true"/> when the value was found; otherwise <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public bool TryGetString(string key, [NotNullWhen(true)] out string? value)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+
+            if (session.TryGetValue(key, out byte[]? bytes))
+            {
+                value = Encoding.UTF8.GetString(bytes);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Stores a 32-bit integer value using a big-endian encoding.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <param name="value">The integer value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public void SetInt32(string key, int value)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+
+            byte[] bytes = new byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+            session.Set(key, bytes);
+        }
+
+        /// <summary>
+        /// Retrieves a 32-bit integer value, or <see langword="null"/> when the
+        /// key is absent or the stored value is not exactly four bytes.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <returns>The integer value, or <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public int? GetInt32(string key)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+
+            return session.TryGetValue(key, out byte[]? bytes) && bytes.Length == sizeof(int)
+                ? BinaryPrimitives.ReadInt32BigEndian(bytes)
+                : null;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve a 32-bit integer value from the session.
+        /// </summary>
+        /// <param name="key">The session key.</param>
+        /// <param name="value">The integer value when found and well-formed.</param>
+        /// <returns><see langword="true"/> when a four-byte value was found; otherwise <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+        public bool TryGetInt32(string key, out int value)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            ArgumentException.ThrowIfNullOrEmpty(key);
+
+            if (session.TryGetValue(key, out byte[]? bytes) && bytes.Length == sizeof(int))
+            {
+                value = BinaryPrimitives.ReadInt32BigEndian(bytes);
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/HttpSession.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/HttpSession.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,9 +9,18 @@ namespace Assimalign.Cohesion.Http;
 /// <summary>
 /// Provides an in-memory HTTP session implementation.
 /// </summary>
+/// <remarks>
+/// The store is process-local and not persisted. <see cref="IsAvailable"/>
+/// follows the conventional <c>ISession</c> contract: it is
+/// <see langword="false"/> until <see cref="LoadAsync"/> has completed, after
+/// which the session is considered ready. The store itself imposes no load
+/// step, so reads and writes succeed before <see cref="LoadAsync"/> is called;
+/// <see cref="IsAvailable"/> simply reports whether a load has occurred.
+/// </remarks>
 public sealed class HttpSession : IHttpSession
 {
     private readonly Dictionary<string, byte[]> _values = new(StringComparer.Ordinal);
+    private bool _isAvailable;
 
     /// <summary>
     /// Initializes a new session.
@@ -24,12 +32,19 @@ public sealed class HttpSession : IHttpSession
     }
 
     /// <inheritdoc />
+    public bool IsAvailable => _isAvailable;
+
+    /// <inheritdoc />
     public string Id { get; }
+
+    /// <inheritdoc />
+    public IEnumerable<string> Keys => _values.Keys;
 
     /// <inheritdoc />
     public Task LoadAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _isAvailable = true;
         return Task.CompletedTask;
     }
 
@@ -46,40 +61,12 @@ public sealed class HttpSession : IHttpSession
         return _values.TryGetValue(key, out value);
     }
 
-    /// <summary>
-    /// Attempts to retrieve a UTF-8 string value from the session.
-    /// </summary>
-    /// <param name="key">The session key.</param>
-    /// <param name="value">The resolved string value.</param>
-    /// <returns><see langword="true"/> when the value was found; otherwise <see langword="false"/>.</returns>
-    public bool TryGetString(string key, [NotNullWhen(true)] out string? value)
-    {
-        if (_values.TryGetValue(key, out byte[]? bytes))
-        {
-            value = Encoding.UTF8.GetString(bytes);
-            return true;
-        }
-
-        value = null;
-        return false;
-    }
-
     /// <inheritdoc />
     public void Set(string key, byte[] value)
     {
         ArgumentNullException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
         _values[key] = value;
-    }
-
-    /// <summary>
-    /// Stores a UTF-8 string value in the session.
-    /// </summary>
-    /// <param name="key">The session key.</param>
-    /// <param name="value">The string value.</param>
-    public void SetString(string key, string value)
-    {
-        Set(key, Encoding.UTF8.GetBytes(value));
     }
 
     /// <inheritdoc />

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/HttpSessionOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/src/HttpSessionOptions.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Configures session behavior. This is the documented home for session
+/// configuration; it intentionally does not bind the package to any backing
+/// store. Cookie emission and store wiring are out of scope for the in-process
+/// session surface and are tracked separately.
+/// </summary>
+public sealed class HttpSessionOptions
+{
+    /// <summary>
+    /// Gets or sets the name of the cookie used to carry the session
+    /// identifier when session-cookie wiring is enabled. Defaults to
+    /// <c>.Cohesion.Session</c>.
+    /// </summary>
+    public string CookieName { get; set; } = ".Cohesion.Session";
+
+    /// <summary>
+    /// Gets or sets the path scope for the session cookie. Defaults to
+    /// <c>/</c>.
+    /// </summary>
+    public string CookiePath { get; set; } = "/";
+
+    /// <summary>
+    /// Gets or sets whether the session cookie is marked <c>HttpOnly</c>.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool CookieHttpOnly { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the idle timeout after which an inactive session is
+    /// considered expired. Defaults to 20 minutes.
+    /// </summary>
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(20);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpSessionOptionsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpSessionOptionsTests.cs
@@ -1,0 +1,38 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+public class HttpSessionOptionsTests
+{
+    [Fact]
+    public void Defaults_ShouldMatchConventionalValues()
+    {
+        HttpSessionOptions options = new();
+
+        options.CookieName.ShouldBe(".Cohesion.Session");
+        options.CookiePath.ShouldBe("/");
+        options.CookieHttpOnly.ShouldBeTrue();
+        options.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(20));
+    }
+
+    [Fact]
+    public void Properties_ShouldBeMutable()
+    {
+        HttpSessionOptions options = new()
+        {
+            CookieName = "custom",
+            CookiePath = "/app",
+            CookieHttpOnly = false,
+            IdleTimeout = TimeSpan.FromMinutes(5),
+        };
+
+        options.CookieName.ShouldBe("custom");
+        options.CookiePath.ShouldBe("/app");
+        options.CookieHttpOnly.ShouldBeFalse();
+        options.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(5));
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpSessionParityTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Sessions/tests/HttpSessionParityTests.cs
@@ -1,0 +1,123 @@
+using System.Linq;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+public class HttpSessionParityTests
+{
+    [Fact]
+    public void IsAvailable_BeforeLoad_ShouldBeFalse()
+    {
+        HttpSession session = new("id");
+
+        session.IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsAvailable_AfterLoad_ShouldBeTrue()
+    {
+        HttpSession session = new("id");
+
+        await session.LoadAsync();
+
+        session.IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Keys_ShouldReflectSetRemoveAndClear()
+    {
+        HttpSession session = new("id");
+
+        session.Set("a", [1]);
+        session.Set("b", [2]);
+        session.Keys.OrderBy(static k => k).ShouldBe(new[] { "a", "b" });
+
+        session.Remove("a");
+        session.Keys.ShouldBe(new[] { "b" });
+
+        session.Clear();
+        session.Keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetInt32_GetInt32_ShouldRoundTrip()
+    {
+        HttpSession session = new("id");
+
+        session.SetInt32("count", 42);
+
+        session.GetInt32("count").ShouldBe(42);
+    }
+
+    [Fact]
+    public void SetInt32_NegativeValue_ShouldRoundTrip()
+    {
+        HttpSession session = new("id");
+
+        session.SetInt32("delta", -123456);
+
+        session.GetInt32("delta").ShouldBe(-123456);
+    }
+
+    [Fact]
+    public void GetInt32_MissingKey_ShouldReturnNull()
+    {
+        HttpSession session = new("id");
+
+        session.GetInt32("missing").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetInt32_NonFourByteValue_ShouldReturnNull()
+    {
+        // A value that was not written as a 4-byte int must not be
+        // misinterpreted as one.
+        HttpSession session = new("id");
+        session.Set("text", [1, 2, 3]);
+
+        session.GetInt32("text").ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetInt32_ShouldRoundTrip()
+    {
+        HttpSession session = new("id");
+        session.SetInt32("n", 7);
+
+        bool found = session.TryGetInt32("n", out int value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(7);
+    }
+
+    [Fact]
+    public void TryGetInt32_MissingKey_ShouldReturnFalse()
+    {
+        HttpSession session = new("id");
+
+        session.TryGetInt32("missing", out int value).ShouldBeFalse();
+        value.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SetString_GetString_ShouldRoundTrip()
+    {
+        HttpSession session = new("id");
+
+        session.SetString("name", "cohesion");
+
+        session.GetString("name").ShouldBe("cohesion");
+    }
+
+    [Fact]
+    public void GetString_MissingKey_ShouldReturnNull()
+    {
+        HttpSession session = new("id");
+
+        session.GetString("missing").ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Completes `Assimalign.Cohesion.Http.Sessions` so the per-exchange session
surface reaches parity with the familiar `ISession` shape, while staying an
**in-process** application-layer concern layered on the protocol core. Builds
on the existing working in-memory `HttpSession` and the
`context.Session` / `context.RequireSession` ergonomics.

## What's included

- **`IHttpSession`** gains `IsAvailable` (false until `LoadAsync` completes)
  and `Keys`; **`HttpSession`** implements both.
- **`HttpSessionExtensions`** — typed accessors over `IHttpSession`:
  `GetString`/`SetString`, `GetInt32`/`SetInt32`, `TryGetString`/`TryGetInt32`.
  Strings UTF-8; `Int32` big-endian; `GetInt32` rejects non-4-byte values so a
  string is never misread as an int. The previous instance string helpers on
  `HttpSession` move here so every `IHttpSession` implementation inherits them.
- **`HttpSessionOptions`** — in-process session configuration (cookie name,
  path, HttpOnly, idle timeout) without binding to a backing store.
- **`docs/DESIGN.md`** added + **`README.md`** extended.

## Tests

Expanded **14 → 27**: availability before/after load, key enumeration across
set/remove/clear, int/string typed round-trips (including negative values,
missing keys, and the non-4-byte rejection), and option defaults/mutation.
All green in Release.

## Scope

In-process only — no backing-store abstraction, no session-id cookie, no
per-request session middleware. `LoadAsync` / `CommitAsync` remain in the
contract so a future store can round-trip without changing callers; the
in-memory store treats them as no-ops. `HttpSessionOptions` is the
configuration home for when store/cookie wiring lands.

## Standards

Surface mirrors the conventional `ISession` contract; application-layer, so no
HTTP wire-protocol RFC suite applies; NativeAOT/trim safe.

Closes #709
Closes #710
Closes #711
Closes #712
Part of #702 (epic #314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
