### PR TITLE
feat(http): request lifetime abort signal (L01.01.11.18)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/README.md
@@ -1,0 +1,48 @@
+# Assimalign.Cohesion.Http.RequestLifetime
+
+The writable per-request abort signal for the Cohesion HTTP family. The
+protocol core exposes a read-only `IHttpContext.RequestAborted` token; this
+package adds the writable side — an `IHttpRequestLifetime` whose `Abort()`
+triggers the token and whose `RequestAborted` can be observed or replaced.
+
+## Why a separate package
+
+`RequestAborted` on the context is read-only by design — the wire protocol
+does not let application code cancel a request. The ability to *trigger* an
+abort (cancel a long-running handler, shed load, react to a downstream
+failure) is a runtime-contract concern, so it layers on top of the core as an
+opt-in feature rather than bloating `IHttpContext`.
+
+## Surface
+
+| Type | Role |
+| --- | --- |
+| `IHttpRequestLifetime` | Settable `RequestAborted` token + `Abort()`. |
+| `HttpRequestLifetime` | `CancellationTokenSource`-backed implementation (disposable). |
+| `IHttpRequestLifetimeFeature` | Carries the lifetime on an `IHttpContext`. |
+| `context.RequestLifetime` | Resolves (lazily installs) the lifetime. |
+| `context.Abort()` | Aborts the current request. |
+
+## Usage
+
+```csharp
+// Observe the abort signal in a long-running handler.
+CancellationToken aborted = context.RequestLifetime.RequestAborted;
+await DoWorkAsync(aborted);
+
+// Force an abort from elsewhere (load shedding, downstream failure).
+context.Abort();
+```
+
+`context.RequestLifetime` lazily installs a default `HttpRequestLifetime` the
+first time it is read. `Abort()` is idempotent and safe to call after the
+request has completed.
+
+## Scope
+
+This package is **standalone**: it provides the feature, implementation, and
+context ergonomics with **no transport-layer changes**. The lazily-installed
+lifetime is self-contained and is not yet auto-linked to the transport's
+`IHttpContext.RequestAborted` — that wiring is a transport concern tracked
+separately. See `docs/DESIGN.md` for the lifetime model, the relationship to
+`IHttpContext.RequestAborted`, and non-goals.

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/docs/DESIGN.md
@@ -1,0 +1,77 @@
+# Assimalign.Cohesion.Http.RequestLifetime — Design
+
+The writable per-request abort signal for the Cohesion HTTP family. This
+document captures the design intent so future readers do not have to
+re-derive it from the code.
+
+## Design intent
+
+The protocol core exposes a **read-only** `IHttpContext.RequestAborted`
+token. Application code and middleware sometimes need the **writable** side:
+a token they can observe *and* a way to force an abort (cancel a long-running
+handler, shed load, react to a downstream failure). This package supplies
+that through `IHttpRequestLifetime` (a settable `RequestAborted` token plus
+`Abort()`), an `IHttpRequestLifetimeFeature` that carries it on a context, and
+ergonomic `context.RequestLifetime` / `context.Abort()` access.
+
+## Lifetime model
+
+`HttpRequestLifetime` is backed by a single `CancellationTokenSource`:
+
+- `RequestAborted` defaults to that source's token, so an observer sees the
+  cancellation when `Abort()` runs.
+- `Abort()` cancels the source. It is **idempotent** (safe to call repeatedly)
+  and a **no-op after `Dispose()`** — a finished request that is aborted again
+  should not throw.
+- `Dispose()` releases the source and is idempotent.
+
+The token is **settable** because the interface allows replacing it (for
+example to substitute a token linked to an external source). The documented
+contract: if you replace `RequestAborted`, you own that token's cancellation;
+`Abort()` still cancels the internal source. This mirrors the conventional
+`IHttpRequestLifetimeFeature` shape where the token and the abort trigger are
+both exposed and a host may swap the token.
+
+## Relationship to IHttpContext.RequestAborted
+
+`IHttpContext.RequestAborted` is the **read surface** the protocol core
+already provides; this package's `IHttpRequestLifetime` is the **writable
+source**. In a fully wired host the transport would create the lifetime and
+arrange for `context.RequestAborted` to observe `lifetime.RequestAborted`, so
+the two agree. That wiring lives in the transport and is **out of scope** for
+this standalone pass — see "Scope" below.
+
+## Context ergonomics
+
+`context.RequestLifetime` lazily installs a default `HttpRequestLifetime`
+(wrapped in the internal `HttpRequestLifetimeFeature`) when none is present,
+mirroring the lazy-install pattern used by the Cookies and Forms features.
+`context.Abort()` is sugar over `context.RequestLifetime.Abort()`. Storage is
+the strongly-typed `IHttpContext.Features` collection so middleware can
+observe or replace the feature.
+
+## Scope: standalone
+
+This pass delivers the feature, its implementation, and the context
+ergonomics — fully functional on their own (`Abort()` fires the token, the
+token is observable). It deliberately makes **no transport-layer changes**:
+the lazily-installed lifetime is self-contained and is not automatically
+linked to the transport's `IHttpContext.RequestAborted` or to a connection's
+`ConnectionCancelled`. That linkage is a transport concern tracked separately.
+
+## AOT posture
+
+No reflection, no runtime code generation. A single
+`CancellationTokenSource`, a settable token field, and `Interlocked`/`Volatile`
+guards for the dispose race. Fully AOT/trim safe.
+
+## Non-goals
+
+- **Transport wiring.** Driving the lifetime from the transport's
+  connection-cancelled / per-request abort signal is out of scope here.
+- **Timeouts.** This package does not impose request timeouts; a host can
+  layer a timer that calls `Abort()`.
+- **Disposal orchestration.** Whoever creates a standalone
+  `HttpRequestLifetime` owns disposing it. When the lifetime is lazily
+  installed via the extension, its disposal follows the host's context
+  teardown story (a transport-wiring concern).

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/Extensions/HttpContextRequestLifetimeExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/Extensions/HttpContextRequestLifetimeExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Surfaces the per-exchange request lifetime on <see cref="IHttpContext"/>,
+/// backed by an <see cref="IHttpRequestLifetimeFeature"/> stored in the
+/// context's feature collection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The protocol core exposes a read-only <see cref="IHttpContext.RequestAborted"/>
+/// token. This package adds the <em>writable</em> side: an
+/// <see cref="IHttpRequestLifetime"/> whose <c>Abort()</c> can trigger the
+/// abort signal and whose <c>RequestAborted</c> token can be observed or
+/// replaced. Reading <see cref="RequestLifetime"/> lazily installs a default
+/// <see cref="HttpRequestLifetime"/> when none has been attached.
+/// </para>
+/// <para>
+/// Standalone scope: the lazily-installed lifetime is self-contained and is
+/// not automatically linked to the transport's
+/// <see cref="IHttpContext.RequestAborted"/>. Wiring the two together is a
+/// transport concern handled separately.
+/// </para>
+/// </remarks>
+public static class HttpContextRequestLifetimeExtensions
+{
+    extension(IHttpContext context)
+    {
+        /// <summary>
+        /// Gets the request lifetime attached to the current exchange,
+        /// installing a default <see cref="HttpRequestLifetime"/> on first
+        /// read when none is present.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+        public IHttpRequestLifetime RequestLifetime
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(context);
+
+                IHttpRequestLifetimeFeature? feature = context.Features.Get<IHttpRequestLifetimeFeature>();
+                if (feature is null)
+                {
+                    feature = new HttpRequestLifetimeFeature(new HttpRequestLifetime());
+                    context.Features.Set<IHttpRequestLifetimeFeature>(feature);
+                }
+
+                return feature.RequestLifetime;
+            }
+        }
+
+        /// <summary>
+        /// Aborts the current request, triggering its
+        /// <see cref="IHttpRequestLifetime.RequestAborted"/> token. Installs a
+        /// default lifetime first when none is present.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+        public void Abort()
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            context.RequestLifetime.Abort();
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/HttpRequestLifetime.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/HttpRequestLifetime.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Default <see cref="IHttpRequestLifetime"/> implementation backed by a
+/// <see cref="CancellationTokenSource"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="RequestAborted"/> defaults to the internal source's token, and
+/// <see cref="Abort"/> cancels that source &#8212; so by default an observer of
+/// <see cref="RequestAborted"/> sees the cancellation. The token is settable
+/// per the interface: replacing it (for example to substitute a token linked
+/// to an external source) means the caller takes responsibility for that
+/// token's cancellation; <see cref="Abort"/> still cancels the internal
+/// source.
+/// </para>
+/// <para>
+/// <see cref="Abort"/> is idempotent and safe to call after
+/// <see cref="Dispose"/>. Dispose releases the underlying
+/// <see cref="CancellationTokenSource"/>.
+/// </para>
+/// </remarks>
+public sealed class HttpRequestLifetime : IHttpRequestLifetime, IDisposable
+{
+    private readonly CancellationTokenSource _abortedSource;
+    private CancellationToken _requestAborted;
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new request lifetime with a fresh cancellation source.
+    /// </summary>
+    public HttpRequestLifetime()
+    {
+        _abortedSource = new CancellationTokenSource();
+        _requestAborted = _abortedSource.Token;
+    }
+
+    /// <inheritdoc />
+    public CancellationToken RequestAborted
+    {
+        get => _requestAborted;
+        set => _requestAborted = value;
+    }
+
+    /// <inheritdoc />
+    public void Abort()
+    {
+        if (Volatile.Read(ref _disposed) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            _abortedSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced with Dispose — the request is already over, so the abort
+            // is moot. Idempotent by contract.
+        }
+    }
+
+    /// <summary>
+    /// Releases the underlying cancellation source. After disposal
+    /// <see cref="Abort"/> is a safe no-op.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
+        _abortedSource.Dispose();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/Internal/HttpRequestLifetimeFeature.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/src/Internal/HttpRequestLifetimeFeature.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Default <see cref="IHttpRequestLifetimeFeature"/> implementation installed
+/// by <see cref="HttpContextRequestLifetimeExtensions"/> to carry the
+/// <see cref="IHttpRequestLifetime"/> on an exchange.
+/// </summary>
+internal sealed class HttpRequestLifetimeFeature : IHttpRequestLifetimeFeature
+{
+    public HttpRequestLifetimeFeature(IHttpRequestLifetime requestLifetime)
+    {
+        ArgumentNullException.ThrowIfNull(requestLifetime);
+        RequestLifetime = requestLifetime;
+    }
+
+    /// <inheritdoc />
+    public string Name => nameof(HttpRequestLifetimeFeature);
+
+    /// <inheritdoc />
+    public IHttpRequestLifetime RequestLifetime { get; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/Assimalign.Cohesion.Http.RequestLifetime.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/Assimalign.Cohesion.Http.RequestLifetime.Tests.csproj
@@ -5,7 +5,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.RequestLifetime" />
-		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Transports" />
 		<CohesionPackageReference Include="coverlet.collector" />
 		<CohesionPackageReference Include="Shouldly" />
 		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/Fixtures/BareHttpContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/Fixtures/BareHttpContext.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.RequestLifetime.Tests;
+
+/// <summary>
+/// Minimal <see cref="IHttpContext"/> test double exposing a real feature
+/// collection so the request-lifetime extension can install and resolve its
+/// feature. Request/response members are inert stubs (the lifetime surface
+/// never touches them).
+/// </summary>
+internal sealed class BareHttpContext : IHttpContext
+{
+    public BareHttpContext()
+    {
+        Request = new BareHttpRequest(this);
+        Response = new BareHttpResponse(this);
+    }
+
+    public HttpVersion Version => HttpVersion.Http11;
+    public IHttpRequest Request { get; }
+    public IHttpResponse Response { get; }
+    public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
+    public IHttpFeatureCollection Features { get; } = new HttpFeatureCollection();
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+    public CancellationToken RequestAborted => CancellationToken.None;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private sealed class BareHttpRequest : IHttpRequest
+    {
+        public BareHttpRequest(IHttpContext context) => HttpContext = context;
+
+        public HttpHost Host => HttpHost.Empty;
+        public HttpPath Path => HttpPath.Root;
+        public HttpMethod Method => HttpMethod.Get;
+        public HttpScheme Scheme => HttpScheme.Http;
+        public IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+        public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+        public IHttpContext HttpContext { get; }
+        public Stream Body => Stream.Null;
+    }
+
+    private sealed class BareHttpResponse : IHttpResponse
+    {
+        public BareHttpResponse(IHttpContext context) => HttpContext = context;
+
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+        public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+        public IHttpContext HttpContext { get; }
+        public Stream Body { get; set; } = Stream.Null;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/HttpContextRequestLifetimeExtensionsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/HttpContextRequestLifetimeExtensionsTests.cs
@@ -1,0 +1,80 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.RequestLifetime.Tests;
+
+public class HttpContextRequestLifetimeExtensionsTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - RequestLifetime: Should install a feature on first read")]
+    public void RequestLifetime_FirstRead_ShouldInstallFeature()
+    {
+        IHttpContext context = new BareHttpContext();
+
+        IHttpRequestLifetime lifetime = context.RequestLifetime;
+
+        lifetime.ShouldNotBeNull();
+        context.Features.Get<IHttpRequestLifetimeFeature>().ShouldNotBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - RequestLifetime: Repeated reads should return the same instance")]
+    public void RequestLifetime_RepeatedReads_ShouldReturnSameInstance()
+    {
+        IHttpContext context = new BareHttpContext();
+
+        IHttpRequestLifetime first = context.RequestLifetime;
+        IHttpRequestLifetime second = context.RequestLifetime;
+
+        second.ShouldBeSameAs(first);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - RequestLifetime: Pre-installed feature should be observed")]
+    public void RequestLifetime_PreInstalledFeature_ShouldBeObserved()
+    {
+        IHttpContext context = new BareHttpContext();
+        HttpRequestLifetime seeded = new();
+        context.Features.Set<IHttpRequestLifetimeFeature>(new TestLifetimeFeature(seeded));
+
+        context.RequestLifetime.ShouldBeSameAs(seeded);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: The extension helper should trigger the lifetime token")]
+    public void Abort_ViaExtension_ShouldTriggerLifetimeToken()
+    {
+        IHttpContext context = new BareHttpContext();
+        IHttpRequestLifetime lifetime = context.RequestLifetime;
+
+        context.Abort();
+
+        lifetime.RequestAborted.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - RequestLifetime: Should throw on a null context")]
+    public void RequestLifetime_OnNullContext_ShouldThrow()
+    {
+        IHttpContext context = null!;
+
+        Should.Throw<ArgumentNullException>(() => _ = context.RequestLifetime);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: Should throw on a null context")]
+    public void Abort_OnNullContext_ShouldThrow()
+    {
+        IHttpContext context = null!;
+
+        Should.Throw<ArgumentNullException>(() => context.Abort());
+    }
+
+    private sealed class TestLifetimeFeature : IHttpRequestLifetimeFeature
+    {
+        public TestLifetimeFeature(IHttpRequestLifetime requestLifetime)
+        {
+            RequestLifetime = requestLifetime;
+        }
+
+        public string Name => nameof(TestLifetimeFeature);
+        public IHttpRequestLifetime RequestLifetime { get; }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/HttpRequestLifetimeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.RequestLifetime/tests/HttpRequestLifetimeTests.cs
@@ -1,0 +1,73 @@
+using System.Threading;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.RequestLifetime.Tests;
+
+public class HttpRequestLifetimeTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: Should trigger the RequestAborted token")]
+    public void Abort_ShouldTriggerRequestAborted()
+    {
+        HttpRequestLifetime lifetime = new();
+        lifetime.RequestAborted.IsCancellationRequested.ShouldBeFalse();
+
+        lifetime.Abort();
+
+        lifetime.RequestAborted.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: Should be idempotent")]
+    public void Abort_CalledTwice_ShouldBeIdempotent()
+    {
+        HttpRequestLifetime lifetime = new();
+
+        lifetime.Abort();
+        Should.NotThrow(() => lifetime.Abort());
+
+        lifetime.RequestAborted.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: Should invoke a registered callback")]
+    public void Abort_ShouldInvokeRegisteredCallback()
+    {
+        HttpRequestLifetime lifetime = new();
+        bool invoked = false;
+        using CancellationTokenRegistration registration = lifetime.RequestAborted.Register(() => invoked = true);
+
+        lifetime.Abort();
+
+        invoked.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Abort: Should be a no-op after dispose")]
+    public void Abort_AfterDispose_ShouldNotThrow()
+    {
+        HttpRequestLifetime lifetime = new();
+        lifetime.Dispose();
+
+        Should.NotThrow(() => lifetime.Abort());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - Dispose: Should be idempotent")]
+    public void Dispose_CalledTwice_ShouldNotThrow()
+    {
+        HttpRequestLifetime lifetime = new();
+
+        lifetime.Dispose();
+        Should.NotThrow(() => lifetime.Dispose());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.RequestLifetime] - RequestAborted: Should be settable to an external token")]
+    public void RequestAborted_Settable_ShouldReturnAssignedToken()
+    {
+        HttpRequestLifetime lifetime = new();
+        using CancellationTokenSource external = new();
+
+        lifetime.RequestAborted = external.Token;
+
+        lifetime.RequestAborted.ShouldBe(external.Token);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `Assimalign.Cohesion.Http.RequestLifetime` — the **writable**
per-request abort signal. The protocol core exposes a read-only
`IHttpContext.RequestAborted`; this package adds the writable side: an
`IHttpRequestLifetime` whose `Abort()` triggers the token and whose
`RequestAborted` can be observed or replaced.

## What's included

- **`HttpRequestLifetime`** (`IHttpRequestLifetime`, `IDisposable`) —
  `CancellationTokenSource`-backed. `RequestAborted` defaults to the source
  token and is settable; `Abort()` is idempotent and a no-op after `Dispose()`;
  `Dispose()` releases the source.
- **`HttpRequestLifetimeFeature`** (internal) — carries the lifetime on a
  context.
- **`HttpContextRequestLifetimeExtensions`** — `context.RequestLifetime`
  (lazy install) and `context.Abort()` ergonomics.
- **`docs/DESIGN.md`** + **`README.md`**.

## Tests

12 tests: abort propagation, idempotent abort, registered-callback firing,
post-dispose safety, idempotent dispose, settable token, feature
install/resolve, pre-installed feature, abort via the extension, and
null-context guards. All green in Release.

## Scope

Standalone — **no transport-layer changes**. The lazily-installed lifetime is
self-contained and is not yet auto-linked to the transport's
`IHttpContext.RequestAborted` or a connection's `ConnectionCancelled`; that
wiring is a transport concern tracked separately. The feature is fully
functional on its own (`Abort()` fires the token; the token is observable).

## Standards

Runtime-contract concern, so no HTTP wire-protocol RFC suite applies;
NativeAOT/trim safe; deterministic disposal, no `async void`.

Closes #713
Closes #714
Closes #715
Part of #703 (epic #314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
