### PR TITLE
feat(http): de-scope server push + enforce disabled (L01.01.11.13)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/docs/DESIGN.md
@@ -265,6 +265,42 @@ The design intent is *failure isolation*: a single malformed peer must
 never bring down the listener. Cancellation propagates normally so
 cooperative shutdown is unaffected.
 
+## Scope decision: server push (de-scoped)
+
+Cohesion **does not implement HTTP/2 or HTTP/3 server push.** This is a
+deliberate, recorded decision, not an implementation gap:
+
+- Server push has effectively failed in the field. Chromium disabled and
+  then removed HTTP/2 push (2022), and HTTP/3 push sees negligible
+  real-world client support. The complexity (push streams, `PUSH_PROMISE`,
+  `MAX_PUSH_ID` / `CANCEL_PUSH` bookkeeping, cache-state assumptions) buys
+  almost nothing for interoperability today, and `103 Early Hints` covers
+  the practical "warm the client early" use case without it.
+- The mechanism is optional for a compliant server: RFC 9113 §8.4 and
+  RFC 9114 §4.6 permit a server to simply never push.
+
+**Enforcement** (so the decision is real, not just documentation):
+
+- **HTTP/2** advertises `SETTINGS_ENABLE_PUSH = 0` in its initial SETTINGS
+  (a server's own ENABLE_PUSH is informational, but we state intent), never
+  emits `PUSH_PROMISE`, and **rejects an inbound `PUSH_PROMISE` as a
+  connection error of type `PROTOCOL_ERROR`** — which is also exactly what
+  RFC 9113 §8.4 requires of a server, since only servers may push and a
+  client therefore must never send one. Without the explicit rejection the
+  frame would fall through the dispatch and be silently ignored.
+- **HTTP/3** never opens a push stream and never sends `PUSH_PROMISE`. The
+  HTTP/3 stream engine rejects server-only frames (including `PUSH_PROMISE`)
+  arriving on a client-initiated request stream as `H3_FRAME_UNEXPECTED`
+  (enforced in the HTTP/3 stream/SETTINGS engine). A client's `MAX_PUSH_ID`
+  is harmless and ignored because the server never pushes.
+
+**Reversibility.** If a concrete consumer ever needs push, the frame types
+are already defined (`Http2FrameType.PushPromise`, `Http3FrameType.PushPromise`,
+`MaxPushId`); re-scoping would add a push-stream send path and flip the
+rejection into acceptance behind a configuration opt-in. The decision is
+documented here so a future reader does not mistake the absence for an
+oversight.
+
 ## Open questions / future work
 
 - A full design write-up covering the protocol context hierarchy

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2ConnectionContext.cs
@@ -409,7 +409,22 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             case Http2FrameType.GoAway:
                 ProcessGoAwayFrame(receivedFrame);
                 return null;
+            case Http2FrameType.PushPromise:
+                // RFC 9113 §8.4 / §6.6 — only servers send PUSH_PROMISE, and a
+                // client cannot push. A server MUST treat the receipt of a
+                // PUSH_PROMISE frame as a connection error of type
+                // PROTOCOL_ERROR. Cohesion does not implement server push
+                // (de-scoped; see docs/DESIGN.md), so rejecting it here is both
+                // the RFC requirement and the enforcement of that decision —
+                // without this case the frame would fall through and be
+                // silently ignored.
+                throw new Http2ConnectionException(
+                    Http2ErrorCode.ProtocolError,
+                    "PUSH_PROMISE received from the client; HTTP/2 servers do not accept pushed streams (RFC 9113 §8.4).");
             default:
+                // RFC 9113 §5.1 — frame types the endpoint does not recognise
+                // MUST be ignored. PRIORITY (0x2, deprecated) and any unknown
+                // extension frame land here.
                 return null;
         }
     }

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http2TransportTests.cs
@@ -312,6 +312,65 @@ public class Http2TransportTests
         await AssertGoAwayAsync(payload, Http2ErrorCode.ProtocolError);
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject a client-sent PUSH_PROMISE with PROTOCOL_ERROR")]
+    public async Task Http2_OnClientPushPromise_ShouldGoAwayProtocolError()
+    {
+        // RFC 9113 §8.4 / §6.6 — only servers send PUSH_PROMISE; a client
+        // cannot push. A server MUST treat receipt of a PUSH_PROMISE as a
+        // connection error of type PROTOCOL_ERROR. Cohesion de-scopes server
+        // push entirely (see docs/DESIGN.md), so this is also the enforcement
+        // of that decision: a peer can never coax the server into a push flow.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: Array.Empty<byte>());
+        // PUSH_PROMISE (0x5) on stream 1 with a promised-stream-id + empty block.
+        byte[] pushPromise = Http2TestSettings.RawFrame(frameType: 0x5, flags: 0x4 /* END_HEADERS */, streamId: 1, payload: new byte[] { 0x00, 0x00, 0x00, 0x02 });
+        await AssertGoAwayAsync(Combine(preface, settings, pushPromise), Http2ErrorCode.ProtocolError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should advertise SETTINGS_ENABLE_PUSH = 0")]
+    public async Task Http2_OnConnect_ShouldAdvertisePushDisabled()
+    {
+        // Cohesion does not implement server push, so the server's initial
+        // SETTINGS MUST advertise ENABLE_PUSH = 0 (RFC 9113 §6.5.2) to tell the
+        // peer not to expect pushed streams.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(frameType: 0x4, flags: 0, streamId: 0, payload: Array.Empty<byte>());
+
+        TestTransportConnectionContext transportContext = new(Combine(preface, settings));
+        TestSingleStreamTransportConnection connection = new(transportContext, TransportProtocol.Tcp);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http20, new TestServerTransport(TransportProtocol.Tcp, new TransportConnection[] { connection }));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        // Drain the receive loop to drive initialization — the server writes
+        // its initial SETTINGS during init. The payload is only preface +
+        // client SETTINGS (no request), so the loop initializes, ACKs, and
+        // completes at end-of-stream without yielding a context.
+        await foreach (IHttpContext _ in httpConnectionContext.ReceiveAsync())
+        {
+        }
+
+        byte[] output = await transportContext.ReadOutputAsync();
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+
+        byte[]? settingsPayload = null;
+        foreach ((long frameType, byte[] payload) in frames)
+        {
+            if (frameType == 0x4)
+            {
+                settingsPayload = payload;
+                break;
+            }
+        }
+
+        settingsPayload.ShouldNotBeNull();
+        Dictionary<Http2TestSettings.Parameter, uint> serverSettings = Http2TestSettings.ReadSettings(settingsPayload!);
+        serverSettings.ContainsKey(Http2TestSettings.Parameter.EnablePush).ShouldBeTrue();
+        serverSettings[Http2TestSettings.Parameter.EnablePush].ShouldBe(0u);
+    }
+
     [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http2: Should reject a non-SETTINGS first client frame with PROTOCOL_ERROR")]
     public async Task Http2_OnFirstClientFrameNotSettings_ShouldGoAwayProtocolError()
     {


### PR DESCRIPTION
## Summary

Records the explicit **de-scope decision for HTTP/2 and HTTP/3 server push** (the issue's acceptance criteria allow a documented retain-or-de-scope decision) and **enforces** it so the absence is deliberate, not an implied gap.

Server push has effectively failed in the field (Chromium removed HTTP/2 push in 2022; HTTP/3 push has negligible client support) and is optional for a compliant server (RFC 9113 §8.4, RFC 9114 §4.6).

## What's included

- **HTTP/2**: rejects an inbound `PUSH_PROMISE` as a connection error of type `PROTOCOL_ERROR`. Only servers may push, so a client sending `PUSH_PROMISE` is a protocol violation per RFC 9113 §8.4 — and this is also the enforcement of the de-scope. Previously the frame fell through the dispatch `default` and was **silently ignored** (latent compliance gap). The server already advertises `SETTINGS_ENABLE_PUSH = 0`.
- **Docs**: `Transports/docs/DESIGN.md` gains a "Server push (de-scoped)" section covering rationale, per-version enforcement, and the reversibility path. The HTTP/3 push-frame rejection lands naturally with the HTTP/3 stream engine (#334) as `H3_FRAME_UNEXPECTED`.
- **Tests**: client-sent `PUSH_PROMISE` → `GOAWAY(PROTOCOL_ERROR)`; server SETTINGS advertises `ENABLE_PUSH = 0`. Full H2 suite green (59 tests).

## Standards

RFC 9113 §8.4 / §6.6 (HTTP/2 push prohibition for clients); RFC 9114 §4.6 (HTTP/3 push is optional). NativeAOT/trim safe.

Closes #338
Part of #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)