### PR TITLE
feat(http): cross-version field normalization (L01.01.11.11)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/HPack/HPackDecodedHeaders.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/HPack/HPackDecodedHeaders.cs
@@ -62,12 +62,11 @@ internal sealed class HPackDecodedHeaders
 
         if (Headers.TryGetValue(key, out HttpHeaderValue existingValue))
         {
-            // RFC 9113 §8.2.3 — multiple Cookie fields in an HTTP/2
-            // field section MUST be coalesced into a single field with
-            // "; " separator before forwarding to HTTP/1.1 semantics.
-            Headers[key] = string.Equals(name, "cookie", StringComparison.OrdinalIgnoreCase)
-                ? string.Concat(existingValue.Value, "; ", value)
-                : HttpHeaderValue.Concat(existingValue, value);
+            // RFC 9113 §8.2.3 — repeated-field combining (Cookie coalesces with
+            // "; "; other list fields combine as distinct values) is the same
+            // rule for HTTP/2 and HTTP/3, centralized in HttpFieldNormalization
+            // so both versions behave identically.
+            Headers[key] = HttpFieldNormalization.CombineFieldValue(key, existingValue, value);
         }
         else
         {
@@ -164,23 +163,21 @@ internal sealed class HPackDecodedHeaders
 
     private static void RejectIfConnectionSpecific(string name, string value)
     {
-        // RFC 9113 §8.2.2 — these connection-specific header fields are
-        // forbidden in HTTP/2 because their semantics conflict with the
-        // protocol's multiplexed framing.
-        if (string.Equals(name, "connection", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "proxy-connection", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "keep-alive", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "transfer-encoding", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "upgrade", StringComparison.OrdinalIgnoreCase))
+        HttpHeaderKey key = new(name);
+
+        // RFC 9113 §8.2.2 — connection-specific header fields are forbidden in
+        // HTTP/2 (the rule is shared with HTTP/3 and lives in
+        // HttpFieldNormalization so both versions reject the same set).
+        if (HttpFieldNormalization.IsForbiddenInHttp2Or3(key))
         {
             throw new HPackDecodingException(
                 $"Connection-specific header field '{name}' is forbidden in HTTP/2 (RFC 9113 §8.2.2).");
         }
 
-        // RFC 9113 §8.2.2 — TE is the one exception: it MAY appear, but
-        // its value MUST be exactly "trailers".
+        // RFC 9113 §8.2.2 — TE is the one exception: it MAY appear, but its
+        // value MUST be exactly "trailers".
         if (string.Equals(name, "te", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(value, "trailers", StringComparison.OrdinalIgnoreCase))
+            && !HttpFieldNormalization.IsTeValueValidInHttp2Or3(value))
         {
             throw new HPackDecodingException(
                 $"HTTP/2 field 'TE' MUST carry only the value 'trailers'; got '{value}'.");

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Stream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http2/Http2Stream.cs
@@ -334,11 +334,10 @@ internal sealed class Http2Stream
         HPackDecodedHeaders decodedHeaders = decoder.DecodeRequestHeaders(_headerBlock.ToArray());
         byte[] bodyBytes = _body.ToArray();
         HttpQueryCollection query = ParseQuery(decodedHeaders.Path ?? "/", out HttpPath path);
-        HttpHost host = !string.IsNullOrWhiteSpace(decodedHeaders.Authority)
-            ? new HttpHost(decodedHeaders.Authority)
-            : decodedHeaders.Headers.TryGetValue(HttpHeaderKey.Host, out HttpHeaderValue hostValue)
-                ? new HttpHost(hostValue.Value)
-                : HttpHost.Empty;
+        // RFC 9113 §8.3.1 — :authority supersedes Host. Resolution is shared
+        // across versions via HttpFieldNormalization so HTTP/2 and HTTP/3
+        // reconcile authority identically.
+        HttpHost host = HttpFieldNormalization.ResolveAuthority(decodedHeaders.Authority, decodedHeaders.Headers);
         HttpScheme scheme = decodedHeaders.Scheme is null
             ? fallbackScheme
             : string.Equals(decodedHeaders.Scheme, "https", StringComparison.OrdinalIgnoreCase) ? HttpScheme.Https : HttpScheme.Http;

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3HeaderCodec.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3HeaderCodec.cs
@@ -54,9 +54,29 @@ internal static class Http3HeaderCodec
 
             HttpHeaderKey key = new(name);
 
+            // RFC 9114 §4.2 — connection-specific fields are forbidden in
+            // HTTP/3 (the same set as HTTP/2), and TE may only be "trailers".
+            // The rule is shared with HTTP/2 via HttpFieldNormalization. A
+            // malformed field section is rejected; the receive loop resets the
+            // offending stream without tearing down the connection.
+            if (HttpFieldNormalization.IsForbiddenInHttp2Or3(key))
+            {
+                throw new InvalidDataException(
+                    $"Connection-specific header field '{name}' is forbidden in HTTP/3 (RFC 9114 §4.2).");
+            }
+
+            if (string.Equals(name, "te", StringComparison.OrdinalIgnoreCase)
+                && !HttpFieldNormalization.IsTeValueValidInHttp2Or3(value))
+            {
+                throw new InvalidDataException(
+                    $"HTTP/3 field 'TE' MUST carry only the value 'trailers'; got '{value}'.");
+            }
+
             if (headers.TryGetValue(key, out HttpHeaderValue existingValue))
             {
-                headers[key] = HttpHeaderValue.Concat(existingValue, value);
+                // RFC 9114 §4.2.1 — repeated-field combining (Cookie coalesces
+                // with "; ", other list fields combine) matches HTTP/2.
+                headers[key] = HttpFieldNormalization.CombineFieldValue(key, existingValue, value);
             }
             else
             {
@@ -65,11 +85,9 @@ internal static class Http3HeaderCodec
         }
 
         HttpQueryCollection query = ParseQuery(pathValue ?? "/", out HttpPath path);
-        HttpHost host = !string.IsNullOrWhiteSpace(authority)
-            ? new HttpHost(authority)
-            : headers.TryGetValue(HttpHeaderKey.Host, out HttpHeaderValue hostValue)
-                ? new HttpHost(hostValue.Value)
-                : HttpHost.Empty;
+        // RFC 9114 §4.3.1 — :authority supersedes Host, resolved identically to
+        // HTTP/2 via HttpFieldNormalization.
+        HttpHost host = HttpFieldNormalization.ResolveAuthority(authority, headers);
         HttpScheme scheme = schemeValue is null
             ? fallbackScheme
             : string.Equals(schemeValue, "https", StringComparison.OrdinalIgnoreCase) ? HttpScheme.Https : HttpScheme.Http;

--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -116,3 +116,52 @@ dictionaries. Fully AOT/trim safe.
 - **Per-field parsers.** `HttpFieldRules` classifies field *names*; it does not
   parse field *values* (dates, cache-control directives, etc.). Value parsing
   belongs to the field-specific consumer.
+
+## Cross-version normalization
+
+`HttpFieldNormalization` is the operational layer over `HttpFieldRules`: where
+`HttpFieldRules` classifies field *names*, `HttpFieldNormalization` performs the
+*translation operations* a transport applies while turning a wire field section
+into an `IHttpRequest` / `IHttpResponse`. It exists so HTTP/1.1, HTTP/2, and
+HTTP/3 normalize the shared concepts identically instead of each re-encoding the
+quirks.
+
+### What it centralizes
+
+- **Authority resolution** (`ResolveAuthority`) — an explicit authority (the
+  HTTP/2 / HTTP/3 `:authority` pseudo-header, or the HTTP/1.1 absolute-form
+  target authority) supersedes the `Host` header, then falls back to `Host`,
+  then to `HttpHost.Empty` (RFC 9112 §3.2.2, RFC 9113 §8.3.1, RFC 9114 §4.3.1).
+  HTTP/2 (`Http2Stream`) and HTTP/3 (`Http3HeaderCodec`) both call it, so a
+  request with `:authority` set and a conflicting `Host` resolves the same way
+  on both.
+- **Connection-specific rejection** (`IsForbiddenInHttp2Or3` +
+  `IsTeValueValidInHttp2Or3`) — `Connection`, `Proxy-Connection`, `Keep-Alive`,
+  `Transfer-Encoding`, and `Upgrade` are forbidden in HTTP/2 and HTTP/3, and
+  `TE` may only be `trailers` (RFC 9113 §8.2.2, RFC 9114 §4.2). The HTTP/2 HPACK
+  decoder and the HTTP/3 codec share this rule — closing a real gap where the
+  HTTP/3 path previously did not reject these fields.
+- **Repeated-field combining** (`CombineFieldValue`) — the request `Cookie`
+  field coalesces with `"; "` (RFC 9113 §8.2.3, RFC 9114 §4.2.1); `Set-Cookie`
+  is never folded; other list fields combine as distinct values. Previously the
+  HTTP/3 path combined cookies with a comma; now it matches HTTP/2.
+
+### Version-specific boundaries that must NOT cross
+
+The normalization layer is deliberately the *only* place these
+version-spanning rules live, but some behaviors are intentionally version-local
+and must not be normalized away:
+
+- **Framing fields** (`Transfer-Encoding`, `Content-Length`, `Connection`,
+  `Keep-Alive`) are HTTP/1.1 connection mechanics. They are rejected — not
+  translated — when they appear in HTTP/2 / HTTP/3, because their semantics do
+  not exist there.
+- **Pseudo-headers** (`:method`, `:scheme`, `:path`, `:authority`) are an
+  HTTP/2 / HTTP/3 concept; they are reconciled into the version-neutral
+  request shape (method, scheme, path, host) at decode time and never emitted
+  as ordinary fields on the HTTP/1.1 side.
+
+### AOT posture
+
+Pure logic over the existing collections — no reflection, no codegen. Fully
+AOT/trim safe.

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpFieldNormalization.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpFieldNormalization.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Cross-version normalization operations that translate the shared HTTP
+/// concepts — authority, repeated-field combining, and the connection-specific
+/// field rules — consistently across HTTP/1.1, HTTP/2, and HTTP/3, so the
+/// transports do not each re-encode the version quirks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the operational layer over <see cref="HttpFieldRules"/> (which
+/// classifies field <em>names</em>): it composes those classifications into the
+/// actual translation operations a transport performs while building an
+/// <see cref="IHttpRequest"/> / <see cref="IHttpResponse"/> from a wire field
+/// section. Keeping it in one place is what lets HTTP/2 and HTTP/3 behave
+/// identically for authority resolution, cookie coalescing, and
+/// connection-specific rejection.
+/// </para>
+/// <para>
+/// The classification methods return booleans rather than throwing so each
+/// transport can raise its own protocol-appropriate error (HTTP/2
+/// <c>PROTOCOL_ERROR</c>, HTTP/3 <c>H3_MESSAGE_ERROR</c>, etc.).
+/// </para>
+/// </remarks>
+public static class HttpFieldNormalization
+{
+    /// <summary>
+    /// Resolves the message authority from the version-specific source with
+    /// the correct precedence: an explicit authority (the HTTP/2 / HTTP/3
+    /// <c>:authority</c> pseudo-header, or the HTTP/1.1 absolute-form target
+    /// authority) supersedes the <c>Host</c> header (RFC 9112 §3.2.2,
+    /// RFC 9113 §8.3.1, RFC 9114 §4.3.1). Falls back to <c>Host</c>, then to
+    /// <see cref="HttpHost.Empty"/>.
+    /// </summary>
+    /// <param name="authority">The explicit authority, or <see langword="null"/>.</param>
+    /// <param name="headers">The message headers (consulted for <c>Host</c>).</param>
+    /// <returns>The resolved host.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="headers"/> is <see langword="null"/>.</exception>
+    public static HttpHost ResolveAuthority(string? authority, IHttpHeaderCollection headers)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        if (!string.IsNullOrWhiteSpace(authority))
+        {
+            return new HttpHost(authority);
+        }
+
+        if (headers.TryGetValue(HttpHeaderKey.Host, out HttpHeaderValue host) && !host.IsEmpty)
+        {
+            return new HttpHost(host.Value);
+        }
+
+        return HttpHost.Empty;
+    }
+
+    /// <summary>
+    /// Determines whether a field is forbidden in an HTTP/2 or HTTP/3 field
+    /// section because it is connection-specific (RFC 9113 §8.2.2,
+    /// RFC 9114 §4.2). <c>TE</c> is intentionally excluded here — it is allowed
+    /// with a restricted value; use <see cref="IsTeValueValidInHttp2Or3"/>.
+    /// </summary>
+    /// <param name="key">The field name.</param>
+    /// <returns><see langword="true"/> when the field must be rejected.</returns>
+    public static bool IsForbiddenInHttp2Or3(HttpHeaderKey key)
+    {
+        return HttpFieldRules.IsConnectionSpecific(key);
+    }
+
+    /// <summary>
+    /// Determines whether a <c>TE</c> field value is valid in an HTTP/2 or
+    /// HTTP/3 field section. <c>TE</c> may only carry the value <c>trailers</c>
+    /// (RFC 9113 §8.2.2, RFC 9114 §4.2); an empty value is treated as absent.
+    /// </summary>
+    /// <param name="value">The <c>TE</c> field value.</param>
+    /// <returns><see langword="true"/> when the value is acceptable.</returns>
+    public static bool IsTeValueValidInHttp2Or3(HttpHeaderValue value)
+    {
+        return value.IsEmpty || string.Equals(value.Value, "trailers", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Combines a repeated field line into an existing value using the
+    /// version-neutral rule: the request <c>Cookie</c> field coalesces with a
+    /// "; " separator (RFC 9113 §8.2.3, RFC 9114 §4.2.1); <c>Set-Cookie</c> and
+    /// other list-valued fields are kept as distinct values (never folded into
+    /// one comma line for <c>Set-Cookie</c> — see
+    /// <see cref="HttpFieldRules.ProhibitsCombining"/>).
+    /// </summary>
+    /// <param name="key">The field name.</param>
+    /// <param name="existing">The value already accumulated for the field.</param>
+    /// <param name="incoming">The newly decoded value to combine.</param>
+    /// <returns>The combined field value.</returns>
+    public static HttpHeaderValue CombineFieldValue(HttpHeaderKey key, HttpHeaderValue existing, HttpHeaderValue incoming)
+    {
+        if (string.Equals(key.Value, "Cookie", StringComparison.OrdinalIgnoreCase))
+        {
+            return new HttpHeaderValue(string.Concat(existing.Value, "; ", incoming.Value));
+        }
+
+        // Set-Cookie and ordinary list fields become multiple distinct values.
+        // HttpHeaderValue preserves them separately; its Value comma-joins list
+        // fields on demand while Set-Cookie callers iterate the distinct values.
+        return HttpHeaderValue.Concat(existing, incoming);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/HttpFieldNormalizationTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/HttpFieldNormalizationTests.cs
@@ -1,0 +1,92 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+public class HttpFieldNormalizationTests
+{
+    [Fact]
+    public void ResolveAuthority_WhenAuthorityPresent_ShouldWinOverHost()
+    {
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.Host] = "host-header.test";
+
+        HttpHost host = HttpFieldNormalization.ResolveAuthority("authority.test", headers);
+
+        host.Value.ShouldBe("authority.test");
+    }
+
+    [Fact]
+    public void ResolveAuthority_WhenAuthorityAbsent_ShouldFallBackToHost()
+    {
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.Host] = "host-header.test";
+
+        HttpFieldNormalization.ResolveAuthority(null, headers).Value.ShouldBe("host-header.test");
+        HttpFieldNormalization.ResolveAuthority("   ", headers).Value.ShouldBe("host-header.test");
+    }
+
+    [Fact]
+    public void ResolveAuthority_WhenNeitherPresent_ShouldBeEmpty()
+    {
+        HttpHeaderCollection headers = new();
+
+        HttpFieldNormalization.ResolveAuthority(null, headers).ShouldBe(HttpHost.Empty);
+    }
+
+    [Theory]
+    [InlineData("Connection", true)]
+    [InlineData("Keep-Alive", true)]
+    [InlineData("Proxy-Connection", true)]
+    [InlineData("Transfer-Encoding", true)]
+    [InlineData("Upgrade", true)]
+    [InlineData("TE", false)] // TE is handled separately (allowed with a restricted value)
+    [InlineData("Content-Type", false)]
+    public void IsForbiddenInHttp2Or3_ShouldClassify(string name, bool expected)
+    {
+        HttpFieldNormalization.IsForbiddenInHttp2Or3(name).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("trailers", true)]
+    [InlineData("TRAILERS", true)]
+    [InlineData("", true)] // empty == absent
+    [InlineData("gzip", false)]
+    [InlineData("trailers, deflate", false)]
+    public void IsTeValueValidInHttp2Or3_ShouldClassify(string value, bool expected)
+    {
+        HttpFieldNormalization.IsTeValueValidInHttp2Or3(new HttpHeaderValue(value)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void CombineFieldValue_OnCookie_ShouldCoalesceWithSemicolon()
+    {
+        HttpHeaderValue combined = HttpFieldNormalization.CombineFieldValue(
+            HttpHeaderKey.Cookie, new HttpHeaderValue("a=1"), new HttpHeaderValue("b=2"));
+
+        combined.Value.ShouldBe("a=1; b=2");
+    }
+
+    [Fact]
+    public void CombineFieldValue_OnSetCookie_ShouldKeepDistinctValues()
+    {
+        HttpHeaderValue combined = HttpFieldNormalization.CombineFieldValue(
+            HttpHeaderKey.SetCookie, new HttpHeaderValue("a=1"), new HttpHeaderValue("b=2"));
+
+        // Set-Cookie must never be folded into one comma line: the two cookies
+        // remain distinct values.
+        combined.Count.ShouldBe(2);
+        combined[0].ShouldBe("a=1");
+        combined[1].ShouldBe("b=2");
+    }
+
+    [Fact]
+    public void CombineFieldValue_OnListField_ShouldCombineAsValues()
+    {
+        HttpHeaderValue combined = HttpFieldNormalization.CombineFieldValue(
+            HttpHeaderKey.Accept, new HttpHeaderValue("text/html"), new HttpHeaderValue("application/json"));
+
+        combined.Count.ShouldBe(2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **`HttpFieldNormalization`** — the operational layer over `HttpFieldRules` (#327) that performs the *translation operations* a transport applies while turning a wire field section into an `IHttpRequest`/`IHttpResponse`, so HTTP/1.1, HTTP/2, and HTTP/3 normalize shared concepts **identically** instead of each re-encoding the quirks.

## What's centralized (and the gaps it closes)

- **`ResolveAuthority`** — `:authority` (H2/H3) / absolute-form authority (H1) supersedes `Host`, then `Host`, then empty (RFC 9112 §3.2.2, RFC 9113 §8.3.1, RFC 9114 §4.3.1). Wired into `Http2Stream` and `Http3HeaderCodec`.
- **`IsForbiddenInHttp2Or3` + `IsTeValueValidInHttp2Or3`** — connection-specific fields rejected and `TE` restricted to `trailers` in H2 **and** H3 (RFC 9113 §8.2.2, RFC 9114 §4.2). **Closes a real compliance gap**: the HTTP/3 codec previously did not reject connection-specific fields at all.
- **`CombineFieldValue`** — `Cookie` coalesces with `"; "`, `Set-Cookie` stays distinct, list fields combine (RFC 9113 §8.2.3, RFC 9114 §4.2.1). **The HTTP/3 path previously combined cookies with a comma** — now it matches HTTP/2.

The HPACK decoder, `Http2Stream`, and `Http3HeaderCodec` now route through the shared layer.

## Version-local boundaries preserved

Framing fields (`Transfer-Encoding`, `Connection`, …) are *rejected*, not translated, in H2/H3; pseudo-headers are reconciled into the version-neutral request shape and never emitted as ordinary H1 fields. Documented in core `docs/DESIGN.md`.

## Tests

`HttpFieldNormalizationTests` (authority precedence, forbidden-field detection, TE validation, Cookie/`Set-Cookie`/list combining). Full HTTP family green — core 261, transports 121 — confirming the H2/H3 rewiring did not regress.

Closes #336
Part of #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)