### PR TITLE
feat(http3): HTTP/3 stream demux + control/SETTINGS engine (#334)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/docs/DESIGN.md
@@ -265,6 +265,132 @@ The design intent is *failure isolation*: a single malformed peer must
 never bring down the listener. Cancellation propagates normally so
 cooperative shutdown is unaffected.
 
+## HTTP/3 stream model and SETTINGS engine
+
+### What it is
+
+HTTP/3 (RFC 9114) runs over QUIC, which surfaces two kinds of
+peer-initiated streams: **bidirectional** streams carry requests, and
+**unidirectional** streams carry control data, QPACK table
+synchronisation, and (from a server) pushes. `Http3ConnectionContext`
+demultiplexes the two off a single accept loop:
+
+```
+accept inbound QUIC stream
+  ├─ bidirectional → request stream → parse HEADERS/DATA → yield IHttpContext
+  └─ unidirectional → read stream-type varint (RFC 9114 §6.2):
+       0x00 control      → read SETTINGS, apply, then keep open
+       0x02 QPACK encoder→ accept (no instructions; dynamic table disabled)
+       0x03 QPACK decoder→ accept (no instructions; dynamic table disabled)
+       0x01 push         → connection error (client must not push)
+       other             → abandon (unknown types are not an error)
+```
+
+The stream direction is reported by the transport via the
+`ITransportConnectionContext.IsBidirectional` signal (see below); the
+HTTP layer never inspects QUIC stream IDs directly.
+
+### Control stream and SETTINGS
+
+RFC 9114 §6.2.1 / §7.2.4 impose two hard rules that the engine enforces
+as connection errors (the loop stops yielding and the connection tears
+down):
+
+- **At most one control stream per peer.** A second control stream is
+  `H3_STREAM_CREATION_ERROR`.
+- **The first frame on the control stream MUST be SETTINGS.** A missing
+  or non-SETTINGS first frame is `H3_MISSING_SETTINGS`.
+
+The SETTINGS payload is parsed into `Http3PeerSettings`, a small
+identifier→value store that recognises `QPACK_MAX_TABLE_CAPACITY`
+(0x01), `MAX_FIELD_SECTION_SIZE` (0x06), `QPACK_BLOCKED_STREAMS` (0x07),
+and `SETTINGS_ENABLE_CONNECT_PROTOCOL` (0x08). Unknown identifiers are
+retained-but-ignored per RFC 9114 §7.2.4.1. Later control frames are not
+acted on in this supported subset — the engine reads and applies the
+mandatory opening SETTINGS frame and leaves the stream open.
+
+### QPACK encoder/decoder streams
+
+Each of the QPACK encoder (0x02) and decoder (0x03) streams may appear
+at most once (RFC 9204 §4.2); a duplicate is a connection error. With
+the QPACK dynamic table disabled (`QPACK_MAX_TABLE_CAPACITY = 0`, the
+posture #335 builds on) these streams carry no instructions the server
+must act on, so accepting the stream and recording that it was seen is
+sufficient. The streams are not drained frame-by-frame.
+
+### Push streams
+
+A client opening a push stream (type 0x01) is `H3_STREAM_CREATION_ERROR`
+— only a server may push, and Cohesion does not push (see "server push
+(de-scoped)" below). The engine treats it as a connection error.
+
+### Incremental reads off the PipeReader
+
+The unidirectional-stream handlers read directly off the transport's
+`PipeReader` (`ITransportConnectionPipe.Input`) using a buffered
+`ReadOnlySequence<byte>` model, **not** the `Stream` adapter that the
+request path uses. Two reasons:
+
+1. **Correct incremental framing.** Control data arrives as a varint
+   stream-type prefix followed by length-delimited frames. A varint's
+   width is encoded in its first two bits, so the reader must be able to
+   buffer "not enough bytes yet, ask for more" without losing the bytes
+   it already saw. `PipeReader.AdvanceTo(consumed, examined)` expresses
+   exactly that; layering a `Stream` over the pipe and reading
+   byte-by-byte does not, and in practice the adapter reported spurious
+   end-of-stream when a multi-byte read followed a run of single-byte
+   varint reads on the same pipe.
+2. **No double-buffering.** Reading the sequence in place and slicing the
+   SETTINGS payload out of the buffered segment avoids copying the whole
+   stream into a `MemoryStream` first.
+
+`QuicVariableLengthInteger.TryDecode(ReadOnlySequence<byte>, …)` is the
+incremental counterpart to the existing span-based `Decode`; it reports
+how many bytes it consumed so the loop can advance the reader precisely.
+
+> **Latent decoder bug fixed in passing.** The QUIC varint length
+> selector was written `first >> 6 switch { … }`. The C# `switch`
+> expression binds tighter than `>>`, so this parsed as
+> `first >> (6 switch { … })` = `first >> 8` — always `0` for a single
+> byte, meaning *every* varint was decoded as one byte. Single-byte
+> values (< 64) decode correctly that way, which is why no prior test
+> caught it; the first multi-byte varint on the decode path (a SETTINGS
+> value of 8192) exposed it. Fixed to `(first >> 6) switch { … }` in
+> `Decode`, `ReadAsync`, and `TryDecode`.
+
+### Why `IsBidirectional` lives on the transport abstraction
+
+Demultiplexing request streams from control/QPACK/push streams requires
+knowing a stream's direction, and only the transport knows it. The
+signal is therefore a member on `ITransportConnectionContext` in
+`Assimalign.Cohesion.Transports`, defined as a default interface member
+returning `true` so every existing single-stream context (TCP, ordinary
+request streams) is unaffected. Only a multiplex transport that exposes
+unidirectional streams overrides it: the QUIC transport's
+`QuicTransportContext` returns
+`Stream.Type == QuicStreamType.Bidirectional`. Keeping the signal in the
+transport abstraction — rather than inferring direction in the HTTP
+layer — preserves the dependency direction and lets any future protocol
+over QUIC reuse it.
+
+### AOT posture
+
+No reflection, no runtime code generation. Stream-type dispatch is a
+`switch` over varint constants; SETTINGS parsing is buffer arithmetic;
+the peer-settings store is a plain dictionary.
+
+### Non-goals
+
+- **Acting on post-SETTINGS control frames.** `GOAWAY`, `MAX_PUSH_ID`,
+  and friends are read off the wire where they appear but are not acted
+  on in this subset (the server never pushes, so `MAX_PUSH_ID` is inert;
+  graceful `GOAWAY`-driven drain is future work).
+- **QPACK dynamic table.** Encoder/decoder streams are accepted but not
+  processed; the static-table + Huffman + literal field-section support
+  (#335) runs with the dynamic table disabled.
+- **Flow control / stream limits.** QUIC-level flow control and
+  `MAX_STREAMS` accounting live in the QUIC transport, not here.
+
 ## Scope decision: server push (de-scoped)
 
 Cohesion **does not implement HTTP/2 or HTTP/3 server push.** This is a

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3ConnectionContext.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.Net;
 using System.Net.Quic;
 using System.Runtime.Versioning;
@@ -20,6 +22,10 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
     private readonly Dictionary<string, object?> _items;
     private readonly Func<IHttpFeatureCollection>? _createFeatures;
     private readonly bool _isSecure;
+    private readonly Http3PeerSettings _peerSettings = new();
+    private bool _controlStreamReceived;
+    private bool _qpackEncoderStreamReceived;
+    private bool _qpackDecoderStreamReceived;
     private EndPoint _localEndPoint;
     private EndPoint _remoteEndPoint;
 
@@ -89,12 +95,229 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
             _localEndPoint = streamContext.LocalEndPoint;
             _remoteEndPoint = streamContext.RemoteEndPoint;
 
+            // RFC 9114 §6 — a bidirectional stream is a request stream; the
+            // peer's unidirectional streams carry a type prefix (control,
+            // QPACK encoder/decoder, push) and are demultiplexed separately.
+            if (!streamContext.IsBidirectional)
+            {
+                if (await TryHandleUnidirectionalStreamAsync(streamContext, cancellationToken).ConfigureAwait(false))
+                {
+                    // A control-stream protocol violation — duplicate control
+                    // or QPACK stream, missing/!SETTINGS first frame, or a
+                    // client-created push stream — is a connection error
+                    // (RFC 9114 §6.2). Terminate the connection.
+                    yield break;
+                }
+
+                continue;
+            }
+
             Http3Context? context = await TryReadRequestAsync(streamContext, cancellationToken).ConfigureAwait(false);
 
             if (context is not null)
             {
                 yield return context;
             }
+        }
+    }
+
+    /// <summary>
+    /// Demultiplexes a peer-initiated unidirectional stream by its RFC 9114
+    /// §6.2 stream-type prefix. Returns <see langword="true"/> when the stream
+    /// is a connection-level protocol violation that must terminate the
+    /// connection (duplicate control / QPACK stream, missing or non-SETTINGS
+    /// first control frame, or a client-created push stream); otherwise
+    /// <see langword="false"/>.
+    /// </summary>
+    private async Task<bool> TryHandleUnidirectionalStreamAsync(ITransportConnectionContext streamContext, CancellationToken cancellationToken)
+    {
+        // RFC 9114 §6.2 — read directly off the PipeReader rather than the
+        // Stream adapter. Unidirectional streams are processed incrementally
+        // (a varint stream-type prefix, then type-specific frames), which the
+        // buffered ReadOnlySequence model expresses directly without the
+        // adapter's read-size quirks.
+        PipeReader reader = streamContext.Pipe.Input;
+
+        long? streamType;
+        try
+        {
+            streamType = await ReadVarintAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsPerStreamFailure(ex))
+        {
+            // The stream type could not be read — RFC 9114 §6.2 permits
+            // abandoning an unparseable unidirectional stream without
+            // affecting the connection.
+            return false;
+        }
+
+        if (streamType is null)
+        {
+            return false;
+        }
+
+        switch (streamType.Value)
+        {
+            case Http3StreamType.Control:
+                return await TryHandleControlStreamAsync(reader, cancellationToken).ConfigureAwait(false);
+
+            case Http3StreamType.QPackEncoder:
+                // RFC 9204 §4.2 — at most one encoder stream. With the dynamic
+                // table disabled (QPACK_MAX_TABLE_CAPACITY = 0) it carries no
+                // instructions to process, so accepting it is sufficient.
+                if (_qpackEncoderStreamReceived)
+                {
+                    return true;
+                }
+
+                _qpackEncoderStreamReceived = true;
+                return false;
+
+            case Http3StreamType.QPackDecoder:
+                if (_qpackDecoderStreamReceived)
+                {
+                    return true;
+                }
+
+                _qpackDecoderStreamReceived = true;
+                return false;
+
+            case Http3StreamType.Push:
+                // RFC 9114 §6.2.2 — a client MUST NOT create a push stream;
+                // treat it as H3_STREAM_CREATION_ERROR.
+                return true;
+
+            default:
+                // RFC 9114 §6.2 — unknown unidirectional stream types are not
+                // an error; the recipient may abandon them.
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads and applies the peer's control stream. Enforces a single control
+    /// stream and that its first frame is SETTINGS (RFC 9114 §6.2.1 / §7.2.4).
+    /// Returns <see langword="true"/> on a protocol violation.
+    /// </summary>
+    private async Task<bool> TryHandleControlStreamAsync(PipeReader reader, CancellationToken cancellationToken)
+    {
+        if (_controlStreamReceived)
+        {
+            // RFC 9114 §6.2.1 — only one control stream per peer.
+            return true;
+        }
+
+        _controlStreamReceived = true;
+
+        try
+        {
+            // RFC 9114 §6.2.1 / §7.2.4 — the first frame on the control stream
+            // MUST be SETTINGS. The frame is read and applied; later control
+            // frames are not acted on in this supported subset.
+            long? frameType = await ReadVarintAsync(reader, cancellationToken).ConfigureAwait(false);
+            long? frameLength = frameType is null
+                ? null
+                : await ReadVarintAsync(reader, cancellationToken).ConfigureAwait(false);
+
+            if (frameType is null || frameLength is null || frameType.Value != (long)Http3FrameType.Settings)
+            {
+                // Missing or non-SETTINGS first frame — H3_MISSING_SETTINGS.
+                return true;
+            }
+
+            byte[] payload = await ReadExactAsync(reader, checked((int)frameLength.Value), cancellationToken).ConfigureAwait(false);
+            ApplySettings(payload);
+            return false;
+        }
+        catch (Exception ex) when (IsPerStreamFailure(ex))
+        {
+            // The control stream is critical; a read/parse failure is a
+            // connection error (H3_FRAME_ERROR / H3_CLOSED_CRITICAL_STREAM).
+            return true;
+        }
+    }
+
+    private void ApplySettings(byte[] payload)
+    {
+        int index = 0;
+        while (index < payload.Length)
+        {
+            long identifier = QuicVariableLengthInteger.Decode(payload, ref index);
+            long value = QuicVariableLengthInteger.Decode(payload, ref index);
+            _peerSettings.Set(identifier, value);
+        }
+    }
+
+    /// <summary>
+    /// Reads a single QUIC variable-length integer off the pipe, buffering
+    /// across reads until a complete integer is available. Returns
+    /// <see langword="null"/> when the stream ends before any byte arrives.
+    /// </summary>
+    private static async Task<long?> ReadVarintAsync(PipeReader reader, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            ReadOnlySequence<byte> buffer = result.Buffer;
+
+            if (QuicVariableLengthInteger.TryDecode(buffer, out long value, out SequencePosition consumed))
+            {
+                reader.AdvanceTo(consumed);
+                return value;
+            }
+
+            if (result.IsCompleted)
+            {
+                if (buffer.IsEmpty)
+                {
+                    // Clean end of stream before the next integer began.
+                    reader.AdvanceTo(buffer.End);
+                    return null;
+                }
+
+                // Bytes remain but cannot form a complete integer.
+                reader.AdvanceTo(buffer.End);
+                throw new EndOfStreamException("The QUIC variable-length integer was incomplete.");
+            }
+
+            // Not enough buffered yet; mark everything examined so the next
+            // read waits for more bytes rather than returning the same span.
+            reader.AdvanceTo(buffer.Start, buffer.End);
+        }
+    }
+
+    /// <summary>
+    /// Reads exactly <paramref name="length"/> bytes off the pipe, buffering
+    /// across reads. Throws <see cref="EndOfStreamException"/> when the stream
+    /// ends first.
+    /// </summary>
+    private static async Task<byte[]> ReadExactAsync(PipeReader reader, int length, CancellationToken cancellationToken)
+    {
+        if (length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        while (true)
+        {
+            ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            ReadOnlySequence<byte> buffer = result.Buffer;
+
+            if (buffer.Length >= length)
+            {
+                ReadOnlySequence<byte> slice = buffer.Slice(0, length);
+                byte[] payload = slice.ToArray();
+                reader.AdvanceTo(slice.End);
+                return payload;
+            }
+
+            if (result.IsCompleted)
+            {
+                reader.AdvanceTo(buffer.End);
+                throw new EndOfStreamException("The HTTP/3 control SETTINGS frame was truncated.");
+            }
+
+            reader.AdvanceTo(buffer.Start, buffer.End);
         }
     }
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3PeerSettings.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3PeerSettings.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http3;
+
+/// <summary>
+/// The HTTP/3 settings advertised by the peer on its control stream
+/// (RFC 9114 §7.2.4, RFC 9204 §5, RFC 9220 §3). Unknown identifiers are
+/// retained but ignored, per RFC 9114 §7.2.4.1.
+/// </summary>
+internal sealed class Http3PeerSettings
+{
+    /// <summary>QPACK_MAX_TABLE_CAPACITY (RFC 9204 §5).</summary>
+    public const long QPackMaxTableCapacity = 0x01;
+
+    /// <summary>MAX_FIELD_SECTION_SIZE (RFC 9114 §7.2.4.1).</summary>
+    public const long MaxFieldSectionSize = 0x06;
+
+    /// <summary>QPACK_BLOCKED_STREAMS (RFC 9204 §5).</summary>
+    public const long QPackBlockedStreams = 0x07;
+
+    /// <summary>SETTINGS_ENABLE_CONNECT_PROTOCOL (RFC 9220 §3).</summary>
+    public const long EnableConnectProtocol = 0x08;
+
+    private readonly Dictionary<long, long> _values = new();
+
+    /// <summary>Records a setting value received from the peer.</summary>
+    /// <param name="identifier">The setting identifier.</param>
+    /// <param name="value">The setting value.</param>
+    public void Set(long identifier, long value)
+    {
+        _values[identifier] = value;
+    }
+
+    /// <summary>Attempts to read a recorded setting value.</summary>
+    /// <param name="identifier">The setting identifier.</param>
+    /// <param name="value">The recorded value when present.</param>
+    /// <returns><see langword="true"/> when the peer advertised the setting.</returns>
+    public bool TryGet(long identifier, out long value)
+    {
+        return _values.TryGetValue(identifier, out value);
+    }
+
+    /// <summary>
+    /// Gets whether the peer advertised support for the extended CONNECT
+    /// protocol (RFC 9220) — i.e. SETTINGS_ENABLE_CONNECT_PROTOCOL = 1.
+    /// </summary>
+    public bool EnableConnectProtocolNegotiated
+        => _values.TryGetValue(EnableConnectProtocol, out long value) && value == 1;
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3StreamType.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/Http3StreamType.cs
@@ -1,0 +1,22 @@
+namespace Assimalign.Cohesion.Http.Transports.Internal.Http3;
+
+/// <summary>
+/// HTTP/3 unidirectional stream type identifiers (RFC 9114 §6.2 / §11.2.4),
+/// carried as a QUIC variable-length integer prefix on each unidirectional
+/// stream. Bidirectional streams carry no such prefix — they are request
+/// streams.
+/// </summary>
+internal static class Http3StreamType
+{
+    /// <summary>The control stream (RFC 9114 §6.2.1).</summary>
+    public const long Control = 0x00;
+
+    /// <summary>A server push stream (RFC 9114 §6.2.2). A client must not open one.</summary>
+    public const long Push = 0x01;
+
+    /// <summary>The QPACK encoder stream (RFC 9204 §4.2).</summary>
+    public const long QPackEncoder = 0x02;
+
+    /// <summary>The QPACK decoder stream (RFC 9204 §4.2).</summary>
+    public const long QPackDecoder = 0x03;
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/QuicVariableLengthInteger.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/src/Internal/Http3/QuicVariableLengthInteger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,7 @@ internal static class QuicVariableLengthInteger
         }
 
         byte first = buffer[0];
-        int length = first >> 6 switch
+        int length = (first >> 6) switch
         {
             0 => 1,
             1 => 2,
@@ -45,7 +46,7 @@ internal static class QuicVariableLengthInteger
     public static long Decode(ReadOnlySpan<byte> buffer, ref int index)
     {
         byte first = buffer[index++];
-        int length = first >> 6 switch
+        int length = (first >> 6) switch
         {
             0 => 1,
             1 => 2,
@@ -65,6 +66,55 @@ internal static class QuicVariableLengthInteger
         }
 
         return (long)value;
+    }
+
+    /// <summary>
+    /// Attempts to decode a QUIC variable-length integer (RFC 9000 §16) from
+    /// the start of a buffered sequence without consuming bytes that are not
+    /// yet available. Used for incremental reads off a
+    /// <see cref="System.IO.Pipelines.PipeReader"/>.
+    /// </summary>
+    /// <param name="buffer">The buffered bytes to decode from.</param>
+    /// <param name="value">The decoded value when a complete integer is present.</param>
+    /// <param name="consumed">The position immediately after the decoded integer.</param>
+    /// <returns>
+    /// <see langword="true"/> when a complete integer was decoded; otherwise
+    /// <see langword="false"/>, indicating more bytes are required.
+    /// </returns>
+    public static bool TryDecode(ReadOnlySequence<byte> buffer, out long value, out SequencePosition consumed)
+    {
+        value = 0;
+        consumed = buffer.Start;
+
+        SequenceReader<byte> reader = new(buffer);
+
+        if (!reader.TryRead(out byte first))
+        {
+            return false;
+        }
+
+        int length = (first >> 6) switch
+        {
+            0 => 1,
+            1 => 2,
+            2 => 4,
+            _ => 8
+        };
+        ulong result = (ulong)(first & 0x3F);
+
+        for (int offset = 1; offset < length; offset++)
+        {
+            if (!reader.TryRead(out byte next))
+            {
+                return false;
+            }
+
+            result = (result << 8) | next;
+        }
+
+        value = (long)result;
+        consumed = reader.Position;
+        return true;
     }
 
     public static void Write(Stream stream, long value)

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http3TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/Http3TransportTests.cs
@@ -81,6 +81,107 @@ public class Http3TransportTests
         secondPath.ShouldBe("/two");
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http3: Should accept a control stream + SETTINGS and still process the request")]
+    public async Task Http3_OnControlStreamThenRequest_ShouldProcessRequest()
+    {
+        // RFC 9114 §6.2.1 / §7.2.4 — the peer opens a unidirectional control
+        // stream (type 0x00) whose first frame is SETTINGS, then a request on a
+        // bidirectional stream. The control stream is consumed and the request
+        // is still surfaced.
+        TestTransportConnectionContext control = new(
+            HttpProtocolPayloadFactory.CreateHttp3ControlStream((0x01, 0), (0x06, 8192)),
+            isBidirectional: false);
+        TestTransportConnectionContext request = new(
+            HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/c", "https", "a"));
+        TestMultiplexTransportConnection connection = new(new[] { control, request }, TransportProtocol.Quic);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http30, new TestServerTransport(TransportProtocol.Quic, new TransportConnection[] { connection }), isSecure: true);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        httpContext.Request.Path.Value.ShouldBe("/c");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http3: Should accept a QPACK encoder stream and still process the request")]
+    public async Task Http3_OnQPackStreamThenRequest_ShouldProcessRequest()
+    {
+        TestTransportConnectionContext qpack = new(
+            HttpProtocolPayloadFactory.CreateHttp3UnidirectionalStream(0x02 /* QPACK encoder */),
+            isBidirectional: false);
+        TestTransportConnectionContext request = new(
+            HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/q", "https", "a"));
+        TestMultiplexTransportConnection connection = new(new[] { qpack, request }, TransportProtocol.Quic);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http30, new TestServerTransport(TransportProtocol.Quic, new TransportConnection[] { connection }), isSecure: true);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        httpContext.Request.Path.Value.ShouldBe("/q");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http3: Should terminate on a duplicate control stream")]
+    public async Task Http3_OnDuplicateControlStream_ShouldTerminate()
+    {
+        // RFC 9114 §6.2.1 — only one control stream per peer; a second is
+        // H3_STREAM_CREATION_ERROR, a connection error.
+        TestTransportConnectionContext first = new(HttpProtocolPayloadFactory.CreateHttp3ControlStream((0x06, 8192)), isBidirectional: false);
+        TestTransportConnectionContext second = new(HttpProtocolPayloadFactory.CreateHttp3ControlStream((0x06, 8192)), isBidirectional: false);
+        TestMultiplexTransportConnection connection = new(new[] { first, second }, TransportProtocol.Quic);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http30, new TestServerTransport(TransportProtocol.Quic, new TransportConnection[] { connection }), isSecure: true);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http3: Should terminate when the control stream's first frame is not SETTINGS")]
+    public async Task Http3_OnControlStreamMissingSettings_ShouldTerminate()
+    {
+        // RFC 9114 §6.2.1 — the first control frame MUST be SETTINGS. A control
+        // stream (type 0x00) whose first frame is DATA (0x00, length 0) is
+        // H3_MISSING_SETTINGS.
+        TestTransportConnectionContext badControl = new(
+            HttpProtocolPayloadFactory.CreateHttp3UnidirectionalStream(0x00, new byte[] { 0x00, 0x00 }),
+            isBidirectional: false);
+        TestMultiplexTransportConnection connection = new(new[] { badControl }, TransportProtocol.Quic);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http30, new TestServerTransport(TransportProtocol.Quic, new TransportConnection[] { connection }), isSecure: true);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Transports] - Http3: Should terminate on a client-created push stream")]
+    public async Task Http3_OnClientPushStream_ShouldTerminate()
+    {
+        // RFC 9114 §6.2.2 — a client MUST NOT create a push stream (type 0x01);
+        // it is H3_STREAM_CREATION_ERROR.
+        TestTransportConnectionContext push = new(
+            HttpProtocolPayloadFactory.CreateHttp3UnidirectionalStream(0x01 /* push */),
+            isBidirectional: false);
+        TestMultiplexTransportConnection connection = new(new[] { push }, TransportProtocol.Quic);
+        HttpConnectionListenerOptions options = new();
+        options.UseTransport(HttpProtocol.Http30, new TestServerTransport(TransportProtocol.Quic, new TransportConnection[] { connection }), isSecure: true);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+    }
+
     private static async Task<IHttpContext> ReadSingleContextAsync(IHttpConnectionContext context)
     {
         await using IAsyncEnumerator<IHttpContext> enumerator = context.ReceiveAsync().GetAsyncEnumerator();

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/HttpProtocolPayloadFactory.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/HttpProtocolPayloadFactory.cs
@@ -82,6 +82,43 @@ internal static class HttpProtocolPayloadFactory
         return buffer.ToArray();
     }
 
+    /// <summary>
+    /// Builds the bytes a peer would send on its HTTP/3 control stream: the
+    /// control stream-type prefix (0x00) followed by a SETTINGS frame carrying
+    /// the supplied identifier/value pairs.
+    /// </summary>
+    public static byte[] CreateHttp3ControlStream(params (long Id, long Value)[] settings)
+    {
+        using MemoryStream settingsPayload = new();
+        foreach ((long id, long value) in settings)
+        {
+            WriteQuicInteger(settingsPayload, id);
+            WriteQuicInteger(settingsPayload, value);
+        }
+
+        using MemoryStream buffer = new();
+        WriteQuicInteger(buffer, 0x00); // control stream type
+        WriteHttp3Frame(buffer, 0x4 /* SETTINGS */, settingsPayload.ToArray());
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Builds the bytes for a generic HTTP/3 unidirectional stream: the
+    /// stream-type prefix followed by an optional raw payload. Used to drive
+    /// QPACK / push / unknown stream-type handling in tests.
+    /// </summary>
+    public static byte[] CreateHttp3UnidirectionalStream(long streamType, byte[]? payload = null)
+    {
+        using MemoryStream buffer = new();
+        WriteQuicInteger(buffer, streamType);
+        if (payload is { Length: > 0 })
+        {
+            buffer.Write(payload, 0, payload.Length);
+        }
+
+        return buffer.ToArray();
+    }
+
     public static IReadOnlyList<(long FrameType, byte[] Payload)> ParseHttp3Frames(byte[] payload)
     {
         List<(long FrameType, byte[] Payload)> frames = new();
@@ -417,7 +454,7 @@ internal static class HttpProtocolPayloadFactory
     private static long DecodeQuicInteger(byte[] buffer, ref int index)
     {
         byte first = buffer[index++];
-        int length = first >> 6 switch
+        int length = (first >> 6) switch
         {
             0 => 1,
             1 => 2,

--- a/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/TestTransportConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Transports/tests/TestObjects/TestTransportConnectionContext.cs
@@ -15,8 +15,10 @@ internal sealed class TestTransportConnectionContext : TransportConnectionContex
     private readonly PipeReader _outputReader;
     private readonly CancellationTokenSource _connectionCancelledSource;
 
-    public TestTransportConnectionContext(byte[] input, EndPoint? localEndPoint = null, EndPoint? remoteEndPoint = null)
+    public TestTransportConnectionContext(byte[] input, EndPoint? localEndPoint = null, EndPoint? remoteEndPoint = null, bool isBidirectional = true)
     {
+        IsBidirectional = isBidirectional;
+
         // Pipes default to pauseWriterThreshold = 64 KB, which blocks the
         // synchronous prime write below for any input larger than that.
         // Tests for flow-control / large-frame scenarios need bigger
@@ -44,6 +46,14 @@ internal sealed class TestTransportConnectionContext : TransportConnectionContex
     public override EndPoint RemoteEndPoint { get; }
 
     public override ITransportConnectionPipe Pipe { get; }
+
+    /// <summary>
+    /// Whether this stream is bidirectional (a request stream) or
+    /// unidirectional (an HTTP/3 control / QPACK / push stream). Defaults to
+    /// <see langword="true"/>; set to <see langword="false"/> to simulate a
+    /// peer-initiated unidirectional stream.
+    /// </summary>
+    public override bool IsBidirectional { get; }
 
     /// <summary>
     /// Cancellation token signalled when the test driver simulates a

--- a/libraries/Net/Assimalign.Cohesion.Transports.Quic/src/QuicTransportContext.cs
+++ b/libraries/Net/Assimalign.Cohesion.Transports.Quic/src/QuicTransportContext.cs
@@ -40,6 +40,9 @@ public sealed class QuicTransportContext : TransportConnectionContext
     internal QuicStream Stream { get; }
 
     /// <inheritdoc />
+    public override bool IsBidirectional => Stream.Type == QuicStreamType.Bidirectional;
+
+    /// <inheritdoc />
     public override EndPoint LocalEndPoint { get; }
 
     /// <inheritdoc />

--- a/libraries/Net/Assimalign.Cohesion.Transports/src/Abstractions/ITransportConnectionContext.cs
+++ b/libraries/Net/Assimalign.Cohesion.Transports/src/Abstractions/ITransportConnectionContext.cs
@@ -22,13 +22,27 @@ public interface ITransportConnectionContext
     ITransportConnectionPipe Pipe { get; }
 
     /// <summary>
-    /// Gets a cancellation token that will be triggered when the connection is closed. This acts as a lifetime for the 
+    /// Gets a cancellation token that will be triggered when the connection is closed. This acts as a lifetime for the
     /// connection and can be used to trigger cleanup of resources associated with the connection.
     /// </summary>
     CancellationToken ConnectionCancelled { get; }
 
     /// <summary>
-    /// 
+    /// Gets a value indicating whether the stream this context represents is
+    /// bidirectional. Single-stream transports (TCP) and ordinary multiplex
+    /// request streams are bidirectional; a multiplex transport (QUIC) can also
+    /// surface unidirectional streams — for example the HTTP/3 control and
+    /// QPACK streams — which report <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Defined as a default interface member returning <see langword="true"/>
+    /// so existing context implementations are unaffected; only multiplex
+    /// transports that expose unidirectional streams need to override it.
+    /// </remarks>
+    bool IsBidirectional => true;
+
+    /// <summary>
+    ///
     /// </summary>
     IDictionary<string, object?> Items { get; }
 }

--- a/libraries/Net/Assimalign.Cohesion.Transports/src/TransportConnectionContext.cs
+++ b/libraries/Net/Assimalign.Cohesion.Transports/src/TransportConnectionContext.cs
@@ -35,7 +35,14 @@ public abstract class TransportConnectionContext : ITransportConnectionContext
     public virtual CancellationToken ConnectionCancelled => _cancellationTokenSource.Token;
 
     /// <summary>
-    /// 
+    /// Gets a value indicating whether the stream this context represents is
+    /// bidirectional. Defaults to <see langword="true"/>; multiplex transports
+    /// that expose unidirectional streams (QUIC) override it.
+    /// </summary>
+    public virtual bool IsBidirectional => true;
+
+    /// <summary>
+    ///
     /// </summary>
     public virtual IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>();
 


### PR DESCRIPTION
## Summary

Implements **#334 — HTTP/3 QUIC streams / control / SETTINGS engine** for the supported HTTP/3 feature set (RFC 9114 §6.2 / §7.2.4, RFC 9204 §4.2).

`Http3ConnectionContext` now demultiplexes peer-initiated QUIC streams off the accept loop:

| Stream | Handling |
|---|---|
| bidirectional | request stream → parse HEADERS/DATA → yield `IHttpContext` |
| `0x00` control | enforce single control stream + SETTINGS-first; apply SETTINGS |
| `0x02`/`0x03` QPACK enc/dec | single-stream enforcement; accepted, no instructions processed (dynamic table disabled) |
| `0x01` push | connection error — a client must not push |
| other | abandoned (unknown types are not an error) |

Connection errors (duplicate control/QPACK stream, missing/non-SETTINGS first control frame, client push stream) cleanly terminate the connection; the listener stays up.

## Changes

- **`Http3StreamType`** — RFC 9114 §6.2 unidirectional stream-type constants.
- **`Http3PeerSettings`** — peer SETTINGS store (`QPACK_MAX_TABLE_CAPACITY`, `MAX_FIELD_SECTION_SIZE`, `QPACK_BLOCKED_STREAMS`, `SETTINGS_ENABLE_CONNECT_PROTOCOL`; unknown ids retained-but-ignored per §7.2.4.1). `EnableConnectProtocolNegotiated` is the seam #339 builds on.
- **`Http3ConnectionContext`** — stream demux + control/QPACK/push handlers; unidirectional reads run **incrementally off the transport `PipeReader`** (buffered `ReadOnlySequence`) rather than the `Stream` adapter.
- **Net library** — `ITransportConnectionContext.IsBidirectional` added as a **default interface member** (`=> true`, non-breaking); `QuicTransportContext` overrides it from `QuicStream.Type`. Keeps direction detection in the transport layer.

## Latent bug fixed in passing

The QUIC varint length selector was written `first >> 6 switch { … }`. The C# `switch` expression binds tighter than `>>`, so this parsed as `first >> (6 switch { … })` = `first >> 8` — **always `0` for a single byte**, meaning every varint decoded as one byte. Single-byte values (< 64) decode correctly that way, which is why no prior test caught it; the first multi-byte varint on the decode path (a SETTINGS value of `8192`) exposed it. Fixed to `(first >> 6) switch { … }` in `Decode`, `ReadAsync`, `TryDecode`, and the test factory's `DecodeQuicInteger`.

## Tests

5 new `Http3TransportTests`: control+SETTINGS then request, QPACK stream then request, duplicate control → terminate, missing-SETTINGS → terminate, client push → terminate.

All suites green:
- core HTTP: **261**
- http.transports: **126**
- net.transports: **22**
- quic.transports: **1**

## Docs

`docs/DESIGN.md` gains an **"HTTP/3 stream model and SETTINGS engine"** section (demux table, control/SETTINGS rules, QPACK posture, PipeReader rationale, the varint bug note, why `IsBidirectional` lives on the transport abstraction, AOT posture, non-goals).

Part of epic #314 `[L01.01.11] Foundation - Http`.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)