### PR TITLE
fix(connections): connected UDP send uses send() not sendto() (macOS EISCONN)

### DIFF
--- a/libraries/Connections/Assimalign.Cohesion.Connections.Udp/src/UdpDatagramConnection.cs
+++ b/libraries/Connections/Assimalign.Cohesion.Connections.Udp/src/UdpDatagramConnection.cs
@@ -78,9 +78,22 @@ internal sealed class UdpDatagramConnection : DatagramConnection
         ArgumentNullException.ThrowIfNull(remoteEndPoint);
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        await _socket
-            .SendToAsync(payload, SocketFlags.None, remoteEndPoint, cancellationToken)
-            .ConfigureAwait(false);
+        if (_remoteEndPoint is not null)
+        {
+            // A connected UDP socket (client role) must use send(), not sendto(): passing an
+            // explicit destination to sendto() on a connected socket fails with EISCONN
+            // ("Socket is already connected") on macOS/BSD, though Linux and Windows tolerate it.
+            // A connected socket always targets its bound peer, so the destination is implicit.
+            await _socket
+                .SendAsync(payload, SocketFlags.None, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            await _socket
+                .SendToAsync(payload, SocketFlags.None, remoteEndPoint, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Fixes a **pre-existing, macOS-only** CI failure in `Assimalign.Cohesion.Connections.Udp` — currently red on `main`'s Connections workflow and on every open PR (surfaced on #809).

`UdpDatagramConnection.SendAsync` always called `Socket.SendToAsync(payload, remoteEndPoint, …)`, even for **client (connected)** sockets that `UdpConnectionFactory.Connect` produces via `socket.Connect(...)`. On macOS/BSD, `sendto()` with an explicit destination on a *connected* UDP socket returns `SocketException: Socket is already connected` (EISCONN); Linux and Windows tolerate it. This deterministically failed three tests on `macos-latest`:

- `SendAsync_ClientToServer_ShouldDeliverPayloadWithSenderEndPoint`
- `SendAsync_ServerReplyToClient_ShouldDeliverPayload`
- `ReceiveAsync_AfterTwoSends_ShouldPreserveMessageBoundaries`

## Fix

Connected sockets now send via `Socket.SendAsync(payload, SocketFlags.None, ct)` (the peer is implicit); unconnected server sockets keep using `SendToAsync`. One conditional in `UdpDatagramConnection.SendAsync` — no public API change, AOT-safe.

## Verification

All 15 `Connections.Udp` tests pass locally on Windows (they passed before too — the bug is macOS-specific). The three affected tests are the cross-platform regression coverage and will now pass on macOS CI.

## Work items resolved by this PR

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)