### PR TITLE
[L03.01.01.01.05] Add TLS convenience surface to the Web server builder (compose Connections.Security UseTls)

### DIFF
--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
@@ -211,8 +211,9 @@ a slot frees.
   before cancelling on shutdown (versus cancelling them with the drain token) is
   future work; it needs a two-phase signal ("finish the current exchange, accept
   no new ones on this connection") that this iteration does not implement.
-- **TLS / HTTP/3 registration surface** on the server builder — tracked
-  separately (issues #763, #767).
+- **HTTP/3 registration surface** on the server builder — tracked separately
+  (issue #767). The TLS convenience surface (issue #763) has landed; see "TLS
+  convenience surface" below.
 - **Per-request service resolution.** DI/logging/config are builder-time only;
   the server resolves nothing per connection or per request.
 - **Re-implementing wire behaviour.** Protocol conformance and wire-level failure
@@ -330,3 +331,86 @@ the default overridable without a dedicated opt-out knob.
 No other interceptor ships by default. Parse-time features under design
 (digest fields, request decompression) register through the same seam when
 their packages land, but each is an explicit opt-in.
+
+## TLS convenience surface
+
+### What it is
+
+`HttpConnectionListenerOptions.UseHttp1s(configure, tlsOptions)` and
+`UseHttp2s(configure, tlsOptions)` (extension members in `WebHostingExtensions`)
+are the secure siblings of the plaintext `UseHttp1` / `UseHttp2` callback sugar.
+Each takes the same `Action<TcpConnectionListenerOptions>` used to configure the
+endpoint plus a `TlsServerOptions`, and registers a listener that serves the
+protocol over TLS:
+
+```csharp
+builder.Server.UseServer(options =>
+{
+    options.UseHttp2s(
+        tcp => tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, 8443),
+        new TlsServerOptions
+        {
+            AuthenticationOptions = { ServerCertificate = certificate }
+        });
+});
+```
+
+### Why here, and why compose-before-register
+
+TLS is a **pre-composed transport layer**, never an HTTP concern — the
+`Assimalign.Cohesion.Http.Connections` `docs/DESIGN.md` records this boundary
+("TLS is a pre-composed layer, not an HTTP concern"), and its
+`HttpConnectionListenerOptions` deliberately carries no TLS or certificate
+options. The convenience honors that boundary by composing
+`TcpConnectionListener.Create(configure).UseTls(tlsOptions)` **before** handing
+the listener to `UseHttp1` / `UseHttp2`. Composition is deferred inside the same
+factory the plaintext sugar uses, so the TCP listener is not bound until the
+`HttpConnectionListener` materializes the registration.
+
+Because the security layer wraps the listener first, the layered listener reports
+`Capabilities.Security == ConnectionSecurity.Tls`. That capability is the single
+source of truth for the `https` scheme — the HTTP layer reads it once per accept
+loop; there is no registration-time `isSecure` parameter to thread through. A
+request served over a `UseHttp1s` / `UseHttp2s` listener therefore carries
+`HttpScheme.Https` end to end.
+
+This is also the layering reason the surface lives in Web.Hosting rather than in
+the transport: Web.Hosting is where the composition root is allowed to depend on
+both `Http.Connections` (the registration surface) and
+`Connections.Security` (the `UseTls` layer). The transport depends on neither
+direction of that composition.
+
+### ALPN defaulting
+
+The .NET / browser HTTP client selects the HTTP version over TLS via ALPN
+(RFC 7301), so a secured HTTP/2 listener is only reachable as HTTP/2 if it
+advertises the `h2` protocol id. To make the common case work without ceremony,
+`UseHttp2s` defaults `AuthenticationOptions.ApplicationProtocols` to
+`SslApplicationProtocol.Http2` (`h2`) and `UseHttp1s` defaults it to
+`SslApplicationProtocol.Http11` (`http/1.1`) **when the caller left the list
+unset** (null or empty). A caller who supplies an explicit protocol list — for
+example to offer both `h2` and `http/1.1` on one endpoint — has it preserved
+unmodified. The default is written onto the caller's `TlsServerOptions` (an
+intentional mutation) so a later read observes the negotiated protocol.
+
+### Certificates are the caller's concern
+
+The server certificate is supplied by the caller through
+`TlsServerOptions.AuthenticationOptions.ServerCertificate` (or a selection
+callback). Certificate sourcing, storage, and rotation are Security-area concerns
+and are explicit non-goals of the security library's TLS surface, so they are not
+re-modeled on this convenience.
+
+### Scope boundary
+
+`UseHttp1s` / `UseHttp2s` cover the stream protocols. HTTP/3 is out of scope here:
+QUIC's transport security is always-on (TLS is inherent to the protocol) and QUIC
+listeners bind asynchronously, so the HTTP/3 registration surface is tracked
+separately under #767.
+
+### AOT posture
+
+No reflection, no runtime codegen. The composition is plain delegate wiring
+(`TcpConnectionListener.Create(...).UseTls(...)` inside a `Func<IConnectionListener>`),
+and the ALPN default is a list assignment. `IsAotCompatible=true` holds with no
+special handling.

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/src/Assimalign.Cohesion.Web.Hosting.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/src/Assimalign.Cohesion.Web.Hosting.csproj
@@ -10,5 +10,6 @@
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Tcp" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Quic" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Security" />
 	</ItemGroup>
 </Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/src/Extensions/WebHostingExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/src/Extensions/WebHostingExtensions.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Net.Security;
 
 using Assimalign.Cohesion.Configuration;
+using Assimalign.Cohesion.Connections;
+using Assimalign.Cohesion.Connections.Security;
 using Assimalign.Cohesion.Connections.Tcp;
 using Assimalign.Cohesion.Http.Connections;
 using Assimalign.Cohesion.Web.Hosting.Internal;
@@ -12,9 +16,24 @@ namespace Assimalign.Cohesion.Web.Hosting;
 /// and <see cref="WebApplicationServerBuilder"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// The plaintext <see cref="WebHostingExtensions.UseHttp1(HttpConnectionListenerOptions, Action{TcpConnectionListenerOptions})"/>
+/// / <see cref="WebHostingExtensions.UseHttp2(HttpConnectionListenerOptions, Action{TcpConnectionListenerOptions})"/>
+/// members register a bare TCP listener; the TLS-enabled
+/// <see cref="WebHostingExtensions.UseHttp1s(HttpConnectionListenerOptions, Action{TcpConnectionListenerOptions}, TlsServerOptions)"/>
+/// / <see cref="WebHostingExtensions.UseHttp2s(HttpConnectionListenerOptions, Action{TcpConnectionListenerOptions}, TlsServerOptions)"/>
+/// members compose the security library's <c>UseTls</c> layer onto that TCP listener <em>before</em>
+/// registration. TLS is never configured inside <c>Assimalign.Cohesion.Http.Connections</c> — it is a
+/// pre-composed transport layer, and the layered listener's
+/// <see cref="ConnectionCapabilities.Security"/> is the single source of truth from which the HTTP
+/// layer derives the <c>https</c> scheme.
+/// </para>
+/// <para>
 /// HTTP/3 has no callback-based overload here because QUIC listeners bind asynchronously
-/// (<c>QuicConnectionListener.CreateAsync</c>); create the listener first and register it through
+/// (<c>QuicConnectionListener.CreateAsync</c>) and QUIC's transport security is always-on; create the
+/// listener first and register it through
 /// <see cref="HttpConnectionListenerOptions.UseHttp3(Assimalign.Cohesion.Connections.IMultiplexedConnectionListener)"/>.
+/// </para>
 /// </remarks>
 public static class WebHostingExtensions
 {
@@ -65,6 +84,88 @@ public static class WebHostingExtensions
             ArgumentNullException.ThrowIfNull(configure);
 
             return options.UseHttp2(() => TcpConnectionListener.Create(configure));
+        }
+
+        /// <summary>
+        /// Serves HTTP/1.1 over TLS by composing the security library's <c>UseTls</c> layer onto a TCP
+        /// connection listener configured by the supplied callback, then registering the secured
+        /// listener for HTTP/1.1.
+        /// </summary>
+        /// <param name="configure">The TCP listener configuration callback (endpoint, socket options).</param>
+        /// <param name="tlsOptions">
+        /// The server TLS options. The caller supplies the server certificate through
+        /// <see cref="TlsServerOptions.AuthenticationOptions"/>; certificate sourcing is a Security-area
+        /// concern and is intentionally not modeled here. When
+        /// <see cref="SslServerAuthenticationOptions.ApplicationProtocols"/> is left unset, it is defaulted
+        /// to <see cref="SslApplicationProtocol.Http11"/> (ALPN <c>http/1.1</c>, RFC 7301); a caller-supplied
+        /// protocol list is preserved unmodified.
+        /// </param>
+        /// <returns>The current options instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> or <paramref name="tlsOptions"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// TLS is composed <em>before</em> registration, so the layered listener reports
+        /// <see cref="ConnectionCapabilities.Security"/> equal to <see cref="ConnectionSecurity.Tls"/>. The
+        /// HTTP layer derives the <c>https</c> scheme from that capability — there is no registration-time
+        /// <c>isSecure</c> flag.
+        /// </remarks>
+        public HttpConnectionListenerOptions UseHttp1s(Action<TcpConnectionListenerOptions> configure, TlsServerOptions tlsOptions)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            ArgumentNullException.ThrowIfNull(tlsOptions);
+
+            EnsureApplicationProtocols(tlsOptions, SslApplicationProtocol.Http11);
+
+            return options.UseHttp1(() => TcpConnectionListener.Create(configure).UseTls(tlsOptions));
+        }
+
+        /// <summary>
+        /// Serves HTTP/2 over TLS by composing the security library's <c>UseTls</c> layer onto a TCP
+        /// connection listener configured by the supplied callback, then registering the secured
+        /// listener for HTTP/2.
+        /// </summary>
+        /// <param name="configure">The TCP listener configuration callback (endpoint, socket options).</param>
+        /// <param name="tlsOptions">
+        /// The server TLS options. The caller supplies the server certificate through
+        /// <see cref="TlsServerOptions.AuthenticationOptions"/>; certificate sourcing is a Security-area
+        /// concern and is intentionally not modeled here. When
+        /// <see cref="SslServerAuthenticationOptions.ApplicationProtocols"/> is left unset, it is defaulted
+        /// to <see cref="SslApplicationProtocol.Http2"/> (ALPN <c>h2</c>, RFC 7301); a caller-supplied
+        /// protocol list is preserved unmodified.
+        /// </param>
+        /// <returns>The current options instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> or <paramref name="tlsOptions"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// TLS is composed <em>before</em> registration, so the layered listener reports
+        /// <see cref="ConnectionCapabilities.Security"/> equal to <see cref="ConnectionSecurity.Tls"/>. The
+        /// HTTP layer derives the <c>https</c> scheme from that capability — there is no registration-time
+        /// <c>isSecure</c> flag. Browsers and the .NET HTTP client negotiate HTTP/2 over TLS via ALPN, so
+        /// the defaulted <c>h2</c> protocol id is what makes the secured listener reachable as HTTP/2.
+        /// </remarks>
+        public HttpConnectionListenerOptions UseHttp2s(Action<TcpConnectionListenerOptions> configure, TlsServerOptions tlsOptions)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            ArgumentNullException.ThrowIfNull(tlsOptions);
+
+            EnsureApplicationProtocols(tlsOptions, SslApplicationProtocol.Http2);
+
+            return options.UseHttp2(() => TcpConnectionListener.Create(configure).UseTls(tlsOptions));
+        }
+    }
+
+    /// <summary>
+    /// Defaults the ALPN application-protocol list on the supplied TLS options when the caller left it
+    /// unset, preserving any caller-supplied list. Mutation is intentional: the default is applied to the
+    /// caller's options so a subsequent read observes the negotiated protocol.
+    /// </summary>
+    /// <param name="tlsOptions">The TLS options whose application protocols are defaulted.</param>
+    /// <param name="defaultProtocol">The ALPN protocol id to install when none was supplied.</param>
+    private static void EnsureApplicationProtocols(TlsServerOptions tlsOptions, SslApplicationProtocol defaultProtocol)
+    {
+        SslServerAuthenticationOptions authentication = tlsOptions.AuthenticationOptions;
+
+        if (authentication.ApplicationProtocols is null || authentication.ApplicationProtocols.Count == 0)
+        {
+            authentication.ApplicationProtocols = new List<SslApplicationProtocol> { defaultProtocol };
         }
     }
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/Assimalign.Cohesion.Web.Hosting.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/Assimalign.Cohesion.Web.Hosting.Tests.csproj
@@ -10,6 +10,7 @@
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.RequestLimits" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Configuration" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Tcp" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Security" />
     <CohesionPackageReference Include="coverlet.collector" />
     <CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
     <CohesionPackageReference Include="Shouldly" />

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/TestObjects/SelfSignedCertificateFactory.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/TestObjects/SelfSignedCertificateFactory.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Assimalign.Cohesion.Web.Hosting.Tests.TestObjects;
+
+/// <summary>
+/// Creates an ephemeral self-signed server-authentication certificate for the TLS convenience
+/// integration tests, mirroring the pattern the <c>Http.Connections</c> HTTP/2 example uses so a real
+/// TLS handshake succeeds over loopback on every supported platform.
+/// </summary>
+internal static class SelfSignedCertificateFactory
+{
+    /// <summary>
+    /// Builds a self-signed certificate whose subject/SAN cover <paramref name="subjectName"/>,
+    /// <c>localhost</c>, and the IPv4 loopback address, with the server-authentication EKU.
+    /// </summary>
+    /// <param name="subjectName">The certificate subject common name and primary DNS SAN.</param>
+    /// <returns>A loaded <see cref="X509Certificate2"/> with an exportable private key.</returns>
+    public static X509Certificate2 Create(string subjectName)
+    {
+        using ECDsa ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        CertificateRequest request = new(
+            new X500DistinguishedName($"CN={subjectName}"),
+            ecdsa,
+            HashAlgorithmName.SHA256);
+
+        SubjectAlternativeNameBuilder subjectAlternativeNames = new();
+        subjectAlternativeNames.AddDnsName(subjectName);
+        subjectAlternativeNames.AddDnsName("localhost");
+        subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+        request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+            new OidCollection
+            {
+                new("1.3.6.1.5.5.7.3.1")
+            },
+            false));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        using X509Certificate2 ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7));
+
+        // Round-trip through PKCS#12 so the private key is persisted in a form Windows Schannel
+        // (SslStream) accepts; CreateSelfSigned alone yields an ephemeral key the platform TLS stack
+        // rejects for server auth.
+        return X509CertificateLoader.LoadPkcs12(ephemeral.Export(X509ContentType.Pfx), password: null);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebTlsHostingExtensionsTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebTlsHostingExtensionsTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Security;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections.Security;
+using Assimalign.Cohesion.Connections.Tcp;
+using Assimalign.Cohesion.Http.Connections;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Web.Hosting.Tests;
+
+/// <summary>
+/// Covers the TLS convenience surface (<c>UseHttp1s</c> / <c>UseHttp2s</c>) added to
+/// <see cref="HttpConnectionListenerOptions"/> for issue #763. These tests pin the deterministic
+/// behaviour: argument validation, ALPN application-protocol defaulting (and preservation), and that
+/// the secured listener registers under the correct HTTP protocol with deferred construction. The
+/// end-to-end TLS handshake is exercised separately in <see cref="WebTlsHostingIntegrationTests"/>.
+/// </summary>
+public class WebTlsHostingExtensionsTests
+{
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should throw when the configure callback is null")]
+    public void UseHttp1s_WithNullConfigure_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        HttpConnectionListenerOptions options = new();
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => options.UseHttp1s(null!, new TlsServerOptions()));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should throw when the configure callback is null")]
+    public void UseHttp2s_WithNullConfigure_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        HttpConnectionListenerOptions options = new();
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => options.UseHttp2s(null!, new TlsServerOptions()));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should throw when the TLS options are null")]
+    public void UseHttp1s_WithNullTlsOptions_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        HttpConnectionListenerOptions options = new();
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => options.UseHttp1s(tcp => { }, null!));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should throw when the TLS options are null")]
+    public void UseHttp2s_WithNullTlsOptions_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        HttpConnectionListenerOptions options = new();
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => options.UseHttp2s(tcp => { }, null!));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should default ALPN to h2 when application protocols are unset")]
+    public void UseHttp2s_WithUnsetApplicationProtocols_ShouldDefaultToH2()
+    {
+        // Arrange — a fresh TlsServerOptions leaves ApplicationProtocols null.
+        HttpConnectionListenerOptions options = new();
+        TlsServerOptions tlsOptions = new();
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBeNull();
+
+        // Act
+        options.UseHttp2s(tcp => { }, tlsOptions);
+
+        // Assert — h2 is installed so the secured listener is reachable as HTTP/2 via ALPN (RFC 7301).
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldNotBeNull();
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBe(new List<SslApplicationProtocol>
+        {
+            SslApplicationProtocol.Http2
+        });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should default ALPN to http/1.1 when application protocols are unset")]
+    public void UseHttp1s_WithUnsetApplicationProtocols_ShouldDefaultToHttp11()
+    {
+        // Arrange
+        HttpConnectionListenerOptions options = new();
+        TlsServerOptions tlsOptions = new();
+
+        // Act
+        options.UseHttp1s(tcp => { }, tlsOptions);
+
+        // Assert
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldNotBeNull();
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBe(new List<SslApplicationProtocol>
+        {
+            SslApplicationProtocol.Http11
+        });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should default ALPN when application protocols are an empty list")]
+    public void UseHttp2s_WithEmptyApplicationProtocols_ShouldDefaultToH2()
+    {
+        // Arrange — an empty (but non-null) list is treated as "unset".
+        HttpConnectionListenerOptions options = new();
+        TlsServerOptions tlsOptions = new()
+        {
+            AuthenticationOptions = new SslServerAuthenticationOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol>()
+            }
+        };
+
+        // Act
+        options.UseHttp2s(tcp => { }, tlsOptions);
+
+        // Assert
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBe(new List<SslApplicationProtocol>
+        {
+            SslApplicationProtocol.Http2
+        });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should preserve caller-supplied application protocols")]
+    public void UseHttp2s_WithExplicitApplicationProtocols_ShouldPreserveThem()
+    {
+        // Arrange — a caller offering both h2 and http/1.1 on one endpoint must not be overridden.
+        HttpConnectionListenerOptions options = new();
+        List<SslApplicationProtocol> explicitProtocols = new()
+        {
+            SslApplicationProtocol.Http2,
+            SslApplicationProtocol.Http11
+        };
+        TlsServerOptions tlsOptions = new()
+        {
+            AuthenticationOptions = new SslServerAuthenticationOptions
+            {
+                ApplicationProtocols = explicitProtocols
+            }
+        };
+
+        // Act
+        options.UseHttp2s(tcp => { }, tlsOptions);
+
+        // Assert — same instance, unmodified.
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBeSameAs(explicitProtocols);
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBe(new List<SslApplicationProtocol>
+        {
+            SslApplicationProtocol.Http2,
+            SslApplicationProtocol.Http11
+        });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should preserve caller-supplied application protocols")]
+    public void UseHttp1s_WithExplicitApplicationProtocols_ShouldPreserveThem()
+    {
+        // Arrange — an explicit non-default choice (h2 only) must survive UseHttp1s untouched.
+        HttpConnectionListenerOptions options = new();
+        List<SslApplicationProtocol> explicitProtocols = new()
+        {
+            SslApplicationProtocol.Http2
+        };
+        TlsServerOptions tlsOptions = new()
+        {
+            AuthenticationOptions = new SslServerAuthenticationOptions
+            {
+                ApplicationProtocols = explicitProtocols
+            }
+        };
+
+        // Act
+        options.UseHttp1s(tcp => { }, tlsOptions);
+
+        // Assert
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBeSameAs(explicitProtocols);
+        tlsOptions.AuthenticationOptions.ApplicationProtocols.ShouldBe(new List<SslApplicationProtocol>
+        {
+            SslApplicationProtocol.Http2
+        });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should defer TCP listener creation and register HTTP/1.1")]
+    public async Task UseHttp1s_WithConfiguredOptions_ShouldDeferCreationAndRegisterHttp11()
+    {
+        // Arrange
+        bool configured = false;
+        HttpConnectionListenerOptions options = new();
+        using System.Security.Cryptography.X509Certificates.X509Certificate2 certificate =
+            TestObjects.SelfSignedCertificateFactory.Create("localhost");
+
+        // Act
+        HttpConnectionListenerOptions result = options.UseHttp1s(
+            tcp =>
+            {
+                configured = true;
+                tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+            },
+            new TlsServerOptions
+            {
+                AuthenticationOptions = { ServerCertificate = certificate }
+            });
+
+        // Assert — the wrapper returns the same options for chaining and defers construction: the
+        // TCP listener (and its TLS layer) are not built until the HttpConnectionListener materializes.
+        result.ShouldBeSameAs(options);
+        configured.ShouldBeFalse();
+
+        await using HttpConnectionListener listener = new(options);
+
+        configured.ShouldBeTrue();
+        listener.Protocols.ShouldBe(HttpProtocol.Http11);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should defer TCP listener creation and register HTTP/2")]
+    public async Task UseHttp2s_WithConfiguredOptions_ShouldDeferCreationAndRegisterHttp20()
+    {
+        // Arrange
+        bool configured = false;
+        HttpConnectionListenerOptions options = new();
+        using System.Security.Cryptography.X509Certificates.X509Certificate2 certificate =
+            TestObjects.SelfSignedCertificateFactory.Create("localhost");
+
+        // Act
+        HttpConnectionListenerOptions result = options.UseHttp2s(
+            tcp =>
+            {
+                configured = true;
+                tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+            },
+            new TlsServerOptions
+            {
+                AuthenticationOptions = { ServerCertificate = certificate }
+            });
+
+        // Assert
+        result.ShouldBeSameAs(options);
+        configured.ShouldBeFalse();
+
+        await using HttpConnectionListener listener = new(options);
+
+        configured.ShouldBeTrue();
+        listener.Protocols.ShouldBe(HttpProtocol.Http20);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebTlsHostingIntegrationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebTlsHostingIntegrationTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections.Security;
+using Assimalign.Cohesion.DependencyInjection;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Http.Connections;
+using Assimalign.Cohesion.Web;
+using Assimalign.Cohesion.Web.Hosting.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+using ClientHttpMethod = System.Net.Http.HttpMethod;
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Web.Hosting.Tests;
+
+/// <summary>
+/// End-to-end coverage for the TLS convenience surface (issue #763): a listener registered through
+/// <c>UseHttp1s</c> / <c>UseHttp2s</c> completes a real TLS handshake with a self-signed certificate,
+/// reports transport security, and serves a request that carries the <c>https</c> scheme. One test
+/// drives the full builder path (<c>WebApplicationBuilder.Server.UseServer(options =&gt;
+/// options.UseHttp1s(...))</c>) to prove the composition root wires the secured listener into the
+/// running server.
+/// </summary>
+public class WebTlsHostingIntegrationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp1s: Should serve an HTTP/1.1 request over TLS with the https scheme")]
+    public async Task UseHttp1s_OverTls_ShouldServeRequestWithHttpsScheme()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+        int port = GetAvailableLoopbackPort();
+        using X509Certificate2 certificate = SelfSignedCertificateFactory.Create("localhost");
+
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1s(
+            tcp => tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, port),
+            new TlsServerOptions
+            {
+                AuthenticationOptions = { ServerCertificate = certificate }
+            });
+
+        await using HttpConnectionListener listener = new(options);
+
+        TaskCompletionSource<HttpScheme> observedScheme = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task serverTask = RunSingleRequestServerAsync(listener, observedScheme, cancellationToken);
+
+        try
+        {
+            // Act — a real HTTP/1.1-over-TLS request from the .NET client.
+            using HttpResponseMessage response = await SendWithRetryAsync(
+                new Uri($"https://127.0.0.1:{port}/secure?probe=h1"),
+                NetHttpVersion.Version11,
+                cancellationToken);
+
+            // Assert — the request completed over TLS and the transport-derived scheme is https.
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            HttpScheme scheme = await observedScheme.Task.WaitAsync(cancellationToken);
+            scheme.ShouldBe(HttpScheme.Https);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await ObserveAsync(serverTask);
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp2s: Should serve an HTTP/2 request over TLS negotiated via the default h2 ALPN")]
+    public async Task UseHttp2s_OverTls_ShouldServeRequestWithHttpsSchemeAndNegotiateH2()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+        int port = GetAvailableLoopbackPort();
+        using X509Certificate2 certificate = SelfSignedCertificateFactory.Create("localhost");
+
+        // No ApplicationProtocols supplied — UseHttp2s defaults ALPN to h2, which is what makes the
+        // client negotiate HTTP/2 over the secured listener.
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2s(
+            tcp => tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, port),
+            new TlsServerOptions
+            {
+                AuthenticationOptions = { ServerCertificate = certificate }
+            });
+
+        await using HttpConnectionListener listener = new(options);
+
+        TaskCompletionSource<HttpScheme> observedScheme = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task serverTask = RunSingleRequestServerAsync(listener, observedScheme, cancellationToken);
+
+        try
+        {
+            // Act — request HTTP/2 exactly; success proves the defaulted h2 ALPN id negotiated.
+            using HttpResponseMessage response = await SendWithRetryAsync(
+                new Uri($"https://127.0.0.1:{port}/secure?probe=h2"),
+                NetHttpVersion.Version20,
+                cancellationToken);
+
+            // Assert
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            response.Version.ShouldBe(NetHttpVersion.Version20);
+            HttpScheme scheme = await observedScheme.Task.WaitAsync(cancellationToken);
+            scheme.ShouldBe(HttpScheme.Https);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await ObserveAsync(serverTask);
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Builder path: UseServer(options => options.UseHttp1s(...)) should serve a request over TLS with the https scheme")]
+    public async Task WebApplicationBuilderServerUseHttp1s_OverTls_ShouldServeRequestWithHttpsScheme()
+    {
+        // Arrange — the full composition-root path: the secured listener is registered inside
+        // builder.Server.UseServer(...), then the built server serves it.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+        int port = GetAvailableLoopbackPort();
+        using X509Certificate2 certificate = SelfSignedCertificateFactory.Create("localhost");
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Server.UseServer(options =>
+        {
+            options.UseHttp1s(
+                tcp => tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, port),
+                new TlsServerOptions
+                {
+                    AuthenticationOptions = { ServerCertificate = certificate }
+                });
+        });
+
+        WebApplication app = builder.Build();
+
+        // A terminal middleware observes the transport-derived scheme and answers 200.
+        TaskCompletionSource<HttpScheme> observedScheme = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        app.Use((context, next) =>
+        {
+            observedScheme.TrySetResult(context.Request.Scheme);
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return next.Invoke(context);
+        });
+
+        // Resolve and drive the default server directly. StartAsync launches the accept loop; the
+        // TCP listener binds lazily on the first accept, so the client send is retried until bound.
+        IWebApplicationServer server = app.Context.ServiceProvider.GetRequiredService<IWebApplicationServer>();
+        await server.StartAsync(cancellationToken);
+
+        try
+        {
+            // Act
+            using HttpResponseMessage response = await SendWithRetryAsync(
+                new Uri($"https://127.0.0.1:{port}/secure"),
+                NetHttpVersion.Version11,
+                cancellationToken);
+
+            // Assert
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            HttpScheme scheme = await observedScheme.Task.WaitAsync(cancellationToken);
+            scheme.ShouldBe(HttpScheme.Https);
+        }
+        finally
+        {
+            await server.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Accepts a single connection, drives its first request through the transport, records the
+    /// request scheme, and answers 200. Any fault is surfaced through <paramref name="observedScheme"/>
+    /// so the awaiting test observes it rather than losing it on a background task.
+    /// </summary>
+    private static async Task RunSingleRequestServerAsync(
+        HttpConnectionListener listener,
+        TaskCompletionSource<HttpScheme> observedScheme,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using IHttpConnection connection = await listener.AcceptOrListenAsync(cancellationToken).ConfigureAwait(false);
+            IHttpConnectionContext context = await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await foreach (IHttpContext exchange in context.ReceiveAsync(cancellationToken).ConfigureAwait(false))
+            {
+                observedScheme.TrySetResult(exchange.Request.Scheme);
+
+                exchange.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                await context.SendAsync(exchange, cancellationToken).ConfigureAwait(false);
+                await exchange.DisposeAsync().ConfigureAwait(false);
+                break;
+            }
+        }
+        catch (Exception exception)
+        {
+            observedScheme.TrySetException(exception);
+        }
+    }
+
+    private static async Task<HttpResponseMessage> SendWithRetryAsync(Uri uri, Version httpVersion, CancellationToken cancellationToken)
+    {
+        using HttpClientHandler handler = new()
+        {
+            // The certificate is a throwaway self-signed test cert; accept it unconditionally.
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        using HttpClient client = new(handler);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
+            {
+                Version = httpVersion,
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact
+            };
+
+            try
+            {
+                return await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (HttpRequestException exception) when (
+                exception.InnerException is SocketException && !cancellationToken.IsCancellationRequested)
+            {
+                // The listener has not bound yet (connection refused); retry until the shared timeout
+                // cancels. A TLS/protocol failure carries a different inner exception and propagates.
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task ObserveAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The test's assertions own the verdict; drain the server task quietly on teardown so a
+            // cancellation/dispose fault does not surface as an unobserved task exception.
+        }
+    }
+
+    private static int GetAvailableLoopbackPort()
+    {
+        using Socket probe = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
## Summary

`Connections.Security` is done and proven end-to-end (the Http2 example already serves HTTPS with ALPN `h2`), but the Web builder exposed only plaintext `UseHttp1` / `UseHttp2`. This adds the TLS convenience surface to the Web server builder for issue #763 (Stage 1 · Lane D).

New extension members on `HttpConnectionListenerOptions` in `Assimalign.Cohesion.Web.Hosting`:

- **`UseHttp1s(Action<TcpConnectionListenerOptions> configure, TlsServerOptions tlsOptions)`**
- **`UseHttp2s(Action<TcpConnectionListenerOptions> configure, TlsServerOptions tlsOptions)`**

Each composes `Connections.Security`'s `UseTls` layer onto the TCP listener **before** registration:

```csharp
builder.Server.UseServer(options =>
{
    options.UseHttp2s(
        tcp => tcp.EndPoint = new IPEndPoint(IPAddress.Loopback, 8443),
        new TlsServerOptions { AuthenticationOptions = { ServerCertificate = certificate } });
});
```

## How it works / layering

Because the security layer wraps the listener first, the layered listener reports `Capabilities.Security == ConnectionSecurity.Tls`. That capability is the **single source of truth** for the `https` scheme — the HTTP layer reads it once per accept loop; there is no registration-time `isSecure` flag. Composition is deferred inside the same factory the plaintext sugar uses, so the TCP listener binds lazily when the `HttpConnectionListener` materializes.

**Layering boundary preserved:** no TLS or certificate options were added to `Assimalign.Cohesion.Http.Connections`' `HttpConnectionListenerOptions` — its `docs/DESIGN.md` records *"TLS is a pre-composed layer, not an HTTP concern"*, and that file is untouched by this PR (verified by diff).

## ALPN defaulting

`UseHttp2s` defaults `AuthenticationOptions.ApplicationProtocols` to `h2` and `UseHttp1s` to `http/1.1` (RFC 7301) **when the caller left the list unset** (null or empty); a caller-supplied list is preserved unmodified. Certificate sourcing stays a Security-area concern (supplied by the caller via `TlsServerOptions`).

## Acceptance criteria

- [x] `Web.Hosting` exposes TLS-enabled convenience members on `HttpConnectionListenerOptions` that compose `UseTls` before registration; csproj gains a `CohesionProjectReference` to `Assimalign.Cohesion.Connections.Security`.
- [x] A listener registered through the new surface serves a request carrying the `https` scheme (integration test, self-signed cert, reusing the `SelfSignedCertificateFactory` pattern).
- [x] HTTP/2 TLS convenience defaults ALPN to `h2` (HTTP/1.1 to `http/1.1`) when unset; explicit `ApplicationProtocols` preserved (unit-tested both ways).
- [x] No TLS/certificate options added to `Http.Connections`' `HttpConnectionListenerOptions` (boundary preserved, verified by diff).
- [x] New public members: XML docs, `ArgumentNullException.ThrowIfNull`, file-scoped namespaces, `extension(...)` syntax, no reflection/codegen (AOT-clean).
- [x] A test demonstrates the full builder path (`WebApplicationBuilder.Server.UseServer(options => options.UseHttp1s(...))`) serving a request over TLS end-to-end.

## Testing

`dotnet test` on `Web.Hosting.Tests` — **39 passed / 0 failed** (14 new; integration tests re-run 3× for flakiness). New coverage:

- **Unit** (`WebTlsHostingExtensionsTests`): null-arg guards, ALPN defaulting for h2 / http/1.1 (incl. empty-list), explicit-protocol preservation, and deferred construction + protocol registration.
- **Integration** (`WebTlsHostingIntegrationTests`, real TLS handshake, self-signed cert): HTTP/1.1 and HTTP/2 at the listener level (h2 negotiated via the defaulted ALPN id), plus the full `WebApplicationBuilder.Server.UseServer(options => options.UseHttp1s(...))` builder path — all assert the served request carries `HttpScheme.Https`.

`Web.Hosting` `docs/DESIGN.md` documents the surface, ALPN defaulting, and the layering boundary.

## Notes

- The issue body also mentions mirroring the members into `Web.Server`; that project was **deleted by #766** (PR #800), so `Web.Hosting` is the only home now — as the plan's Progress Log records.
- HTTP/3 / QUIC convenience stays out of scope (QUIC's TLS is always-on; tracked under #767). The `Web.Hosting` non-goal was updated accordingly.
- Framework packaging (`frameworks/Assimalign.Cohesion.App.props`) is uniformly WIP for the Web resource — `Web.Hosting` and all its transport deps (`Http.Connections`, `Connections.Tcp/Quic`) are absent pending the holistic "assemble resources/Web" effort — so no manifest entry was added for `Connections.Security` here (it would be inconsistent and out of scope).
- Collision watch: #776 also edits `Web.Hosting` (pipeline exception boundary) but different files; if it merges first, only a trivial `docs/DESIGN.md` append may need rebasing.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)
