### PR TITLE
[L03.01.02.01.01] Route matcher: precedence ordering, 405/404 split, HEAD→GET

### DIFF
--- a/resources/Web/Assimalign.Cohesion.Web.Routing/README.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/README.md
@@ -1,0 +1,57 @@
+# Assimalign.Cohesion.Web.Routing
+
+Deterministic, standards-aware HTTP route matching for the Cohesion Web stack. This is an
+**L3** service-platform library: it consumes the L1 `Assimalign.Cohesion.Http` protocol
+primitives and is consumed by the higher-level web programming models (API, functions,
+controllers, metadata, results).
+
+## What it does
+
+- Parses route templates (`/users/{id:int}/assets/{name}.{ext?}`, catch-alls, defaults,
+  inline constraints) into an immutable `RoutePattern`.
+- Matches an inbound request against a set of routes with correct **precedence** (a literal
+  segment beats a parameter segment regardless of registration order).
+- Distinguishes **404** (no route matched the path) from **405** (a route matched the path
+  but not the method), emitting an RFC 9110 `Allow` header for the latter.
+- Accepts **multiple HTTP methods** per route and serves **HEAD** from a matching **GET**
+  route (RFC 9110 §9.3.2).
+
+## Key types
+
+| Type | Role |
+|------|------|
+| `RoutePattern` / `RoutePatternParser` | Parsed, immutable template shape and its parser. |
+| `RoutePrecedence` | Computes inbound (match) and outbound (URL-gen) precedence. |
+| `Route` | A pattern + the HTTP methods it accepts + a handler. |
+| `Router` | Evaluates routes by precedence; produces a `RouteMatch`. |
+| `RouteMatch` / `RouteMatchStatus` | The match outcome: `Matched`, `MethodNotAllowed`, `NoMatch`. |
+| `RouteParameterPolicy*` | Inline constraints (`int`, `range`, `regex`, required-value). |
+| `RoutingExtensions.UseRouting` | Pipeline integration (dispatch / 405 / fall-through). |
+
+## Usage
+
+```csharp
+var router = new Router(new IRouterRoute[]
+{
+    new Route(HttpMethod.Get, "/api/status", statusHandler),   // literal — wins for /api/status
+    new Route(HttpMethod.Get, "/api/{id:int}", getHandler),    // constrained parameter
+    new Route(new[] { HttpMethod.Get, HttpMethod.Post }, "/items", itemsHandler),
+});
+
+RouteMatch match = router.Match(context);
+switch (match.Status)
+{
+    case RouteMatchStatus.Matched:          /* match.Route, match.Values */ break;
+    case RouteMatchStatus.MethodNotAllowed: /* 405 + match.ToAllowHeaderValue() */ break;
+    case RouteMatchStatus.NoMatch:          /* 404 */ break;
+}
+```
+
+Within a web application pipeline, prefer `builder.UseRouting()`, which performs this dispatch
+(invoke handler / emit 405 + `Allow` / fall through to the next middleware) for you.
+
+## Design
+
+See [docs/DESIGN.md](docs/DESIGN.md) for the matcher pipeline, the precedence scheme, the
+405-vs-404 model, the HEAD→GET fallback, AOT posture, and the routing features delivered by
+sibling issues (metadata, groups, link generation, source-gen binding).

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/docs/DESIGN.md
@@ -1,6 +1,174 @@
+# Assimalign.Cohesion.Web.Routing — Design
 
+## Purpose
 
+This library turns a set of registered route templates into a deterministic decision:
+given an inbound `IHttpContext`, which handler (if any) should run, and — when none
+should — whether that is a *no route* (404) or a *wrong method* (405) situation. It is a
+foundation primitive: the API, function, controller, and metadata programming models
+(issues #149, #150, #151, #786–#789, #796) all build on the matcher defined here, so the
+matcher's behavior must be predictable and standards-aware before those layers are added.
 
+Scope of this library:
 
-IRouter
-    -> Executes
+- Route **template parsing** into an immutable `RoutePattern` (`Patterns/`).
+- Route **parameter policies / constraints** (`Policies/`) evaluated during matching.
+- A **route** (`Route`) that binds a pattern, the HTTP methods it accepts, and a handler.
+- A **router** (`Router`) that evaluates routes against a request with correct precedence
+  and HTTP method semantics.
+- Minimal **pipeline integration** (`UseRouting`) so a web application can dispatch through
+  the router.
+
+## The matcher pipeline
+
+```
+raw template ──RoutePatternParser──▶ RoutePattern ──┐
+                                                     ├─▶ Route ──┐
+     HttpMethod[] ─────────────────────────────────-┘           ├─▶ Router ──▶ RouteMatch
+                                                                 │
+     IRouterRouteHandler ────────────────────────────────────---┘
+```
+
+- **`RoutePattern`** is the parsed, immutable shape of a template: an ordered list of path
+  segments (literals, separators, parameters), the parameters and their inline policies,
+  defaults, required values, and the precomputed inbound/outbound precedence.
+- **`Route`** pairs a pattern with the set of HTTP methods it accepts and the handler to
+  invoke. Matching is split into two phases (see below).
+- **`Router`** owns the collection of routes and produces a `RouteMatch` for a request.
+
+### Two-phase matching (path, then method)
+
+`IRouterRoute` exposes matching as two operations rather than one:
+
+- `TryMatchPath(context, out values)` — matches the request **path** and validates parameter
+  policies, **ignoring** the HTTP method.
+- `TryMatch(context, out values)` — the full match: `TryMatchPath` **and** the request method
+  is accepted.
+
+Splitting the phases is what lets the router tell a genuine 404 apart from a 405. If any route
+matches the path but none accepts the method, the correct response is `405 Method Not Allowed`
+with an `Allow` header — not `404 Not Found`. A single combined predicate (the original design)
+collapsed both into "no match" and could never produce a 405. This split is the seam the whole
+405-vs-404 behavior hangs on.
+
+## Precedence ordering (fix for the insertion-order defect)
+
+Each `RoutePattern` carries an `InboundPrecedence` (a `decimal`) computed by `RoutePrecedence`.
+Every segment contributes one digit at a decreasing decimal place, where a **lower** digit is
+**more specific**:
+
+| Segment kind                         | Digit |
+|--------------------------------------|-------|
+| Literal                              | 1     |
+| Constrained parameter / multi-part   | 2     |
+| Unconstrained parameter              | 3     |
+| Constrained catch-all                | 4     |
+| Unconstrained catch-all              | 5     |
+
+So `/api/status` = `1.1`, `/api/{id:int}` = `1.2`, `/api/{id}` = `1.3`. **Lower is more
+specific and must be evaluated first.**
+
+The original `Router` computed precedence but never used it — it matched routes in **insertion
+order** and returned the first hit. That meant registering `/api/{id}` before `/api/status`
+shadowed the literal: a request for `/api/status` matched the parameter route. `Router` now
+sorts its candidates **once at construction** by ascending `InboundPrecedence`, breaking ties by
+**registration order** (a stable, deterministic total order via the `PrecedenceKey` comparer).
+`Routes` still enumerates in registration order; only the internal evaluation list is reordered.
+
+Method acceptance can still override raw precedence: the router walks candidates in precedence
+order and returns the first whose path **and** method both match. A higher-precedence route that
+matches the path but not the method does not block a lower-precedence route that matches both —
+it only contributes to the `Allow` set if nothing ends up matching.
+
+## HTTP method semantics
+
+### Multiple methods per route
+
+A `Route` accepts a **set** of methods (`Methods`), not a single one. Constructors accept either
+a single `HttpMethod` (the common case) or an `IEnumerable<HttpMethod>`. Duplicate methods are
+de-duplicated at construction. An **empty** method set means "accept any method" — useful for
+catch-all/fallback routes.
+
+### 405 vs 404 and the `Allow` header
+
+`Router.Match` returns a `RouteMatch` with one of three `RouteMatchStatus` values:
+
+- `Matched` — a route matched path and method; `Route` and `Values` are populated.
+- `MethodNotAllowed` — one or more routes matched the path but none accepted the method;
+  `AllowedMethods` holds the union of methods those routes accept, and `ToAllowHeaderValue()`
+  formats them as an RFC 9110 `Allow` header (`"GET, POST, HEAD"`).
+- `NoMatch` — nothing matched the path.
+
+`RouteMatch` is a `readonly struct` so the common path allocates nothing beyond the captured
+route values.
+
+### HEAD falls back to GET
+
+Per RFC 9110 §9.3.2 a `HEAD` request is answered identically to `GET` (headers only, no body).
+A route that maps `GET` but not `HEAD` therefore **accepts** `HEAD`: the router's method-
+acceptance check treats `HEAD` as satisfied by a `GET` mapping when `HEAD` is not explicitly
+mapped. Symmetrically, a `405` `Allow` header for a `GET`-capable path advertises `HEAD`. An
+explicit `HEAD` route still wins for `HEAD` requests, and a `HEAD`-only route does **not** answer
+`GET`.
+
+The fallback lives in `Router`, not in `Route`. `Route.TryMatch`/`AcceptsMethod` report *exact*
+membership so the route's declared surface stays honest; the router layers the RFC synthesis on
+top. This keeps `Methods` a truthful description of what was registered while still serving HEAD
+correctly end-to-end.
+
+## Pipeline integration (`UseRouting`)
+
+The `UseRouting` middleware resolves the `IRouterFeature`, calls `router.Match(context)` once,
+and dispatches on the result:
+
+- `Matched` → store the match on the context (`SetRouteMatch`) and invoke the handler
+  (terminal; downstream middleware does not run).
+- `MethodNotAllowed` → set `405` and the `Allow` header, then **short-circuit** (do not fall
+  through to the terminal 404 pipeline).
+- `NoMatch` → call `next`, letting the rest of the pipeline (and any terminal 404) handle it.
+
+`IRouter.RouteAsync` performs the same dispatch for callers that use the router directly without
+the middleware, so a direct `RouteAsync` also produces a correct 405 with `Allow`.
+
+## Parameter policies (constraints)
+
+Inline constraints (`{id:int}`, `{id:range(1,10)}`, `{id:regex(...)}`, required-value, …) are
+resolved through a `RouteParameterPolicyMap` and evaluated **inside** `TryMatchPath`. A failed
+constraint means the path did not match *for that route*, so a more general route can still pick
+the request up (e.g. `/api/{id:int}` rejects `/api/abc`, which then falls through to
+`/api/{id}`). Unknown policy references fail fast at `Route` construction, not at request time.
+
+## AOT posture
+
+- No reflection, no runtime code generation, no dynamic activation anywhere in the match path —
+  the library is `IsAotCompatible` and trim-safe.
+- Parameter policies are explicit objects resolved through a map, not reflected constructors.
+- Source-generated endpoint **binding** (turning a matched route into typed handler arguments)
+  is intentionally out of scope here and is delivered by the analyzer work in #796; the matcher
+  produces a `RouteValueDictionary` of strings and lets that layer bind.
+
+## Lifecycle and immutability
+
+- `RoutePattern` and `Route` are immutable once constructed.
+- `Router` snapshots its routes into an immutable list and precomputes the precedence-ordered
+  evaluation array in its constructor. A router instance is therefore safe to share across
+  concurrent requests; there is no per-request mutable router state.
+- `RouteMatch` is an immutable value; the only mutable output is the per-request
+  `RouteValueDictionary`.
+
+## Non-goals (delivered elsewhere in the routing epic #28)
+
+- **Endpoint metadata bag** — #150 (`IRouterRoute` metadata seam that auth/CORS/OpenAPI consume).
+- **Typed route values, richer constraints, per-app router state** — #789.
+- **Route groups (`MapGroup`)** — #786.
+- **Named routes + link generation (outbound URL building)** — #787. `OutboundPrecedence` is
+  computed and preserved for this future work but is not consumed by the matcher.
+- **Host-based matching (`RequireHost`)** — #788.
+- **Source-generated binding + validation** — #796.
+- **Result writers / content negotiation** — #149.
+
+## Standards
+
+- **RFC 3986** — URI path syntax (segment splitting, percent-encoding expectations).
+- **RFC 9110** — HTTP semantics: §9.3.2 (HEAD as GET), §15.5.6 (405 + `Allow`), method
+  case-sensitivity.

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouter.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,20 +7,31 @@ namespace Assimalign.Cohesion.Web.Routing;
 using Assimalign.Cohesion.Http;
 
 /// <summary>
-/// 
+/// Evaluates a set of routes against incoming HTTP requests, honoring route precedence and HTTP method semantics.
 /// </summary>
 public interface IRouter
 {
     /// <summary>
-    /// Gets the routes associated with the router.
+    /// Gets the routes associated with the router, in registration order.
     /// </summary>
     IEnumerable<IRouterRoute> Routes { get; }
 
     /// <summary>
-    /// Rou
+    /// Evaluates the request against the configured routes without invoking a handler or mutating the response.
     /// </summary>
-    /// <param name="context"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="context">The HTTP context to evaluate.</param>
+    /// <returns>
+    /// A <see cref="RouteMatch"/> describing whether a route matched, whether the path matched but the method
+    /// did not (405), or whether nothing matched (404).
+    /// </returns>
+    RouteMatch Match(IHttpContext context);
+
+    /// <summary>
+    /// Routes the request: on a successful match the mapped handler is invoked; on a method mismatch a 405
+    /// response with an <c>Allow</c> header is produced; on no match the router takes no action.
+    /// </summary>
+    /// <param name="context">The HTTP context to route.</param>
+    /// <param name="cancellationToken">A token used to cancel handler execution.</param>
+    /// <returns>A task that completes when routing (and any invoked handler) completes.</returns>
     Task RouteAsync(IHttpContext context, CancellationToken cancellationToken = default);
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouterRoute.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouterRoute.cs
@@ -1,20 +1,56 @@
-﻿using Assimalign.Cohesion.Http;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
 
 namespace Assimalign.Cohesion.Web.Routing;
 
+/// <summary>
+/// Represents a single routable endpoint: a route pattern, the HTTP methods it accepts,
+/// and the handler invoked when a request matches.
+/// </summary>
+/// <remarks>
+/// Matching is split into a path phase (<see cref="TryMatchPath"/>) and a method phase so a
+/// router can tell a genuine no-match (404) apart from a path that matched with the wrong method
+/// (405). <see cref="InboundPrecedence"/> lets the router order candidates by specificity rather
+/// than by registration order.
+/// </remarks>
 public interface IRouterRoute
 {
     /// <summary>
-    /// A handler mapped to the route, which will be executed when the route is successfully matched.
+    /// Gets the handler mapped to the route, executed when the route is successfully matched.
     /// </summary>
     IRouterRouteHandler Handler { get; }
 
     /// <summary>
-    /// 
+    /// Gets the HTTP methods accepted by the route.
     /// </summary>
-    /// <param name="method"></param>
-    /// <param name="path"></param>
-    /// <param name="values"></param>
-    /// <returns></returns>
+    /// <remarks>
+    /// An empty collection indicates the route accepts any HTTP method.
+    /// </remarks>
+    IReadOnlyCollection<HttpMethod> Methods { get; }
+
+    /// <summary>
+    /// Gets the inbound (request-matching) precedence of the route.
+    /// </summary>
+    /// <remarks>
+    /// Lower values are more specific and are evaluated first. Literal segments sort ahead of
+    /// constrained parameters, which sort ahead of unconstrained parameters and catch-alls.
+    /// </remarks>
+    decimal InboundPrecedence { get; }
+
+    /// <summary>
+    /// Attempts to match the request path and parameter policies against the route, ignoring the HTTP method.
+    /// </summary>
+    /// <param name="context">The HTTP context to evaluate.</param>
+    /// <param name="values">The captured route values when the request path matches.</param>
+    /// <returns><see langword="true"/> when the request path matches; otherwise <see langword="false"/>.</returns>
+    bool TryMatchPath(IHttpContext context, out RouteValueDictionary values);
+
+    /// <summary>
+    /// Attempts to match the request path, parameter policies, and HTTP method against the route.
+    /// </summary>
+    /// <param name="context">The HTTP context to evaluate.</param>
+    /// <param name="values">The captured route values when the route matches.</param>
+    /// <returns><see langword="true"/> when the request path and method both match; otherwise <see langword="false"/>.</returns>
     bool TryMatch(IHttpContext context, out RouteValueDictionary values);
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Extensions/RoutingExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Extensions/RoutingExtensions.cs
@@ -23,7 +23,7 @@ public static class RoutingExtensions
             builder.Use(async (context, next) =>
             {
                 using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken.None);
-                
+
                 CancellationToken cancellationToken = cancellationTokenSource.Token;
 
                 IHttpFeatureCollection? features = context.Features;
@@ -36,11 +36,25 @@ public static class RoutingExtensions
                 IRouterFeature feature = features.Get<IRouterFeature>() ?? throw new InvalidOperationException("No router feature was registered.");
                 IRouter router = feature.Router;
 
-                await router.RouteAsync(context, cancellationToken).ConfigureAwait(false);
+                RouteMatch match = router.Match(context);
 
-                if (!context.TryGetRoute(out _))
+                switch (match.Status)
                 {
-                    await next.Invoke(context).ConfigureAwait(false);
+                    case RouteMatchStatus.Matched:
+                        context.SetRouteMatch(match.Route!, match.Values);
+                        await match.Route!.Handler.InvokeAsync(context, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case RouteMatchStatus.MethodNotAllowed:
+                        // A route matched the path but not the method: emit 405 with an Allow header and
+                        // short-circuit rather than falling through to the terminal 404 pipeline.
+                        context.Response.StatusCode = HttpStatusCode.MethodNotAllowed;
+                        context.Response.Headers[HttpHeaderKey.Allow] = match.ToAllowHeaderValue();
+                        break;
+
+                    default:
+                        await next.Invoke(context).ConfigureAwait(false);
+                        break;
                 }
             });
 

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Route.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Route.cs
@@ -10,11 +10,18 @@ using Assimalign.Cohesion.Web.Routing.Policies;
 namespace Assimalign.Cohesion.Web.Routing;
 
 /// <summary>
-/// Represents a concrete route pattern, method, and handler pairing.
+/// Represents a concrete route pattern, the HTTP methods it accepts, and its handler.
 /// </summary>
+/// <remarks>
+/// A route can accept more than one HTTP method. Path matching (<see cref="TryMatchPath"/>) is
+/// separated from method acceptance so a <see cref="Router"/> can distinguish a 404 (no path
+/// matched) from a 405 (a path matched but the method did not).
+/// </remarks>
 public sealed class Route : IRouterRoute
 {
     private static readonly IRouterRouteHandler EmptyHandler = new EmptyRouterRouteHandler();
+
+    private readonly HttpMethod[] _methods;
 
     /// <summary>
     /// Creates a new route from a raw route pattern.
@@ -22,7 +29,7 @@ public sealed class Route : IRouterRoute
     /// <param name="method">The HTTP method accepted by the route.</param>
     /// <param name="pattern">The raw route pattern.</param>
     public Route(HttpMethod method, string pattern)
-        : this(method, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
+        : this(new[] { method }, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
     {
     }
 
@@ -33,7 +40,7 @@ public sealed class Route : IRouterRoute
     /// <param name="pattern">The raw route pattern.</param>
     /// <param name="handler">The handler mapped to the route.</param>
     public Route(HttpMethod method, string pattern, IRouterRouteHandler handler)
-        : this(method, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), handler)
+        : this(new[] { method }, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), handler)
     {
     }
 
@@ -44,7 +51,7 @@ public sealed class Route : IRouterRoute
     /// <param name="pattern">The raw route pattern.</param>
     /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
     public Route(HttpMethod method, string pattern, RouteParameterPolicyMap policyMap)
-        : this(method, RoutePatternParser.Parse(pattern), policyMap, EmptyHandler)
+        : this(new[] { method }, RoutePatternParser.Parse(pattern), policyMap, EmptyHandler)
     {
     }
 
@@ -56,7 +63,7 @@ public sealed class Route : IRouterRoute
     /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
     /// <param name="handler">The handler mapped to the route.</param>
     public Route(HttpMethod method, string pattern, RouteParameterPolicyMap policyMap, IRouterRouteHandler handler)
-        : this(method, RoutePatternParser.Parse(pattern), policyMap, handler)
+        : this(new[] { method }, RoutePatternParser.Parse(pattern), policyMap, handler)
     {
     }
 
@@ -66,7 +73,7 @@ public sealed class Route : IRouterRoute
     /// <param name="method">The HTTP method accepted by the route.</param>
     /// <param name="pattern">The parsed route pattern.</param>
     public Route(HttpMethod method, RoutePattern pattern)
-        : this(method, pattern, RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
+        : this(new[] { method }, pattern, RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
     {
     }
 
@@ -77,7 +84,7 @@ public sealed class Route : IRouterRoute
     /// <param name="pattern">The parsed route pattern.</param>
     /// <param name="handler">The handler mapped to the route.</param>
     public Route(HttpMethod method, RoutePattern pattern, IRouterRouteHandler handler)
-        : this(method, pattern, RouteParameterPolicyMap.CreateDefault(), handler)
+        : this(new[] { method }, pattern, RouteParameterPolicyMap.CreateDefault(), handler)
     {
     }
 
@@ -88,31 +95,111 @@ public sealed class Route : IRouterRoute
     /// <param name="pattern">The parsed route pattern.</param>
     /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
     public Route(HttpMethod method, RoutePattern pattern, RouteParameterPolicyMap policyMap)
-        : this(method, pattern, policyMap, EmptyHandler)
+        : this(new[] { method }, pattern, policyMap, EmptyHandler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from a raw route pattern accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The raw route pattern.</param>
+    public Route(IEnumerable<HttpMethod> methods, string pattern)
+        : this(methods, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from a raw route pattern and mapped handler accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The raw route pattern.</param>
+    /// <param name="handler">The handler mapped to the route.</param>
+    public Route(IEnumerable<HttpMethod> methods, string pattern, IRouterRouteHandler handler)
+        : this(methods, RoutePatternParser.Parse(pattern), RouteParameterPolicyMap.CreateDefault(), handler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from a raw route pattern and custom policy map accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The raw route pattern.</param>
+    /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
+    public Route(IEnumerable<HttpMethod> methods, string pattern, RouteParameterPolicyMap policyMap)
+        : this(methods, RoutePatternParser.Parse(pattern), policyMap, EmptyHandler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from a raw route pattern, custom policy map, and mapped handler accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The raw route pattern.</param>
+    /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
+    /// <param name="handler">The handler mapped to the route.</param>
+    public Route(IEnumerable<HttpMethod> methods, string pattern, RouteParameterPolicyMap policyMap, IRouterRouteHandler handler)
+        : this(methods, RoutePatternParser.Parse(pattern), policyMap, handler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from an already parsed route pattern accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The parsed route pattern.</param>
+    public Route(IEnumerable<HttpMethod> methods, RoutePattern pattern)
+        : this(methods, pattern, RouteParameterPolicyMap.CreateDefault(), EmptyHandler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from an already parsed route pattern and mapped handler accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The parsed route pattern.</param>
+    /// <param name="handler">The handler mapped to the route.</param>
+    public Route(IEnumerable<HttpMethod> methods, RoutePattern pattern, IRouterRouteHandler handler)
+        : this(methods, pattern, RouteParameterPolicyMap.CreateDefault(), handler)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new route from an already parsed route pattern and custom policy map accepting multiple HTTP methods.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="pattern">The parsed route pattern.</param>
+    /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
+    public Route(IEnumerable<HttpMethod> methods, RoutePattern pattern, RouteParameterPolicyMap policyMap)
+        : this(methods, pattern, policyMap, EmptyHandler)
     {
     }
 
     /// <summary>
     /// Creates a new route from an already parsed route pattern, custom policy map, and mapped handler.
     /// </summary>
-    /// <param name="method">The HTTP method accepted by the route.</param>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
     /// <param name="pattern">The parsed route pattern.</param>
     /// <param name="policyMap">The policy map used to resolve parameter policies.</param>
     /// <param name="handler">The handler mapped to the route.</param>
-    public Route(HttpMethod method, RoutePattern pattern, RouteParameterPolicyMap policyMap, IRouterRouteHandler handler)
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="methods"/>, <paramref name="pattern"/>, <paramref name="policyMap"/>,
+    /// or <paramref name="handler"/> is <see langword="null"/>.
+    /// </exception>
+    public Route(IEnumerable<HttpMethod> methods, RoutePattern pattern, RouteParameterPolicyMap policyMap, IRouterRouteHandler handler)
     {
-        Method = method;
+        ArgumentNullException.ThrowIfNull(methods);
+
         Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
         PolicyMap = policyMap ?? throw new ArgumentNullException(nameof(policyMap));
         Handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        _methods = NormalizeMethods(methods);
 
         ValidatePatternPolicies(Pattern, PolicyMap);
     }
 
-    /// <summary>
-    /// Gets the HTTP method accepted by the route.
-    /// </summary>
-    public HttpMethod Method { get; }
+    /// <inheritdoc />
+    public IReadOnlyCollection<HttpMethod> Methods => _methods;
 
     /// <summary>
     /// Gets the parsed route pattern.
@@ -125,22 +212,64 @@ public sealed class Route : IRouterRoute
     public RouteParameterPolicyMap PolicyMap { get; }
 
     /// <inheritdoc />
+    public decimal InboundPrecedence => Pattern.InboundPrecedence;
+
+    /// <inheritdoc />
     public IRouterRouteHandler Handler { get; }
+
+    /// <summary>
+    /// Determines whether the route accepts the supplied HTTP method.
+    /// </summary>
+    /// <param name="method">The HTTP method to test.</param>
+    /// <returns>
+    /// <see langword="true"/> when the route accepts the method, or when the route accepts any method
+    /// (its <see cref="Methods"/> collection is empty); otherwise <see langword="false"/>.
+    /// </returns>
+    public bool AcceptsMethod(HttpMethod method)
+    {
+        if (_methods.Length == 0)
+        {
+            return true;
+        }
+
+        for (int i = 0; i < _methods.Length; i++)
+        {
+            if (_methods[i] == method)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <inheritdoc />
     public bool TryMatch(IHttpContext httpContext, out RouteValueDictionary values)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        HttpMethod method = httpContext.Request.Method;
-        HttpPath path = httpContext.Request.Path;
-
-        values = new RouteValueDictionary();
-
-        if (Method != method)
+        if (!TryMatchPath(httpContext, out values))
         {
             return false;
         }
+
+        if (AcceptsMethod(httpContext.Request.Method))
+        {
+            return true;
+        }
+
+        values = new RouteValueDictionary();
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryMatchPath(IHttpContext httpContext, out RouteValueDictionary values)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        HttpPath path = httpContext.Request.Path;
+
+        values = new RouteValueDictionary();
 
         string[] requestSegments = SplitPath(path);
         int requestIndex = 0;
@@ -201,6 +330,31 @@ public sealed class Route : IRouterRoute
         }
 
         return true;
+    }
+
+    private static HttpMethod[] NormalizeMethods(IEnumerable<HttpMethod> methods)
+    {
+        List<HttpMethod> normalized = new();
+
+        foreach (HttpMethod method in methods)
+        {
+            bool exists = false;
+            for (int i = 0; i < normalized.Count; i++)
+            {
+                if (normalized[i] == method)
+                {
+                    exists = true;
+                    break;
+                }
+            }
+
+            if (!exists)
+            {
+                normalized.Add(method);
+            }
+        }
+
+        return normalized.ToArray();
     }
 
     private static bool TryMatchMissingSegment(RoutePatternPathSegment pathSegment, RouteValueDictionary values)

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/RouteMatch.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/RouteMatch.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// Represents the result of matching an HTTP request against an <see cref="IRouter"/>.
+/// </summary>
+/// <remarks>
+/// The result distinguishes three outcomes so a router — or middleware built over one — can produce
+/// the correct response: a successful match, a path that matched with an unacceptable method
+/// (405, carrying the set of acceptable methods for the <c>Allow</c> header), and no match at all (404).
+/// </remarks>
+public readonly struct RouteMatch
+{
+    private RouteMatch(
+        RouteMatchStatus status,
+        IRouterRoute? route,
+        RouteValueDictionary values,
+        IReadOnlyList<HttpMethod> allowedMethods)
+    {
+        Status = status;
+        Route = route;
+        Values = values;
+        AllowedMethods = allowedMethods;
+    }
+
+    /// <summary>
+    /// Gets the outcome of the match.
+    /// </summary>
+    public RouteMatchStatus Status { get; }
+
+    /// <summary>
+    /// Gets the matched route when <see cref="Status"/> is <see cref="RouteMatchStatus.Matched"/>; otherwise <see langword="null"/>.
+    /// </summary>
+    public IRouterRoute? Route { get; }
+
+    /// <summary>
+    /// Gets the captured route values when <see cref="Status"/> is <see cref="RouteMatchStatus.Matched"/>; otherwise an empty collection.
+    /// </summary>
+    public RouteValueDictionary Values { get; }
+
+    /// <summary>
+    /// Gets the HTTP methods acceptable for the matched path when <see cref="Status"/> is
+    /// <see cref="RouteMatchStatus.MethodNotAllowed"/>; otherwise an empty collection.
+    /// </summary>
+    public IReadOnlyList<HttpMethod> AllowedMethods { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the request matched a route.
+    /// </summary>
+    public bool IsMatched => Status == RouteMatchStatus.Matched;
+
+    /// <summary>
+    /// A shared result representing no matching route (404 territory).
+    /// </summary>
+    public static readonly RouteMatch Unmatched = new(
+        RouteMatchStatus.NoMatch,
+        route: null,
+        new RouteValueDictionary(),
+        Array.Empty<HttpMethod>());
+
+    /// <summary>
+    /// Creates a successful match result.
+    /// </summary>
+    /// <param name="route">The matched route.</param>
+    /// <param name="values">The captured route values.</param>
+    /// <returns>A <see cref="RouteMatch"/> whose <see cref="Status"/> is <see cref="RouteMatchStatus.Matched"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="route"/> or <paramref name="values"/> is <see langword="null"/>.</exception>
+    public static RouteMatch Matched(IRouterRoute route, RouteValueDictionary values)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        ArgumentNullException.ThrowIfNull(values);
+
+        return new RouteMatch(RouteMatchStatus.Matched, route, values, Array.Empty<HttpMethod>());
+    }
+
+    /// <summary>
+    /// Creates a method-mismatch (405) result.
+    /// </summary>
+    /// <param name="allowedMethods">The methods acceptable for the matched path.</param>
+    /// <returns>A <see cref="RouteMatch"/> whose <see cref="Status"/> is <see cref="RouteMatchStatus.MethodNotAllowed"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="allowedMethods"/> is <see langword="null"/>.</exception>
+    public static RouteMatch MethodNotAllowed(IReadOnlyList<HttpMethod> allowedMethods)
+    {
+        ArgumentNullException.ThrowIfNull(allowedMethods);
+
+        return new RouteMatch(RouteMatchStatus.MethodNotAllowed, route: null, new RouteValueDictionary(), allowedMethods);
+    }
+
+    /// <summary>
+    /// Formats <see cref="AllowedMethods"/> as an RFC 9110 <c>Allow</c> header value (a comma-separated method list).
+    /// </summary>
+    /// <returns>The formatted header value, or <see cref="HttpHeaderValue.Empty"/> when no methods are present.</returns>
+    public HttpHeaderValue ToAllowHeaderValue()
+    {
+        if (AllowedMethods.Count == 0)
+        {
+            return HttpHeaderValue.Empty;
+        }
+
+        string[] tokens = new string[AllowedMethods.Count];
+        for (int i = 0; i < AllowedMethods.Count; i++)
+        {
+            tokens[i] = AllowedMethods[i].Value;
+        }
+
+        return new HttpHeaderValue(string.Join(", ", tokens));
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/RouteMatchStatus.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/RouteMatchStatus.cs
@@ -1,0 +1,23 @@
+namespace Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// Describes the outcome of evaluating an HTTP request against an <see cref="IRouter"/>.
+/// </summary>
+public enum RouteMatchStatus
+{
+    /// <summary>
+    /// No route matched the request path. Callers should treat this as a candidate for a 404 response.
+    /// </summary>
+    NoMatch = 0,
+
+    /// <summary>
+    /// A route matched both the request path and the request method.
+    /// </summary>
+    Matched = 1,
+
+    /// <summary>
+    /// One or more routes matched the request path, but none accepted the request method.
+    /// Callers should treat this as a 405 response and emit an <c>Allow</c> header.
+    /// </summary>
+    MethodNotAllowed = 2,
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Router.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Router.cs
@@ -13,19 +13,30 @@ namespace Assimalign.Cohesion.Web.Routing;
 /// <summary>
 /// Represents a router that evaluates a set of routes against incoming HTTP requests.
 /// </summary>
+/// <remarks>
+/// Candidates are evaluated in ascending <see cref="IRouterRoute.InboundPrecedence"/> order (more specific
+/// routes first), with registration order breaking ties. This means a literal segment always wins over a
+/// parameter segment regardless of the order the routes were registered. Method handling follows RFC 9110:
+/// a path that matches with an unacceptable method yields <see cref="RouteMatchStatus.MethodNotAllowed"/>
+/// (405) with the acceptable methods, and a <c>HEAD</c> request is served by a matching <c>GET</c> route
+/// when <c>HEAD</c> is not explicitly mapped.
+/// </remarks>
 public sealed class Router : IRouter
 {
     private readonly IReadOnlyList<IRouterRoute> _routes;
+    private readonly IRouterRoute[] _ordered;
 
     /// <summary>
     /// Creates a new router from the supplied route collection.
     /// </summary>
     /// <param name="routes">The routes to evaluate.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="routes"/> is <see langword="null"/>.</exception>
     public Router(IEnumerable<IRouterRoute> routes)
     {
         ArgumentNullException.ThrowIfNull(routes);
 
         _routes = routes.ToImmutableList();
+        _ordered = OrderByPrecedence(_routes);
     }
 
     /// <summary>
@@ -80,11 +91,48 @@ public sealed class Router : IRouter
     }
 
     /// <summary>
-    /// Gets the routes evaluated by the router.
+    /// Gets the routes evaluated by the router, in registration order.
     /// </summary>
     public IReadOnlyList<IRouterRoute> Routes => _routes;
 
     IEnumerable<IRouterRoute> IRouter.Routes => Routes;
+
+    /// <inheritdoc />
+    public RouteMatch Match(IHttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        HttpMethod method = context.Request.Method;
+        List<HttpMethod>? allowed = null;
+
+        for (int i = 0; i < _ordered.Length; i++)
+        {
+            IRouterRoute candidate = _ordered[i];
+
+            if (!candidate.TryMatchPath(context, out RouteValueDictionary values))
+            {
+                continue;
+            }
+
+            if (AcceptsMethod(candidate, method))
+            {
+                return RouteMatch.Matched(candidate, values);
+            }
+
+            // Path matched but the method did not — remember the acceptable methods in case no
+            // higher- or lower-precedence candidate ends up matching the method (a 405, not a 404).
+            allowed ??= new List<HttpMethod>();
+            AccumulateAllowedMethods(candidate, allowed);
+        }
+
+        if (allowed is not null)
+        {
+            AddImpliedMethods(allowed);
+            return RouteMatch.MethodNotAllowed(allowed);
+        }
+
+        return RouteMatch.Unmatched;
+    }
 
     /// <summary>
     /// Attempts to match the current request against the configured routes.
@@ -95,17 +143,13 @@ public sealed class Router : IRouter
     /// <returns><see langword="true"/> when a route matches; otherwise <see langword="false"/>.</returns>
     public bool TryMatch(IHttpContext context, out IRouterRoute? route, out RouteValueDictionary values)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        RouteMatch match = Match(context);
 
-        for (int i = 0; i < _routes.Count; i++)
+        if (match.Status == RouteMatchStatus.Matched)
         {
-            IRouterRoute candidate = _routes[i];
-
-            if (candidate.TryMatch(context, out values))
-            {
-                route = candidate;
-                return true;
-            }
+            route = match.Route;
+            values = match.Values;
+            return true;
         }
 
         route = null;
@@ -118,12 +162,134 @@ public sealed class Router : IRouter
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (TryMatch(context, out IRouterRoute? route, out RouteValueDictionary values) && route is not null)
+        RouteMatch match = Match(context);
+
+        switch (match.Status)
         {
-            context.SetRouteMatch(route, values);
-            return route.Handler.InvokeAsync(context, cancellationToken);
+            case RouteMatchStatus.Matched:
+                context.SetRouteMatch(match.Route!, match.Values);
+                return match.Route!.Handler.InvokeAsync(context, cancellationToken);
+
+            case RouteMatchStatus.MethodNotAllowed:
+                ApplyMethodNotAllowed(context, match);
+                return Task.CompletedTask;
+
+            default:
+                return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Writes a 405 status code and an <c>Allow</c> header describing the acceptable methods for the matched path.
+    /// </summary>
+    /// <param name="context">The HTTP context whose response is updated.</param>
+    /// <param name="match">A <see cref="RouteMatchStatus.MethodNotAllowed"/> match result.</param>
+    internal static void ApplyMethodNotAllowed(IHttpContext context, RouteMatch match)
+    {
+        context.Response.StatusCode = HttpStatusCode.MethodNotAllowed;
+        context.Response.Headers[HttpHeaderKey.Allow] = match.ToAllowHeaderValue();
+    }
+
+    private static bool AcceptsMethod(IRouterRoute route, HttpMethod method)
+    {
+        IReadOnlyCollection<HttpMethod> methods = route.Methods;
+
+        if (methods.Count == 0)
+        {
+            return true;
         }
 
-        return Task.CompletedTask;
+        foreach (HttpMethod accepted in methods)
+        {
+            if (accepted == method)
+            {
+                return true;
+            }
+        }
+
+        // RFC 9110 §9.3.2: a HEAD request is served identically to GET. A route that maps GET but not
+        // HEAD therefore accepts HEAD, letting the handler run with the response body ultimately elided.
+        if (method == HttpMethod.Head)
+        {
+            foreach (HttpMethod accepted in methods)
+            {
+                if (accepted == HttpMethod.Get)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void AccumulateAllowedMethods(IRouterRoute route, List<HttpMethod> allowed)
+    {
+        foreach (HttpMethod method in route.Methods)
+        {
+            if (!ContainsMethod(allowed, method))
+            {
+                allowed.Add(method);
+            }
+        }
+    }
+
+    private static void AddImpliedMethods(List<HttpMethod> allowed)
+    {
+        // A GET-capable resource also answers HEAD, so advertise it in the Allow header.
+        if (ContainsMethod(allowed, HttpMethod.Get) && !ContainsMethod(allowed, HttpMethod.Head))
+        {
+            allowed.Add(HttpMethod.Head);
+        }
+    }
+
+    private static bool ContainsMethod(List<HttpMethod> methods, HttpMethod method)
+    {
+        for (int i = 0; i < methods.Count; i++)
+        {
+            if (methods[i] == method)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IRouterRoute[] OrderByPrecedence(IReadOnlyList<IRouterRoute> routes)
+    {
+        int count = routes.Count;
+        var ordered = new IRouterRoute[count];
+        var keys = new PrecedenceKey[count];
+
+        for (int i = 0; i < count; i++)
+        {
+            ordered[i] = routes[i];
+            keys[i] = new PrecedenceKey(routes[i].InboundPrecedence, i);
+        }
+
+        // Sort by precedence ascending (more specific first), registration index breaking ties so the
+        // ordering is deterministic and stable.
+        Array.Sort(keys, ordered);
+        return ordered;
+    }
+
+    private readonly struct PrecedenceKey : IComparable<PrecedenceKey>
+    {
+        public PrecedenceKey(decimal precedence, int index)
+        {
+            Precedence = precedence;
+            Index = index;
+        }
+
+        public decimal Precedence { get; }
+
+        public int Index { get; }
+
+        public int CompareTo(PrecedenceKey other)
+        {
+            int result = Precedence.CompareTo(other.Precedence);
+            return result != 0 ? result : Index.CompareTo(other.Index);
+        }
     }
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RoutePatternParserTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RoutePatternParserTests.cs
@@ -1,3 +1,4 @@
+using Assimalign.Cohesion.Web.Routing.Exceptions;
 using Assimalign.Cohesion.Web.Routing.Patterns;
 using Shouldly;
 using Xunit;
@@ -28,5 +29,67 @@ public class RoutePatternParserTests
         RoutePatternParameterSegment? extensionParameter = pattern.GetParameter("ext");
         extensionParameter.ShouldNotBeNull();
         extensionParameter.IsOptional.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Parse: Should recognize a catch-all parameter")]
+    public void Parse_WithCatchAllParameter_ShouldMarkParameterAsCatchAll()
+    {
+        // Arrange
+        const string patternText = "/files/{**path}";
+
+        // Act
+        RoutePattern pattern = RoutePatternParser.Parse(patternText);
+
+        // Assert
+        RoutePatternParameterSegment? pathParameter = pattern.GetParameter("path");
+        pathParameter.ShouldNotBeNull();
+        pathParameter.IsCatchAll.ShouldBeTrue();
+        pathParameter.EncodeSlashes.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Parse: Should capture a parameter default value")]
+    public void Parse_WithParameterDefault_ShouldCaptureDefaultValue()
+    {
+        // Arrange
+        const string patternText = "/blog/{page=1}";
+
+        // Act
+        RoutePattern pattern = RoutePatternParser.Parse(patternText);
+
+        // Assert
+        RoutePatternParameterSegment? pageParameter = pattern.GetParameter("page");
+        pageParameter.ShouldNotBeNull();
+        pageParameter.Default.ShouldBe("1");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Parse: Should capture multiple inline constraints")]
+    public void Parse_WithMultipleConstraints_ShouldCaptureEachPolicy()
+    {
+        // Arrange
+        const string patternText = "/orders/{id:int:min(1)}";
+
+        // Act
+        RoutePattern pattern = RoutePatternParser.Parse(patternText);
+
+        // Assert
+        RoutePatternParameterSegment? idParameter = pattern.GetParameter("id");
+        idParameter.ShouldNotBeNull();
+        idParameter.ParameterPolicies.Count.ShouldBe(2);
+        idParameter.ParameterPolicies[0].Content.ShouldBe("int");
+        idParameter.ParameterPolicies[1].Content.ShouldBe("min(1)");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Parse: Should reject consecutive separators")]
+    public void Parse_WithConsecutiveSeparators_ShouldThrow()
+    {
+        // Act & Assert
+        Should.Throw<RoutePatternException>(() => RoutePatternParser.Parse("/api//status"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Parse: Should reject a catch-all that is not last")]
+    public void Parse_WithCatchAllNotLast_ShouldThrow()
+    {
+        // Act & Assert
+        Should.Throw<RoutePatternException>(() => RoutePatternParser.Parse("/files/{**path}/extra"));
     }
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RoutePrecedenceTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RoutePrecedenceTests.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+
+using Assimalign.Cohesion.Web.Routing.Patterns;
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Cohesion.Web.Routing.Tests;
+
+public class RoutePrecedenceTests
+{
+    [Theory(DisplayName = "Cohesion Test [Web.Routing] - InboundPrecedence: Should compute documented values")]
+    [InlineData("/api/status", "1.1")]
+    [InlineData("/api/{id:int}", "1.2")]
+    [InlineData("/api/{id}", "1.3")]
+    [InlineData("/api/template/{id:int}", "1.12")]
+    [InlineData("/api/template/{id}", "1.13")]
+    public void InboundPrecedence_ShouldMatchDocumentedValues(string pattern, string expected)
+    {
+        // Arrange
+        decimal expectedPrecedence = decimal.Parse(expected, CultureInfo.InvariantCulture);
+
+        // Act
+        RoutePattern routePattern = RoutePatternParser.Parse(pattern);
+
+        // Assert
+        routePattern.InboundPrecedence.ShouldBe(expectedPrecedence);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - InboundPrecedence: Specificity orders literal < constrained < unconstrained < catch-all")]
+    public void InboundPrecedence_ShouldOrderBySpecificity()
+    {
+        // Arrange
+        decimal literal = RoutePatternParser.Parse("/api/status").InboundPrecedence;
+        decimal constrained = RoutePatternParser.Parse("/api/{id:int}").InboundPrecedence;
+        decimal unconstrained = RoutePatternParser.Parse("/api/{id}").InboundPrecedence;
+        decimal catchAll = RoutePatternParser.Parse("/api/{**path}").InboundPrecedence;
+
+        // Assert — lower precedence is more specific and is matched first.
+        literal.ShouldBeLessThan(constrained);
+        constrained.ShouldBeLessThan(unconstrained);
+        unconstrained.ShouldBeLessThan(catchAll);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouteTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouteTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Assimalign.Cohesion.Http;
 using Assimalign.Cohesion.Web.Routing.Tests.TestObjects;
 using Shouldly;
@@ -71,5 +73,95 @@ public class RouteTests
 
         // Assert
         matched.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - TryMatchPath: Should match the path while ignoring the method")]
+    public void TryMatchPath_OnMethodMismatch_ShouldStillMatchPath()
+    {
+        // Arrange
+        Route route = new(HttpMethod.Get, "/users/{id:int}");
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Post, "/users/42");
+
+        // Act
+        bool pathMatched = route.TryMatchPath(context, out RouteValueDictionary values);
+        bool fullMatch = route.TryMatch(context, out _);
+
+        // Assert
+        pathMatched.ShouldBeTrue();
+        values["id"].ShouldBe("42");
+        fullMatch.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - TryMatch: Should accept any of the mapped methods")]
+    public void TryMatch_OnMultiMethodRoute_ShouldAcceptEachMappedMethod()
+    {
+        // Arrange
+        Route route = new(new[] { HttpMethod.Get, HttpMethod.Post }, "/items/{id}");
+
+        // Act
+        bool getMatched = route.TryMatch(TestHttpContext.Create(HttpMethod.Get, "/items/1"), out _);
+        bool postMatched = route.TryMatch(TestHttpContext.Create(HttpMethod.Post, "/items/1"), out _);
+        bool deleteMatched = route.TryMatch(TestHttpContext.Create(HttpMethod.Delete, "/items/1"), out _);
+
+        // Assert
+        getMatched.ShouldBeTrue();
+        postMatched.ShouldBeTrue();
+        deleteMatched.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Methods: Should de-duplicate repeated methods")]
+    public void Methods_WithDuplicateMethods_ShouldDeduplicate()
+    {
+        // Arrange
+        Route route = new(new[] { HttpMethod.Get, HttpMethod.Get, HttpMethod.Post }, "/items");
+
+        // Act
+        int methodCount = route.Methods.Count;
+
+        // Assert
+        methodCount.ShouldBe(2);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - AcceptsMethod: Empty method set should accept any method")]
+    public void AcceptsMethod_OnEmptyMethodSet_ShouldAcceptAnyMethod()
+    {
+        // Arrange
+        Route route = new(Array.Empty<HttpMethod>(), "/any/{id}");
+
+        // Act
+        bool acceptsGet = route.AcceptsMethod(HttpMethod.Get);
+        bool acceptsDelete = route.AcceptsMethod(HttpMethod.Delete);
+        bool fullMatch = route.TryMatch(TestHttpContext.Create(HttpMethod.Patch, "/any/9"), out _);
+
+        // Assert
+        acceptsGet.ShouldBeTrue();
+        acceptsDelete.ShouldBeTrue();
+        fullMatch.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - TryMatch: Should capture a catch-all remainder")]
+    public void TryMatch_OnCatchAllRoute_ShouldCaptureRemainder()
+    {
+        // Arrange
+        Route route = new(HttpMethod.Get, "/files/{**path}");
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/files/images/logo.png");
+
+        // Act
+        bool matched = route.TryMatch(context, out RouteValueDictionary values);
+
+        // Assert
+        matched.ShouldBeTrue();
+        values["path"].ShouldBe("images/logo.png");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - InboundPrecedence: Literal route outranks parameter route")]
+    public void InboundPrecedence_LiteralRoute_ShouldOutrankParameterRoute()
+    {
+        // Arrange
+        Route literalRoute = new(HttpMethod.Get, "/api/status");
+        Route parameterRoute = new(HttpMethod.Get, "/api/{id}");
+
+        // Act & Assert — lower inbound precedence is more specific and evaluated first.
+        literalRoute.InboundPrecedence.ShouldBeLessThan(parameterRoute.InboundPrecedence);
     }
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouterTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouterTests.cs
@@ -1,0 +1,302 @@
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Routing.Tests.TestObjects;
+using Shouldly;
+using Xunit;
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.Routing.Tests;
+
+public class RouterTests
+{
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Literal beats parameter registered first")]
+    public void Match_LiteralRegisteredAfterParameter_ShouldPreferLiteral()
+    {
+        // Arrange — the confirmed defect: a parameter route registered before a literal must not shadow it.
+        Route parameterRoute = new(HttpMethod.Get, "/api/{id}");
+        Route literalRoute = new(HttpMethod.Get, "/api/status");
+        Router router = new(new IRouterRoute[] { parameterRoute, literalRoute });
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/api/status");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeSameAs(literalRoute);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Precedence order is independent of registration order")]
+    public void Match_LiteralRegisteredBeforeParameter_ShouldPreferLiteral()
+    {
+        // Arrange
+        Route literalRoute = new(HttpMethod.Get, "/api/status");
+        Route parameterRoute = new(HttpMethod.Get, "/api/{id}");
+        Router router = new(new IRouterRoute[] { literalRoute, parameterRoute });
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/api/status");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeSameAs(literalRoute);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Parameter route matches when no literal applies")]
+    public void Match_ParameterRoute_ShouldMatchWhenNoLiteralApplies()
+    {
+        // Arrange
+        Route parameterRoute = new(HttpMethod.Get, "/api/{id}");
+        Route literalRoute = new(HttpMethod.Get, "/api/status");
+        Router router = new(new IRouterRoute[] { parameterRoute, literalRoute });
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/api/42");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeSameAs(parameterRoute);
+        match.Values["id"].ShouldBe("42");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Constrained parameter outranks unconstrained parameter")]
+    public void Match_ConstrainedParameter_ShouldOutrankUnconstrainedParameter()
+    {
+        // Arrange
+        Route unconstrained = new(HttpMethod.Get, "/api/{id}");
+        Route constrained = new(HttpMethod.Get, "/api/{id:int}");
+        Router router = new(new IRouterRoute[] { unconstrained, constrained });
+
+        // Act
+        RouteMatch numeric = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/42"));
+        RouteMatch textual = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/abc"));
+
+        // Assert
+        numeric.Status.ShouldBe(RouteMatchStatus.Matched);
+        numeric.Route.ShouldBeSameAs(constrained);
+
+        textual.Status.ShouldBe(RouteMatchStatus.Matched);
+        textual.Route.ShouldBeSameAs(unconstrained);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: A more specific method match outranks a higher-precedence path")]
+    public void Match_MethodAcceptance_ShouldOverrideHigherPrecedencePath()
+    {
+        // Arrange — the literal has higher precedence but only accepts GET; a POST must fall to the param route.
+        Route getLiteral = new(HttpMethod.Get, "/api/status");
+        Route postParameter = new(HttpMethod.Post, "/api/{id}");
+        Router router = new(new IRouterRoute[] { getLiteral, postParameter });
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Post, "/api/status");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeSameAs(postParameter);
+        match.Values["id"].ShouldBe("status");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Path match with wrong method yields 405")]
+    public void Match_PathMatchWithWrongMethod_ShouldReturnMethodNotAllowed()
+    {
+        // Arrange
+        Route route = new(HttpMethod.Get, "/users/{id}");
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Post, "/users/5");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.MethodNotAllowed);
+        match.Route.ShouldBeNull();
+        match.AllowedMethods.ShouldContain(HttpMethod.Get);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: No path match yields no match")]
+    public void Match_NoPathMatch_ShouldReturnNoMatch()
+    {
+        // Arrange
+        Route route = new(HttpMethod.Get, "/users/{id}");
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/orders/5");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.NoMatch);
+        match.Route.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: A route accepting multiple methods matches each")]
+    public void Match_MultiMethodRoute_ShouldMatchEachMethod()
+    {
+        // Arrange
+        Route route = new(new[] { HttpMethod.Get, HttpMethod.Post }, "/items");
+        Router router = new(route);
+
+        // Act
+        RouteMatch get = router.Match(TestHttpContext.Create(HttpMethod.Get, "/items"));
+        RouteMatch post = router.Match(TestHttpContext.Create(HttpMethod.Post, "/items"));
+        RouteMatch delete = router.Match(TestHttpContext.Create(HttpMethod.Delete, "/items"));
+
+        // Assert
+        get.Status.ShouldBe(RouteMatchStatus.Matched);
+        post.Status.ShouldBe(RouteMatchStatus.Matched);
+
+        delete.Status.ShouldBe(RouteMatchStatus.MethodNotAllowed);
+        delete.AllowedMethods.ShouldContain(HttpMethod.Get);
+        delete.AllowedMethods.ShouldContain(HttpMethod.Post);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: 405 across routes unions the allowed methods")]
+    public void Match_MethodMismatchAcrossRoutes_ShouldUnionAllowedMethods()
+    {
+        // Arrange — two routes share a path but map different methods.
+        Route getRoute = new(HttpMethod.Get, "/resource");
+        Route putRoute = new(HttpMethod.Put, "/resource");
+        Router router = new(new IRouterRoute[] { getRoute, putRoute });
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Delete, "/resource");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.MethodNotAllowed);
+        match.AllowedMethods.ShouldContain(HttpMethod.Get);
+        match.AllowedMethods.ShouldContain(HttpMethod.Put);
+        match.AllowedMethods.ShouldContain(HttpMethod.Head);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: 405 Allow header advertises HEAD for GET routes")]
+    public void Match_MethodMismatchOnGetRoute_ShouldAdvertiseHeadInAllowHeader()
+    {
+        // Arrange
+        Route route = new(HttpMethod.Get, "/reports");
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Post, "/reports");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.MethodNotAllowed);
+        match.AllowedMethods.ShouldContain(HttpMethod.Head);
+
+        string allow = match.ToAllowHeaderValue().Value;
+        allow.ShouldContain("GET", Case.Sensitive);
+        allow.ShouldContain("HEAD", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: HEAD falls back to a GET route")]
+    public void Match_HeadRequest_ShouldFallBackToGetRoute()
+    {
+        // Arrange
+        Route getRoute = new(HttpMethod.Get, "/page");
+        Router router = new(getRoute);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Head, "/page");
+
+        // Act
+        RouteMatch match = router.Match(context);
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeSameAs(getRoute);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Explicit HEAD route matches HEAD")]
+    public void Match_ExplicitHeadRoute_ShouldMatchHead()
+    {
+        // Arrange
+        Route headRoute = new(HttpMethod.Head, "/probe");
+        Router router = new(headRoute);
+
+        // Act
+        RouteMatch head = router.Match(TestHttpContext.Create(HttpMethod.Head, "/probe"));
+        RouteMatch get = router.Match(TestHttpContext.Create(HttpMethod.Get, "/probe"));
+
+        // Assert
+        head.Status.ShouldBe(RouteMatchStatus.Matched);
+        head.Route.ShouldBeSameAs(headRoute);
+
+        // A HEAD-only route does not answer GET.
+        get.Status.ShouldBe(RouteMatchStatus.MethodNotAllowed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Routes: Registration order is preserved")]
+    public void Routes_ShouldPreserveRegistrationOrder()
+    {
+        // Arrange
+        Route first = new(HttpMethod.Get, "/api/{id}");
+        Route second = new(HttpMethod.Get, "/api/status");
+        Router router = new(new IRouterRoute[] { first, second });
+
+        // Act
+        IRouterRoute[] routes = System.Linq.Enumerable.ToArray(router.Routes);
+
+        // Assert
+        routes[0].ShouldBeSameAs(first);
+        routes[1].ShouldBeSameAs(second);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - RouteAsync: Invokes handler on a successful match")]
+    public async Task RouteAsync_OnMatch_ShouldInvokeHandlerAndStoreRoute()
+    {
+        // Arrange
+        RecordingRouterRouteHandler handler = new();
+        Route route = new(HttpMethod.Get, "/ping", handler);
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/ping");
+
+        // Act
+        await router.RouteAsync(context);
+
+        // Assert
+        handler.WasInvoked.ShouldBeTrue();
+        context.TryGetRoute(out IRouterRoute? matched).ShouldBeTrue();
+        matched.ShouldBeSameAs(route);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - RouteAsync: Emits 405 and Allow header on method mismatch")]
+    public async Task RouteAsync_OnMethodMismatch_ShouldEmit405AndAllowHeader()
+    {
+        // Arrange
+        RecordingRouterRouteHandler handler = new();
+        Route route = new(HttpMethod.Get, "/ping", handler);
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Post, "/ping");
+
+        // Act
+        await router.RouteAsync(context);
+
+        // Assert
+        handler.WasInvoked.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.MethodNotAllowed);
+
+        context.Response.Headers.TryGetValue(HttpHeaderKey.Allow, out HttpHeaderValue allow).ShouldBeTrue();
+        allow.Value.ShouldContain("GET", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - RouteAsync: Leaves the response untouched on no match")]
+    public async Task RouteAsync_OnNoMatch_ShouldLeaveResponseUntouched()
+    {
+        // Arrange
+        RecordingRouterRouteHandler handler = new();
+        Route route = new(HttpMethod.Get, "/ping", handler);
+        Router router = new(route);
+        TestHttpContext context = TestHttpContext.Create(HttpMethod.Get, "/pong");
+
+        // Act
+        await router.RouteAsync(context);
+
+        // Assert
+        handler.WasInvoked.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.TryGetRoute(out _).ShouldBeFalse();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/TestObjects/TestHttpObjects.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/TestObjects/TestHttpObjects.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +10,8 @@ namespace Assimalign.Cohesion.Web.Routing.Tests.TestObjects;
 
 internal sealed class TestHttpRequest : HttpRequest
 {
+    private HttpContext? _httpContext;
+
     public override HttpHost Host { get; set; } = HttpHost.Empty;
 
     public override HttpPath Path { get; set; } = HttpPath.Root;
@@ -18,62 +20,101 @@ internal sealed class TestHttpRequest : HttpRequest
 
     public override HttpScheme Scheme { get; set; } = HttpScheme.Http;
 
-    public override IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+    public override HttpQueryCollection Query { get; } = new HttpQueryCollection();
 
-    public override IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public override HttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
 
-    public override IHttpCookieCollection Cookies { get; } = new HttpCookieCollection();
-
-    public override IHttpFormCollection Form { get; } = new HttpFormCollection();
+    public override HttpContext HttpContext => _httpContext
+        ?? throw new InvalidOperationException(
+            "The HttpContext back-reference has not been attached. Construct the TestHttpRequest through a TestHttpContext.");
 
     public override Stream Body { get; set; } = Stream.Null;
 
-    public override ClaimsPrincipal ClaimsPrincipal { get; set; } = new(new ClaimsIdentity());
+    internal void AttachContext(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _httpContext ??= context;
+    }
 }
 
 internal sealed class TestHttpResponse : HttpResponse
 {
+    private HttpContext? _httpContext;
+
     public override HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
 
-    public override IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public override HttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
 
-    public override IHttpCookieCollection Cookies { get; } = new HttpCookieCollection();
+    public override HttpContext HttpContext => _httpContext
+        ?? throw new InvalidOperationException(
+            "The HttpContext back-reference has not been attached. Construct the TestHttpResponse through a TestHttpContext.");
 
     public override Stream Body { get; set; } = new MemoryStream();
+
+    internal void AttachContext(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _httpContext ??= context;
+    }
+}
+
+internal sealed class RecordingRouterRouteHandler : IRouterRouteHandler
+{
+    public bool WasInvoked { get; private set; }
+
+    public IHttpContext? Context { get; private set; }
+
+    public Task InvokeAsync(IHttpContext context, CancellationToken cancellationToken = default)
+    {
+        WasInvoked = true;
+        Context = context;
+        return Task.CompletedTask;
+    }
 }
 
 internal sealed class TestHttpContext : HttpContext
 {
     private TestHttpContext(
         HttpVersion version,
-        HttpSession session,
         TestHttpRequest request,
         TestHttpResponse response,
-        IHttpConnectionInfo? connectionInfo = null,
-        CancellationToken requestAborted = default)
+        HttpConnectionInfo? connectionInfo = null,
+        CancellationToken requestCancelled = default)
     {
         Version = version;
-        Session = session;
         Request = request;
         Response = response;
         ConnectionInfo = connectionInfo ?? HttpConnectionInfo.Empty;
-        RequestAborted = requestAborted;
-        Items = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        Features = new HttpFeatureCollection();
+        Items = new Dictionary<string, object?>(StringComparer.Ordinal);
+        RequestCancelled = requestCancelled;
+
+        request.AttachContext(this);
+        response.AttachContext(this);
     }
 
     public override HttpVersion Version { get; }
-
-    public override HttpSession Session { get; }
 
     public override TestHttpRequest Request { get; }
 
     public override TestHttpResponse Response { get; }
 
-    public override IHttpConnectionInfo ConnectionInfo { get; }
+    public override HttpConnectionInfo ConnectionInfo { get; }
+
+    public override HttpFeatureCollection Features { get; }
 
     public override IDictionary<string, object?> Items { get; }
 
-    public override CancellationToken RequestAborted { get; }
+    public override CancellationToken RequestCancelled { get; }
+
+    public override void Cancel()
+    {
+    }
+
+    public override Task CancelAsync()
+    {
+        return Task.CompletedTask;
+    }
 
     public override ValueTask DisposeAsync()
     {
@@ -84,7 +125,6 @@ internal sealed class TestHttpContext : HttpContext
     {
         return new TestHttpContext(
             HttpVersion.Http11,
-            new HttpSession("routing-test-session"),
             new TestHttpRequest
             {
                 Method = method,


### PR DESCRIPTION
## Summary

Fixes the confirmed matcher defects in the Web routing library and expands template-parsing, matching, and precedence test coverage (Stage 2 · Lane F · issue #148).

The router previously computed `RoutePrecedence` but never used it — it matched routes by **linear first-match in registration order**, so registering `/api/{id}` before `/api/status` shadowed the literal. It also could not distinguish a wrong-method request (405) from a genuine no-match (404), supported only one method per route, and had no HEAD handling.

## What changed

**1. Precedence ordering (was: insertion order)**
- `Router` now sorts candidates **once at construction** by ascending `InboundPrecedence` (more specific first — literal `1` < constrained param `2` < unconstrained param `3` < catch-all), breaking ties by registration order via a deterministic `PrecedenceKey` comparer.
- `Routes` still enumerates in registration order; only internal evaluation is reordered.

**2. 405 vs 404 + multiple methods per route**
- New public result types `RouteMatch` (readonly struct) and `RouteMatchStatus` (`Matched` / `MethodNotAllowed` / `NoMatch`).
- `IRouterRoute` matching is split into `TryMatchPath` (path + constraints, method-agnostic) and `TryMatch` (path + method), so the router can tell "path matched, wrong method" (405, with the acceptable methods for an RFC 9110 `Allow` header) apart from "nothing matched" (404).
- `Route` accepts a **set** of HTTP methods (single-method and `IEnumerable<HttpMethod>` constructors; duplicates de-duped; empty set = any method).

**3. HEAD falls back to GET (RFC 9110 §9.3.2)**
- A route mapping `GET` but not `HEAD` serves `HEAD`; a `GET`-capable path advertises `HEAD` in the 405 `Allow` header. An explicit `HEAD` route still wins; a `HEAD`-only route does not answer `GET`. The synthesis lives in `Router`, keeping `Route.Methods` a truthful record of what was registered.

**Pipeline integration** — `UseRouting` now dispatches on `router.Match(context)`: `Matched` → invoke handler (terminal); `MethodNotAllowed` → set 405 + `Allow` and short-circuit; `NoMatch` → call `next`. `IRouter.RouteAsync` performs the same dispatch for direct callers.

## Tests

`dotnet test` → **41 passed, 0 failed.** Added `RouterTests` (precedence/defect, 405/404, multi-method, HEAD fallback, `RouteAsync` dispatch) and `RoutePrecedenceTests` (documented precedence values + specificity ordering); expanded `RouteTests` (path/method split, multi-method, catch-all, empty-method-set) and `RoutePatternParserTests` (catch-all, defaults, multiple constraints, invalid patterns).

> **Note:** the routing test project's `TestObjects` doubles were stale against the evolved `Assimalign.Cohesion.Http` abstract base classes (added `HttpContext` back-refs, `Features`/`RequestCancelled`/`Cancel`, concrete collection types; removed `Session`), so the test project didn't build on `main`. They're refreshed here (mirroring `Http`'s own `TestHttpTypes`) — no production behavior change.

## Docs

Authored `docs/DESIGN.md` (matcher pipeline, two-phase matching, precedence scheme, 405/404 model, HEAD→GET, AOT posture, non-goals) and a project `README.md`.

## Notes for reviewers

- **AOT:** no reflection/dynamic codegen on the match path; `IsAotCompatible` intact.
- **#150 coordination (Lane F):** this touches `IRouterRoute`/`Route`/`Router`. #150 (endpoint metadata bag) also touches these. Changes are additive (distinct members), so a merge is mechanical; if #150 lands first I'll rebase.
- **Out of scope (flagged, not fixed here):** `UseRouting()` returns `RouterBuilder.Shared` while `AddRouting()`'s `RouterFeature` builds from its *own* `RouterBuilder` — routes mapped via the returned shared builder wouldn't reach the feature's router. Pre-existing and orthogonal to the matcher defects; left for a separate fix to avoid scope creep.
- Per the program protocol, `docs/HTTP_WEB_PROGRAM_PLAN.md` is intentionally untouched (the orchestrator reconciles the Progress Log).

Closes #148
