### PR TITLE
[L01.01.11.30] Harden the cookie model per RFC 6265bis: lifetime cap, size limits, octet-grammar validation

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/README.md
@@ -30,11 +30,12 @@ backed by features stored in `IHttpContext.Features`.
 
 | Type | Role |
 |------|------|
-| `HttpCookie` | Single cookie with name, value, and `HttpCookieOptions` |
+| `HttpCookie` | Single cookie with name, value, and `HttpCookieOptions`; validates the RFC 6265 §4.1.1 name/value grammar at construction and exposes `ClampLifetime` |
 | `HttpCookieOptions` | RFC 6265 §5.2 attributes &mdash; Domain, Path, Expires, MaxAge, Secure, HttpOnly, SameSite |
 | `HttpCookieSameSiteMode` | Enum: Unspecified / None / Lax / Strict |
+| `HttpCookieLimits` | RFC 6265bis parse-side size limits (name+value, attribute value, attribute count) and the 400-day lifetime cap |
 | `IHttpCookieCollection` | Mutable collection of `HttpCookie`; used on both request and response sides |
-| `HttpCookieCollection` | Default in-memory implementation |
+| `HttpCookieCollection` | Default in-memory implementation; enforces `HttpCookieLimits` and drops malformed cookies while parsing |
 | `IHttpRequestCookieFeature` | Per-exchange request-cookie state (parsed snapshot) stored in `IHttpContext.Features` |
 | `IHttpResponseCookieFeature` | Per-exchange response-cookie state (mutable, drained to `Set-Cookie` at flush) stored in `IHttpContext.Features` |
 | `HttpRequestCookieFeature` | Default request-feature implementation (internal) |
@@ -68,6 +69,37 @@ returns an empty collection (and installs the feature so subsequent reads
 are cheap) and `context.Response.Cookies` returns a fresh empty mutable
 collection (also installing the feature). The presence of the feature
 signals that cookie handling has been observed for this exchange.
+
+## Wire-safety hardening (RFC 6265bis)
+
+This is the **model** library, so it owns the rules that keep a cookie
+well-formed on the wire — not cookie *policy* (see the split below):
+
+- **Octet-grammar validation.** `HttpCookie` rejects a name outside the
+  RFC 6265 §4.1.1 `token` grammar or a value containing `;`, `,`,
+  whitespace, a control character, CR/LF, DQUOTE, or backslash — throwing
+  `ArgumentException` — so a hostile value can never split or corrupt the
+  emitted `Set-Cookie` line. The invariant holds for the object's lifetime
+  because `Name`/`Value` are immutable.
+- **Parse-side size limits.** `HttpCookieCollection` enforces
+  `HttpCookieLimits` (name+value ≤ 4096, attribute value ≤ 1024, bounded
+  attribute count) while parsing; oversized cookies/attributes are ignored,
+  not thrown. Pass a custom `HttpCookieLimits` to the constructor to tune
+  them.
+- **400-day lifetime cap.** `cookie.ClampLifetime(now)` returns a cookie
+  whose `Max-Age`/`Expires` is capped at 400 days (RFC 6265bis §5.5);
+  zero/negative `Max-Age` (deletion) round-trips unchanged.
+
+```csharp
+// Cap an outbound cookie's lifetime at emission time.
+HttpCookie capped = cookie.ClampLifetime(DateTimeOffset.UtcNow);
+```
+
+**Model vs. policy.** Prefix invariants (`__Host-`/`__Secure-`),
+`SameSite=None`+`Secure` pairing, and *deciding when* to apply the lifetime
+cap are **policy** and live in `Assimalign.Cohesion.Web.CookiePolicy`, which
+depends on this package (never the reverse). See `docs/DESIGN.md` for the
+full split.
 
 ## How the transports plug in
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/docs/DESIGN.md
@@ -136,6 +136,78 @@ Dependency direction is one-way: cookie-aware packages depend on this
 one; this one depends only on the protocol core. The protocol core
 never gains a back-reference.
 
+## Wire-safety hardening (RFC 6265bis) &mdash; the model / policy split
+
+The package owns the RFC 6265 / 6265bis rules that make a cookie
+**well-formed on the wire**. It deliberately does *not* own the rules
+that decide whether a well-formed cookie is **allowed by policy**. The
+dividing line is: *"could this corrupt the header or the store?"* is a
+model concern; *"should this cookie be permitted / rewritten for this
+site?"* is a policy concern. Three model-level guards were added under
+issue [L01.01.11.30]:
+
+1. **Octet-grammar validation at construction (anti header-splitting).**
+   `HttpCookie` validates its `Name` against the RFC 6265 §4.1.1
+   `token` grammar and its `Value` against `*cookie-octet` (optionally a
+   single surrounding DQUOTE pair) in the constructor, throwing
+   `ArgumentException` on a violation. Because `Name`/`Value` are
+   immutable, a constructed cookie can *never* hold a `;`, `,`,
+   whitespace, control character, or CR/LF octet — so `ToString()` can
+   never emit a value that splits or corrupts the `Set-Cookie` line, and
+   the request-side fold (`name=value; …`) is equally safe. This is an
+   argument-validation error (a server bug), not a request rejection, so
+   it surfaces as `ArgumentException` rather than an area `HttpException`
+   with an `HttpErrorCode` (those are reserved for transport-level
+   request rejection). The grammar itself lives in the internal
+   `HttpCookieGrammar` helper as `SearchValues<char>` membership scans —
+   no regex, no allocation, AOT-safe.
+
+2. **Configurable parse-side size limits (`HttpCookieLimits`).**
+   `HttpCookieCollection` parsing enforces RFC 6265bis-aligned defaults:
+   name+value ≤ 4096 octets, per-attribute value ≤ 1024 octets, and a
+   bounded retained-attribute count (default 50, a DoS backstop that
+   keeps a hostile `Set-Cookie` from growing the attribute/extension list
+   without bound). Oversized cookies and attributes are **ignored**
+   (dropped) rather than throwing, matching the RFC's parsing-robustness
+   posture — a malformed inbound header must not crash the server. The
+   limits are a constructor parameter (`HttpCookieLimits.Default` when
+   omitted), so a host can tune or effectively disable a dimension
+   (`int.MaxValue`). The outer bound on total header length stays with
+   the transport's request/response header-size limits; these are the
+   per-cookie inner defense.
+
+3. **Lifetime cap mechanism (`HttpCookie.ClampLifetime`).** The model
+   supplies the RFC 6265bis §5.5 400-day constant
+   (`HttpCookieLimits.DefaultMaxLifetime`) and the *pure* clamping math:
+   `ClampLifetime(referenceTime[, maxLifetime])` returns a cookie whose
+   `Max-Age` is reduced to the cap when longer and whose `Expires` is
+   pulled back to `referenceTime + cap` when further out, while a zero or
+   negative `Max-Age` (a deletion signal, RFC 6265 §5.2.2) and a
+   past/near `Expires` round-trip untouched. Clamping is a pure function
+   with no hidden clock: **deciding when to apply it** — at emission,
+   against the current time — is an emission/policy responsibility, so
+   the mechanism lives here and the "apply the cap to outbound cookies"
+   trigger is left to the emitter / `Web.CookiePolicy`. Keeping the clock
+   out of the model is what makes the cap deterministically testable.
+
+**What stays here vs. what is `Web.CookiePolicy`'s job.** Everything above
+is wire-safety / well-formedness and lives in this model library. The
+following are *policy* and are explicitly **not** implemented here — they
+belong to `Assimalign.Cohesion.Web.CookiePolicy` (see its `docs/DESIGN.md`)
+because they encode a site's decision about acceptable cookies, not the
+wire grammar:
+
+- `__Host-` / `__Secure-` **prefix invariants** (require `Secure`, and for
+  `__Host-` also `Path=/` with no `Domain`).
+- **`SameSite=None` requires `Secure`** pairing (reject or upgrade).
+- **Applying** the 400-day lifetime cap to outbound cookies at emission
+  time (the model provides the mechanism; the middleware decides to run it
+  and supplies "now").
+
+The one-way dependency direction (`Web.CookiePolicy` → `Http.Cookies` →
+`Http` core, never a back-reference) is what lets the policy layer compose
+these model mechanisms without the model ever learning about policy.
+
 ## AOT posture
 
 `<IsAotCompatible>true</IsAotCompatible>` is inherited from the shared
@@ -144,7 +216,9 @@ generation, and no dynamic type loading. The feature lookup uses
 `typeof(IHttpRequestCookieFeature)` / `typeof(IHttpResponseCookieFeature)`
 as JIT-time constant keys into the underlying
 `Dictionary<Type, object>`; trim and AOT roots are unaffected. The
-parser is a string-tokenization loop with no regex.
+parser is a string-tokenization loop with no regex, and the octet-grammar
+guard (`HttpCookieGrammar`) classifies characters with
+`SearchValues<char>` membership scans — again no regex, no reflection.
 
 ## Non-goals
 
@@ -158,10 +232,15 @@ parser is a string-tokenization loop with no regex.
   top of this one. The base package stays focused on the typed model
   and the wire/feature plumbing.
 - **Cookie-policy enforcement.** Middleware that strips, rewrites, or
-  rejects cookies based on policy (Secure-only, SameSite upgrades,
-  prefix enforcement) belongs in a dedicated package
-  (`Assimalign.Cohesion.Web.CookiePolicy`) that's allowed to depend
-  on this one.
+  rejects cookies based on policy (Secure-only, `SameSite=None`+`Secure`
+  pairing, `__Host-`/`__Secure-` prefix enforcement, and *deciding when*
+  to apply the 400-day lifetime cap to outbound cookies) belongs in a
+  dedicated package (`Assimalign.Cohesion.Web.CookiePolicy`) that's
+  allowed to depend on this one. This library provides the wire-safety
+  *mechanisms* (octet-grammar validation, size limits, the
+  `ClampLifetime` math); the policy layer decides *whether and when* to
+  apply the policy-shaped ones. See "Wire-safety hardening" above for the
+  full split.
 - **Direction-specific interfaces.** As discussed above, a future
   refactor may introduce `IRequestCookieCollection` /
   `IResponseCookies` if real call sites prove the unified shape is

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookie.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookie.cs
@@ -7,19 +7,53 @@ namespace Assimalign.Cohesion.Http;
 /// <summary>
 /// Represents an HTTP cookie value.
 /// </summary>
+/// <remarks>
+/// The <see cref="Name"/> and <see cref="Value"/> are validated against the
+/// RFC 6265 &#167; 4.1.1 grammar at construction: the name must be a
+/// <c>token</c> and the value must be <c>*cookie-octet</c> (optionally
+/// DQUOTE-wrapped). Because the two are immutable, a constructed
+/// <see cref="HttpCookie"/> can never carry an octet &#8212; <c>;</c>,
+/// <c>,</c>, whitespace, a control character, or CR/LF &#8212; that would
+/// split or corrupt the serialized <c>Set-Cookie</c> line.
+/// </remarks>
 [DebuggerDisplay("{ToString()}")]
 public sealed class HttpCookie
 {
     /// <summary>
     /// Initializes a new cookie instance.
     /// </summary>
-    /// <param name="name">The cookie name.</param>
-    /// <param name="value">The cookie value.</param>
+    /// <param name="name">The cookie name. Must be a non-empty RFC 6265 &#167; 4.1.1 <c>token</c>.</param>
+    /// <param name="value">The cookie value. Must be RFC 6265 &#167; 4.1.1 <c>*cookie-octet</c>, optionally wrapped in a single pair of DQUOTEs.</param>
     /// <param name="options">The cookie options.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/> or empty, or <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> is not a valid RFC 6265 token, or
+    /// <paramref name="value"/> contains an octet outside the RFC 6265
+    /// cookie-octet grammar (a control character including CR/LF, whitespace,
+    /// DQUOTE, comma, semicolon, or backslash). Such input is rejected so the
+    /// value cannot split or corrupt the emitted <c>Set-Cookie</c> header.
+    /// </exception>
     public HttpCookie(string name, string value = "", HttpCookieOptions? options = null)
     {
         ArgumentNullException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(value);
+
+        // RFC 6265 §4.1.1 octet-grammar validation (anti header-splitting). The
+        // raw name/value is deliberately not echoed into the message so a
+        // hostile control character cannot leak into logs downstream.
+        if (!HttpCookieGrammar.IsValidName(name))
+        {
+            throw new ArgumentException(
+                "Cookie name is not a valid RFC 6265 token: it must be non-empty and contain only token characters (no control characters, whitespace, or separators such as '=', ';', or ',').",
+                nameof(name));
+        }
+
+        if (!HttpCookieGrammar.IsValidValue(value))
+        {
+            throw new ArgumentException(
+                "Cookie value contains characters outside the RFC 6265 cookie-octet grammar. Control characters (including CR/LF), whitespace, DQUOTE, comma, semicolon, and backslash are forbidden so the value cannot split or corrupt the Set-Cookie header line; percent- or base64-encode such values first.",
+                nameof(value));
+        }
 
         Name = name;
         Value = value;
@@ -45,6 +79,81 @@ public sealed class HttpCookie
     /// Gets a value indicating whether the cookie has a non-empty value.
     /// </summary>
     public bool HasValue => !string.IsNullOrEmpty(Value);
+
+    /// <summary>
+    /// Returns a cookie whose lifetime is capped at the RFC 6265bis 400-day
+    /// maximum (<see cref="HttpCookieLimits.DefaultMaxLifetime"/>), measured
+    /// relative to <paramref name="referenceTime"/>.
+    /// </summary>
+    /// <param name="referenceTime">The instant a future <see cref="HttpCookieOptions.Expires"/> is measured against &#8212; typically the moment the cookie is emitted.</param>
+    /// <returns>A clamped cookie, or the same instance when no clamping is required.</returns>
+    /// <remarks>See <see cref="ClampLifetime(DateTimeOffset, TimeSpan)"/> for the full clamping rules.</remarks>
+    public HttpCookie ClampLifetime(DateTimeOffset referenceTime)
+        => ClampLifetime(referenceTime, HttpCookieLimits.DefaultMaxLifetime);
+
+    /// <summary>
+    /// Returns a cookie whose <c>Max-Age</c> and <c>Expires</c> are capped at
+    /// <paramref name="maxLifetime"/> (RFC 6265bis &#167; 5.5 lifetime limit).
+    /// </summary>
+    /// <param name="referenceTime">The instant a future <see cref="HttpCookieOptions.Expires"/> is measured against &#8212; typically the moment the cookie is emitted.</param>
+    /// <param name="maxLifetime">The maximum permitted lifetime. Must be non-negative.</param>
+    /// <returns>
+    /// A cookie with <c>Max-Age</c> reduced to <paramref name="maxLifetime"/>
+    /// when it was longer, and <c>Expires</c> pulled back to
+    /// <paramref name="referenceTime"/> + <paramref name="maxLifetime"/> when
+    /// it was further out. A zero or negative <c>Max-Age</c> (a deletion
+    /// signal per RFC 6265 &#167; 5.2.2) and a past or near-future
+    /// <c>Expires</c> are preserved exactly. Returns the same instance when no
+    /// clamping is required.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLifetime"/> is negative.</exception>
+    public HttpCookie ClampLifetime(DateTimeOffset referenceTime, TimeSpan maxLifetime)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxLifetime.Ticks, nameof(maxLifetime));
+
+        TimeSpan? maxAge = Options.MaxAge;
+        DateTimeOffset? expires = Options.Expires;
+        bool changed = false;
+
+        // Max-Age: only a positive duration longer than the cap is clamped.
+        // Zero and negative Max-Age are deletion signals (RFC 6265 §5.2.2) and
+        // are left untouched so deletion semantics still round-trip.
+        if (maxAge is TimeSpan age && age > maxLifetime)
+        {
+            maxAge = maxLifetime;
+            changed = true;
+        }
+
+        // Expires: an absolute expiry more than maxLifetime past referenceTime
+        // is pulled back to the cap. A past or near-future expiry is left as-is.
+        if (expires is DateTimeOffset when)
+        {
+            // Saturate at DateTimeOffset.MaxValue rather than overflowing when
+            // referenceTime + maxLifetime would run off the end of the range.
+            DateTimeOffset cap = maxLifetime < DateTimeOffset.MaxValue - referenceTime
+                ? referenceTime + maxLifetime
+                : DateTimeOffset.MaxValue;
+
+            if (when > cap)
+            {
+                expires = cap;
+                changed = true;
+            }
+        }
+
+        if (!changed)
+        {
+            return this;
+        }
+
+        HttpCookieOptions clamped = new(Options)
+        {
+            MaxAge = maxAge,
+            Expires = expires,
+        };
+
+        return new HttpCookie(Name, Value, clamped);
+    }
 
     /// <inheritdoc />
     public override string ToString()

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookieCollection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookieCollection.cs
@@ -31,11 +31,22 @@ namespace Assimalign.Cohesion.Http;
 /// not reflected back into this object &#8211; callers should mutate
 /// through the collection rather than the header.
 /// </para>
+/// <para>
+/// Parsing is hardened per RFC 6265bis: cookies whose name plus value or
+/// whose individual attributes exceed the configured
+/// <see cref="HttpCookieLimits"/> are ignored (not truncated, not thrown),
+/// the retained attribute count per cookie is bounded, and cookies whose
+/// name or value falls outside the RFC 6265 &#167; 4.1.1 grammar are dropped
+/// rather than surfaced. This is wire-safety hardening, not cookie policy;
+/// prefix/pairing enforcement lives in
+/// <c>Assimalign.Cohesion.Web.CookiePolicy</c>.
+/// </para>
 /// </remarks>
 public sealed class HttpCookieCollection : IHttpCookieCollection
 {
     private readonly IHttpHeaderCollection _headers;
     private readonly HttpHeaderKey _headerKey;
+    private readonly HttpCookieLimits _limits;
     private readonly List<HttpCookie> _cookies = new();
 
     /// <summary>
@@ -53,10 +64,8 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
     /// <summary>
     /// Initializes a cookie collection synchronized with
     /// <paramref name="headers"/> through the supplied
-    /// <paramref name="headerKey"/>. Existing cookies on the header are
-    /// parsed into the collection during construction; subsequent
-    /// <see cref="Add"/>, <see cref="Remove"/>, and <see cref="Clear"/>
-    /// calls write back to the same header.
+    /// <paramref name="headerKey"/>, using the RFC 6265bis default parsing
+    /// limits (<see cref="HttpCookieLimits.Default"/>).
     /// </summary>
     /// <param name="headers">The header collection that owns the wire
     /// representation.</param>
@@ -67,10 +76,39 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
     /// <paramref name="headers"/> is <see langword="null"/>.
     /// </exception>
     public HttpCookieCollection(IHttpHeaderCollection headers, HttpHeaderKey headerKey)
+        : this(headers, headerKey, HttpCookieLimits.Default)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a cookie collection synchronized with
+    /// <paramref name="headers"/> through the supplied
+    /// <paramref name="headerKey"/> and bounded by
+    /// <paramref name="limits"/>. Existing cookies on the header are parsed
+    /// into the collection during construction &#8212; with oversized cookies
+    /// and attributes ignored per <paramref name="limits"/> and malformed
+    /// cookies dropped per the RFC 6265 &#167; 4.1.1 grammar &#8212; and
+    /// subsequent <see cref="Add"/>, <see cref="Remove"/>, and
+    /// <see cref="Clear"/> calls write back to the same header.
+    /// </summary>
+    /// <param name="headers">The header collection that owns the wire
+    /// representation.</param>
+    /// <param name="headerKey">Either <see cref="HttpHeaderKey.Cookie"/>
+    /// (request side) or <see cref="HttpHeaderKey.SetCookie"/> (response
+    /// side). The cookie format follows the header semantics.</param>
+    /// <param name="limits">The RFC 6265bis size limits applied while parsing
+    /// the header.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="headers"/> or <paramref name="limits"/> is
+    /// <see langword="null"/>.
+    /// </exception>
+    public HttpCookieCollection(IHttpHeaderCollection headers, HttpHeaderKey headerKey, HttpCookieLimits limits)
     {
         ArgumentNullException.ThrowIfNull(headers);
+        ArgumentNullException.ThrowIfNull(limits);
         _headers = headers;
         _headerKey = headerKey;
+        _limits = limits;
 
         ReadFromHeaders();
     }
@@ -189,23 +227,39 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
                 }
 
                 int eq = trimmed.IndexOf('=');
-                string name;
-                string val;
+                ReadOnlySpan<char> name;
+                ReadOnlySpan<char> val;
                 if (eq < 0)
                 {
-                    name = trimmed.ToString();
-                    val = string.Empty;
+                    name = trimmed;
+                    val = default;
                 }
                 else
                 {
-                    name = trimmed[..eq].Trim().ToString();
-                    val = trimmed[(eq + 1)..].Trim().ToString();
+                    name = trimmed[..eq].Trim();
+                    val = trimmed[(eq + 1)..].Trim();
                 }
 
-                if (name.Length > 0)
+                if (name.Length == 0)
                 {
-                    _cookies.Add(new HttpCookie(name, val));
+                    continue;
                 }
+
+                // RFC 6265bis per-cookie size guard — an oversized name=value
+                // pair is ignored rather than truncated or rejected with an error.
+                if (name.Length + val.Length > _limits.MaxNameValueLength)
+                {
+                    continue;
+                }
+
+                // RFC 6265 §4.1.1 grammar guard — drop a malformed inbound pair
+                // (it could not be constructed as an HttpCookie anyway).
+                if (!HttpCookieGrammar.IsValidName(name) || !HttpCookieGrammar.IsValidValue(val))
+                {
+                    continue;
+                }
+
+                _cookies.Add(new HttpCookie(name.ToString(), val.ToString()));
             }
         }
     }
@@ -231,7 +285,7 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
         }
     }
 
-    private static HttpCookie? ParseSetCookieValue(string raw)
+    private HttpCookie? ParseSetCookieValue(string raw)
     {
         string[] segments = raw.Split(';');
         if (segments.Length == 0)
@@ -264,12 +318,27 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
             return null;
         }
 
+        // RFC 6265bis per-cookie size guard — a cookie whose name+value exceeds
+        // the limit is ignored wholesale rather than truncated or rejected.
+        if (name.Length + value.Length > _limits.MaxNameValueLength)
+        {
+            return null;
+        }
+
+        // RFC 6265 §4.1.1 grammar guard — drop a malformed cookie (an
+        // out-of-grammar name/value could not be constructed anyway).
+        if (!HttpCookieGrammar.IsValidName(name) || !HttpCookieGrammar.IsValidValue(value))
+        {
+            return null;
+        }
+
         // Build options with the wire-empty defaults: HttpCookieOptions's
         // own ctor sets Path = "/" as a convenience for senders, but for
         // a faithful round-trip we only set Path when the wire actually
         // carried it. Override here before walking the attributes.
         HttpCookieOptions options = new() { Path = null };
 
+        int attributes = 0;
         for (int i = 1; i < segments.Length; i++)
         {
             string segment = segments[i].Trim();
@@ -277,6 +346,14 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
             {
                 continue;
             }
+
+            // Bound the number of attributes retained so a hostile Set-Cookie
+            // with many ';'-separated segments cannot grow options unbounded.
+            if (attributes >= _limits.MaxAttributeCount)
+            {
+                break;
+            }
+            attributes++;
 
             int attrEq = segment.IndexOf('=');
             if (attrEq < 0)
@@ -287,6 +364,15 @@ public sealed class HttpCookieCollection : IHttpCookieCollection
             {
                 string attrName = segment[..attrEq].Trim();
                 string attrValue = segment[(attrEq + 1)..].Trim();
+
+                // RFC 6265bis attribute-value size guard — an oversized
+                // attribute value is dropped while the rest of the cookie
+                // (including already-parsed attributes) is retained.
+                if (attrValue.Length > _limits.MaxAttributeValueLength)
+                {
+                    continue;
+                }
+
                 ApplyValueAttribute(attrName, attrValue, options);
             }
         }

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookieLimits.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/HttpCookieLimits.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Configurable RFC 6265bis defensive limits applied when
+/// <see cref="HttpCookieCollection"/> parses a <c>Cookie</c> or
+/// <c>Set-Cookie</c> header, plus the lifetime cap consumed by
+/// <see cref="HttpCookie.ClampLifetime(DateTimeOffset, TimeSpan)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The size limits are wire-safety, not policy: a cookie whose name plus
+/// value exceeds <see cref="MaxNameValueLength"/> is ignored wholesale, an
+/// attribute whose value exceeds <see cref="MaxAttributeValueLength"/> is
+/// dropped, and attributes beyond <see cref="MaxAttributeCount"/> are not
+/// retained. Oversized input is silently ignored rather than rejected with an
+/// exception, matching RFC 6265bis parsing-robustness guidance
+/// (draft-ietf-httpbis-rfc6265bis).
+/// </para>
+/// <para>
+/// Set any dimension to <see cref="int.MaxValue"/> to make it effectively
+/// unbounded. The limits bound each cookie individually; the outer bound on
+/// total header length is owned by the transport's request/response header
+/// size limits.
+/// </para>
+/// </remarks>
+public sealed class HttpCookieLimits
+{
+    /// <summary>
+    /// The RFC 6265bis default maximum number of octets in a single cookie's
+    /// name plus value (4096).
+    /// </summary>
+    public const int DefaultMaxNameValueLength = 4096;
+
+    /// <summary>
+    /// The RFC 6265bis default maximum number of octets in a single cookie
+    /// attribute value (1024).
+    /// </summary>
+    public const int DefaultMaxAttributeValueLength = 1024;
+
+    /// <summary>
+    /// The default upper bound on the number of attributes retained while
+    /// parsing one <c>Set-Cookie</c> value (50). This is a denial-of-service
+    /// backstop &#8212; not an RFC-mandated value &#8212; that keeps a hostile
+    /// cookie with thousands of <c>;</c>-separated segments from growing the
+    /// parsed attribute/extension list without bound.
+    /// </summary>
+    public const int DefaultMaxAttributeCount = 50;
+
+    /// <summary>
+    /// The RFC 6265bis default maximum cookie lifetime (400 days). Cookies
+    /// whose <c>Max-Age</c> or <c>Expires</c> would exceed this are clamped by
+    /// <see cref="HttpCookie.ClampLifetime(DateTimeOffset, TimeSpan)"/>.
+    /// </summary>
+    public static readonly TimeSpan DefaultMaxLifetime = TimeSpan.FromDays(400);
+
+    /// <summary>
+    /// Gets a shared instance carrying the RFC 6265bis default limits. Used by
+    /// the <see cref="HttpCookieCollection"/> constructors that do not take an
+    /// explicit <see cref="HttpCookieLimits"/>.
+    /// </summary>
+    public static HttpCookieLimits Default { get; } = new();
+
+    /// <summary>
+    /// Gets the maximum number of octets permitted in a parsed cookie's name
+    /// plus value. Cookies exceeding this are ignored. Defaults to
+    /// <see cref="DefaultMaxNameValueLength"/>.
+    /// </summary>
+    public int MaxNameValueLength { get; init; } = DefaultMaxNameValueLength;
+
+    /// <summary>
+    /// Gets the maximum number of octets permitted in a single parsed cookie
+    /// attribute value. Attributes exceeding this are dropped while the rest of
+    /// the cookie is retained. Defaults to
+    /// <see cref="DefaultMaxAttributeValueLength"/>.
+    /// </summary>
+    public int MaxAttributeValueLength { get; init; } = DefaultMaxAttributeValueLength;
+
+    /// <summary>
+    /// Gets the maximum number of attributes retained while parsing a single
+    /// <c>Set-Cookie</c> value. Attributes beyond this count are ignored.
+    /// Defaults to <see cref="DefaultMaxAttributeCount"/>.
+    /// </summary>
+    public int MaxAttributeCount { get; init; } = DefaultMaxAttributeCount;
+
+    /// <summary>
+    /// Gets the maximum cookie lifetime enforced by
+    /// <see cref="HttpCookie.ClampLifetime(DateTimeOffset)"/>. Defaults to
+    /// <see cref="DefaultMaxLifetime"/> (400 days).
+    /// </summary>
+    public TimeSpan MaxLifetime { get; init; } = DefaultMaxLifetime;
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/Internal/HttpCookieGrammar.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/src/Internal/HttpCookieGrammar.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Buffers;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// RFC 6265 &#167; 4.1.1 cookie grammar primitives: <c>cookie-name</c> (an
+/// RFC 9110 <c>token</c>) and <c>cookie-value</c> (<c>*cookie-octet</c>,
+/// optionally wrapped in a single pair of DQUOTEs) classification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Shared by <see cref="HttpCookie"/> construction &#8212; which rejects an
+/// out-of-grammar name or value so a hostile octet (<c>;</c>, <c>,</c>,
+/// whitespace, a control character, or CR/LF) cannot split or corrupt the
+/// emitted <c>Set-Cookie</c> line &#8212; and by
+/// <see cref="HttpCookieCollection"/> parsing, which silently drops
+/// out-of-grammar cookies for wire robustness (RFC 6265bis parsing guidance)
+/// instead of throwing on hostile inbound data.
+/// </para>
+/// <para>
+/// Both classifiers are pure span scans over <see cref="SearchValues{T}"/>
+/// membership sets &#8212; no allocation, no regex, no reflection &#8212; so
+/// the package stays trim- and NativeAOT-safe.
+/// </para>
+/// </remarks>
+internal static class HttpCookieGrammar
+{
+    // RFC 9110 §5.6.2 tchar — the character set of an RFC 6265 §4.1.1
+    // cookie-name token. Excludes controls, whitespace, and separators
+    // (notably '=', ';', and ',').
+    private static readonly SearchValues<char> TokenChars = SearchValues.Create(
+        "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
+    // RFC 6265 §4.1.1 cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E:
+    // US-ASCII minus CTLs (incl. CR/LF), whitespace (SP), DQUOTE, comma,
+    // semicolon, and backslash — precisely the octets that cannot appear in a
+    // bare cookie value without breaking the Cookie / Set-Cookie wire grammar.
+    private static readonly SearchValues<char> CookieOctets = SearchValues.Create(BuildCookieOctets());
+
+    /// <summary>
+    /// Determines whether <paramref name="name"/> is a non-empty RFC 6265
+    /// &#167; 4.1.1 <c>cookie-name</c> (an RFC 9110 <c>token</c>).
+    /// </summary>
+    /// <param name="name">The candidate cookie name.</param>
+    /// <returns><see langword="true"/> when every character is a token character and the span is non-empty.</returns>
+    public static bool IsValidName(ReadOnlySpan<char> name)
+        => !name.IsEmpty && !name.ContainsAnyExcept(TokenChars);
+
+    /// <summary>
+    /// Determines whether <paramref name="value"/> is a well-formed RFC 6265
+    /// &#167; 4.1.1 <c>cookie-value</c> (<c>*cookie-octet</c>, optionally
+    /// wrapped in a single pair of DQUOTEs). The empty string is well-formed.
+    /// </summary>
+    /// <param name="value">The candidate cookie value.</param>
+    /// <returns><see langword="true"/> when the value contains only cookie-octets (ignoring an optional surrounding DQUOTE pair).</returns>
+    public static bool IsValidValue(ReadOnlySpan<char> value)
+    {
+        // cookie-value = *cookie-octet — the empty string is well-formed.
+        if (value.IsEmpty)
+        {
+            return true;
+        }
+
+        // A cookie-value may be wrapped in a single pair of DQUOTEs; the quotes
+        // are part of the stored value, but the octets between them still may
+        // not include a bare DQUOTE (RFC 6265 §4.1.1).
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+        {
+            value = value[1..^1];
+        }
+
+        return !value.ContainsAnyExcept(CookieOctets);
+    }
+
+    private static char[] BuildCookieOctets()
+    {
+        // 1 + 9 + 14 + 32 + 34 = 90 permitted octets across the five ranges.
+        char[] octets = new char[90];
+        int i = 0;
+        octets[i++] = (char)0x21;
+        for (char c = (char)0x23; c <= 0x2B; c++)
+        {
+            octets[i++] = c;
+        }
+        for (char c = (char)0x2D; c <= 0x3A; c++)
+        {
+            octets[i++] = c;
+        }
+        for (char c = (char)0x3C; c <= 0x5B; c++)
+        {
+            octets[i++] = c;
+        }
+        for (char c = (char)0x5D; c <= 0x7E; c++)
+        {
+            octets[i++] = c;
+        }
+        return octets;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieLifetimeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieLifetimeTests.cs
@@ -1,0 +1,147 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Cookies.Tests;
+
+/// <summary>
+/// RFC 6265bis &#167; 5.5 400-day lifetime cap enforced by
+/// <see cref="HttpCookie.ClampLifetime(DateTimeOffset, TimeSpan)"/>. Covers the
+/// exact-cap, cap-plus-one-second, and deletion (zero/negative) boundaries for
+/// <c>Max-Age</c> and the reference-relative clamp for <c>Expires</c>.
+/// </summary>
+public class HttpCookieLifetimeTests
+{
+    private static readonly TimeSpan Cap = TimeSpan.FromDays(400);
+    private static readonly DateTimeOffset Now = new(2026, 07, 06, 12, 00, 00, TimeSpan.Zero);
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: Max-Age exactly 400 days is left unchanged")]
+    public void ClampLifetime_MaxAgeExactlyAtCap_ShouldRemainUnchanged()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = Cap });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.MaxAge.ShouldBe(Cap);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: Max-Age 400 days + 1s is clamped to 400 days")]
+    public void ClampLifetime_MaxAgeOverCapByOneSecond_ShouldClampToCap()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = Cap + TimeSpan.FromSeconds(1) });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.MaxAge.ShouldBe(Cap);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: negative Max-Age round-trips unchanged (deletion)")]
+    public void ClampLifetime_NegativeMaxAge_ShouldRemainUnchanged()
+    {
+        TimeSpan delete = TimeSpan.FromDays(-1);
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = delete });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.MaxAge.ShouldBe(delete);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: zero Max-Age round-trips unchanged (deletion)")]
+    public void ClampLifetime_ZeroMaxAge_ShouldRemainUnchanged()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = TimeSpan.Zero });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.MaxAge.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: no lifetime set returns the same instance")]
+    public void ClampLifetime_NoLifetime_ShouldReturnSameInstance()
+    {
+        HttpCookie cookie = new("sid", "v");
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.ShouldBeSameAs(cookie);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: Expires beyond the cap is pulled back to reference + cap")]
+    public void ClampLifetime_ExpiresBeyondCap_ShouldClampToReferencePlusCap()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { Expires = Now + Cap + TimeSpan.FromDays(1) });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.Expires.ShouldBe(Now + Cap);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: Expires exactly at the cap is left unchanged")]
+    public void ClampLifetime_ExpiresExactlyAtCap_ShouldRemainUnchanged()
+    {
+        DateTimeOffset atCap = Now + Cap;
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { Expires = atCap });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.Expires.ShouldBe(atCap);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: a past Expires is left unchanged")]
+    public void ClampLifetime_ExpiresInPast_ShouldRemainUnchanged()
+    {
+        DateTimeOffset past = Now - TimeSpan.FromDays(10);
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { Expires = past });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.Expires.ShouldBe(past);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: default overload caps at 400 days")]
+    public void ClampLifetime_DefaultOverload_ShouldCapAt400Days()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = TimeSpan.FromDays(1000) });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now);
+
+        clamped.Options.MaxAge.ShouldBe(TimeSpan.FromDays(400));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: clamps Max-Age and Expires together")]
+    public void ClampLifetime_BothMaxAgeAndExpiresOverCap_ShouldClampBoth()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions
+        {
+            MaxAge = Cap + TimeSpan.FromDays(30),
+            Expires = Now + Cap + TimeSpan.FromDays(30),
+        });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.Options.MaxAge.ShouldBe(Cap);
+        clamped.Options.Expires.ShouldBe(Now + Cap);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: does not mutate the original cookie")]
+    public void ClampLifetime_WhenClamping_ShouldNotMutateOriginal()
+    {
+        TimeSpan original = Cap + TimeSpan.FromDays(100);
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = original });
+
+        HttpCookie clamped = cookie.ClampLifetime(Now, Cap);
+
+        clamped.ShouldNotBeSameAs(cookie);
+        cookie.Options.MaxAge.ShouldBe(original);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ClampLifetime: negative max lifetime throws")]
+    public void ClampLifetime_NegativeMaxLifetime_ShouldThrow()
+    {
+        HttpCookie cookie = new("sid", "v", new HttpCookieOptions { MaxAge = Cap });
+
+        Should.Throw<ArgumentOutOfRangeException>(() => cookie.ClampLifetime(Now, TimeSpan.FromDays(-1)));
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieLimitsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieLimitsTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Cookies.Tests;
+
+/// <summary>
+/// RFC 6265bis per-cookie size limits enforced by
+/// <see cref="HttpCookieCollection"/> parsing: a cookie whose name+value
+/// exceeds <see cref="HttpCookieLimits.MaxNameValueLength"/> is ignored, an
+/// attribute exceeding <see cref="HttpCookieLimits.MaxAttributeValueLength"/>
+/// is dropped, and attributes past <see cref="HttpCookieLimits.MaxAttributeCount"/>
+/// are not retained. Oversized input is ignored, never thrown.
+/// </summary>
+public class HttpCookieLimitsTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpCookieLimits: defaults match RFC 6265bis")]
+    public void Default_ShouldMatchRfc6265bisValues()
+    {
+        HttpCookieLimits limits = HttpCookieLimits.Default;
+
+        limits.MaxNameValueLength.ShouldBe(4096);
+        limits.MaxAttributeValueLength.ShouldBe(1024);
+        limits.MaxAttributeCount.ShouldBe(50);
+        limits.MaxLifetime.ShouldBe(TimeSpan.FromDays(400));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Request parse: name+value exactly at the 4096 limit is kept")]
+    public void RequestParse_NameValueAtLimit_ShouldKeep()
+    {
+        // name "n" (1) + value (4095) == 4096 octets.
+        string value = new('a', 4095);
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.Cookie] = "n=" + value;
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.Cookie);
+
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Value.Length.ShouldBe(4095);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Request parse: name+value over the 4096 limit is ignored")]
+    public void RequestParse_NameValueOverLimit_ShouldDrop()
+    {
+        // name "n" (1) + value (4096) == 4097 octets — one over.
+        string value = new('a', 4096);
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.Cookie] = "n=" + value;
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.Cookie);
+
+        cookies.Count.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Response parse: oversized cookie is ignored, sibling kept")]
+    public void ResponseParse_OneOversizedCookie_ShouldDropOnlyThatValue()
+    {
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = new HttpHeaderValue(new[]
+        {
+            "ok=1",
+            "big=" + new string('a', 5000),
+        });
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.SetCookie);
+
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Name.ShouldBe("ok");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Response parse: attribute value at the 1024 limit is kept")]
+    public void ResponseParse_AttributeValueAtLimit_ShouldKeep()
+    {
+        string attrValue = new('a', 1024);
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = "id=1; X=" + attrValue;
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.SetCookie);
+
+        HttpCookie cookie = cookies.Single();
+        cookie.Options.Extensions.ShouldContain("X=" + attrValue);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Response parse: oversized attribute is dropped, cookie retained")]
+    public void ResponseParse_AttributeValueOverLimit_ShouldDropAttributeKeepCookie()
+    {
+        string attrValue = new('a', 1025);
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = "id=1; X=" + attrValue;
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.SetCookie);
+
+        HttpCookie cookie = cookies.Single();
+        cookie.Name.ShouldBe("id");
+        cookie.Value.ShouldBe("1");
+        cookie.Options.Extensions.ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Response parse: attributes past the count bound are ignored")]
+    public void ResponseParse_AttributeCountExceeded_ShouldIgnoreExcess()
+    {
+        HttpCookieLimits limits = new() { MaxAttributeCount = 3 };
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = "id=1; A=1; B=2; C=3; D=4; E=5";
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.SetCookie, limits);
+
+        HttpCookie cookie = cookies.Single();
+        cookie.Options.Extensions.Count.ShouldBe(3);
+        cookie.Options.Extensions.ShouldContain("A=1");
+        cookie.Options.Extensions.ShouldContain("C=3");
+        cookie.Options.Extensions.ShouldNotContain("D=4");
+        cookie.Options.Extensions.ShouldNotContain("E=5");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Request parse: custom name+value limit is honored")]
+    public void RequestParse_CustomNameValueLimit_ShouldBeHonored()
+    {
+        HttpCookieLimits limits = new() { MaxNameValueLength = 10 };
+        HttpHeaderCollection headers = new();
+        // "keep" (2+4=6, kept) vs "drop" (2 + 20 = 22, dropped).
+        headers[HttpHeaderKey.Cookie] = "id=keep; xl=" + new string('a', 20);
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.Cookie, limits);
+
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Value.ShouldBe("keep");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Parse: oversized input is ignored, never thrown")]
+    public void Parse_OversizedInput_ShouldNotThrow()
+    {
+        // A valid small cookie trailed by thousands of attribute segments: the
+        // count bound caps retention and nothing throws.
+        string flood = string.Concat(Enumerable.Repeat("x; ", 5000));
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = new HttpHeaderValue(new[]
+        {
+            "huge=" + new string('a', 100_000),
+            "id=1; " + flood,
+        });
+
+        HttpCookieCollection cookies = Should.NotThrow(
+            () => new HttpCookieCollection(headers, HttpHeaderKey.SetCookie));
+
+        // The oversized cookie is dropped; the small one survives with its
+        // attribute list bounded by the default MaxAttributeCount.
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Options.Extensions.Count.ShouldBeLessThanOrEqualTo(HttpCookieLimits.DefaultMaxAttributeCount);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieValidationTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Cookies/tests/HttpCookieValidationTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Cookies.Tests;
+
+/// <summary>
+/// RFC 6265 &#167; 4.1.1 octet-grammar validation at <see cref="HttpCookie"/>
+/// construction and the matching drop-on-parse robustness in
+/// <see cref="HttpCookieCollection"/>. These are the anti-header-splitting
+/// guards: a name or value carrying <c>;</c>, <c>,</c>, whitespace, a control
+/// character, or CR/LF must never reach the serialized <c>Set-Cookie</c> line.
+/// </summary>
+public class HttpCookieValidationTests
+{
+    // Each forbidden cookie-octet class, addressed by code point so no raw
+    // control byte ever appears in source.
+    [Theory(DisplayName = "Cohesion Test [Http] - HttpCookie ctor: rejects values with forbidden octets")]
+    [InlineData(0x00)] // NUL control
+    [InlineData(0x09)] // HTAB (whitespace / control)
+    [InlineData(0x0A)] // LF — header-splitting octet
+    [InlineData(0x0D)] // CR — header-splitting octet
+    [InlineData(0x20)] // SP (whitespace)
+    [InlineData(0x22)] // DQUOTE
+    [InlineData(0x2C)] // comma — cookie-list / folding delimiter
+    [InlineData(0x3B)] // semicolon — attribute delimiter
+    [InlineData(0x5C)] // backslash
+    [InlineData(0x7F)] // DEL control
+    public void Ctor_ValueWithForbiddenOctet_ShouldThrowArgumentException(int octet)
+    {
+        string value = "a" + (char)octet + "b";
+
+        ArgumentException ex = Should.Throw<ArgumentException>(() => new HttpCookie("sid", value));
+        ex.ParamName.ShouldBe("value");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpCookie ctor: CR/LF value cannot inject a second Set-Cookie line")]
+    public void Ctor_CrlfInjectionValue_IsRejectedSoSerializationStaysSingleLine()
+    {
+        // The injection can never be constructed, so ToString() can never emit
+        // the smuggled directive on its own header line.
+        Should.Throw<ArgumentException>(() => new HttpCookie("sid", "abc\r\nSet-Cookie: role=admin"));
+    }
+
+    // Cookie-name must be an RFC 9110 token; separators and controls are out.
+    [Theory(DisplayName = "Cohesion Test [Http] - HttpCookie ctor: rejects names outside the token grammar")]
+    [InlineData(0x3D)] // '=' separator
+    [InlineData(0x3B)] // ';'
+    [InlineData(0x20)] // SP
+    [InlineData(0x2C)] // ','
+    [InlineData(0x09)] // HTAB
+    [InlineData(0x0D)] // CR
+    [InlineData(0x0A)] // LF
+    [InlineData(0x28)] // '(' separator
+    [InlineData(0x22)] // DQUOTE
+    public void Ctor_NameWithForbiddenOctet_ShouldThrowArgumentException(int octet)
+    {
+        string name = "a" + (char)octet + "b";
+
+        ArgumentException ex = Should.Throw<ArgumentException>(() => new HttpCookie(name, "value"));
+        ex.ParamName.ShouldBe("name");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - HttpCookie ctor: accepts well-formed cookie values")]
+    [InlineData("abc123")]
+    [InlineData("")]                 // cookie-value = *cookie-octet — empty is valid
+    [InlineData("YWJjZA+/9g==")]     // base64 payload — '+', '/', '=' are all cookie-octets
+    [InlineData("\"quoted-value\"")] // a single surrounding DQUOTE pair is permitted
+    [InlineData("a!#$%&'()*-./:<=>?@[]^_`{|}~")] // dense cookie-octet coverage
+    public void Ctor_WellFormedValue_ShouldNotThrow(string value)
+    {
+        HttpCookie cookie = new("sid", value);
+        cookie.Value.ShouldBe(value);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpCookie ctor: accepts a dense token name")]
+    public void Ctor_DenseTokenName_ShouldNotThrow()
+    {
+        HttpCookie cookie = new("a!#$%&'*+-.^_`|~09AZaz", "v");
+        cookie.Name.ShouldBe("a!#$%&'*+-.^_`|~09AZaz");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Request parse: drops a pair whose value carries a control octet")]
+    public void RequestParse_ValueWithControlOctet_ShouldDropOnlyThatCookie()
+    {
+        // The BEL (0x07) in the second value falls outside cookie-octet, so the
+        // pair is dropped while the well-formed pair survives.
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.Cookie] = "good=ok; bad=va" + (char)0x07 + "lue";
+
+        HttpCookieCollection cookies = new(headers, HttpHeaderKey.Cookie);
+
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Name.ShouldBe("good");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Response parse: drops a malformed cookie without throwing")]
+    public void ResponseParse_MalformedNameValue_ShouldDropAndNotThrow()
+    {
+        HttpHeaderCollection headers = new();
+        headers[HttpHeaderKey.SetCookie] = new HttpHeaderValue(new[] { "id=1", "bad=x" + (char)0x07 + "y" });
+
+        HttpCookieCollection cookies = Should.NotThrow(
+            () => new HttpCookieCollection(headers, HttpHeaderKey.SetCookie));
+
+        cookies.Count.ShouldBe(1);
+        cookies.Single().Name.ShouldBe("id");
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.CookiePolicy/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.CookiePolicy/docs/DESIGN.md
@@ -1,0 +1,72 @@
+# Assimalign.Cohesion.Web.CookiePolicy &mdash; Design
+
+## Design intent
+
+`Web.CookiePolicy` is the request-pipeline middleware that enforces a
+site's **cookie policy** on top of the wire-level cookie model in
+`Assimalign.Cohesion.Http.Cookies`. Where the model library answers
+*"is this cookie well-formed on the wire?"*, this package answers
+*"is this well-formed cookie **allowed**, and if not, is it rejected or
+rewritten?"* — the decisions that depend on deployment posture rather
+than on the RFC grammar.
+
+The middleware is installed builder-time via `UseCookiePolicy(...)` and
+intercepts the response cookie collection (and, where relevant, the
+request collection) surfaced by `Http.Cookies`, applying the configured
+`CookiePolicyOptions` before the transport drains cookies into
+`Set-Cookie` headers.
+
+## The model / policy split (RFC 6265 / 6265bis)
+
+The split is deliberate and documented on both sides (see
+`Assimalign.Cohesion.Http.Cookies/docs/DESIGN.md` → "Wire-safety
+hardening"). The rule of thumb: *wire-safety and well-formedness* live in
+the model; *site policy* lives here.
+
+| RFC 6265 / 6265bis rule | Owner | Rationale |
+|---|---|---|
+| `cookie-name` token / `cookie-value` octet-grammar validation (anti header-splitting) | **`Http.Cookies`** (model) | Well-formedness; a malformed value corrupts the wire regardless of policy. Enforced at `HttpCookie` construction. |
+| Per-cookie size limits (name+value ≤ 4096, attribute value ≤ 1024, bounded attribute count) | **`Http.Cookies`** (model) | Wire/parse robustness; oversized input is ignored during parsing via `HttpCookieLimits`. |
+| 400-day lifetime **cap math** (`HttpCookie.ClampLifetime`) | **`Http.Cookies`** (model) | Pure, clock-free mechanism, deterministically testable. |
+| **Applying** the lifetime cap to outbound cookies at emission (supplying "now") | **`Web.CookiePolicy`** (policy) | Deciding to override an app's explicit lifetime — and reading the clock — is a policy/emission act. |
+| `__Host-` / `__Secure-` **prefix invariants** (require `Secure`; `__Host-` also requires `Path=/` and no `Domain`) | **`Web.CookiePolicy`** (policy) | Encodes a site's trust decision, not the wire grammar. |
+| `SameSite=None` **requires** `Secure` (reject or upgrade) | **`Web.CookiePolicy`** (policy) | A deployment-posture pairing rule (reject vs. upgrade is configurable). |
+
+The model provides the *mechanisms*; this middleware decides *whether and
+when* to apply the policy-shaped ones and owns the prefix/pairing rules
+outright.
+
+## Dependency direction
+
+One-way: `Web.CookiePolicy` → `Assimalign.Cohesion.Web` (pipeline) +
+`Assimalign.Cohesion.Http.Cookies` (model) → `Assimalign.Cohesion.Http`
+(core). The model never gains a back-reference to the policy layer, which
+is what lets the policy compose the model's mechanisms freely. Enforcement
+is expected to intercept via `IHttpResponseCookieFeature` /
+`IHttpRequestCookieFeature` replacement, as documented in the
+`Http.Cookies` README.
+
+## AOT posture
+
+`<IsAotCompatible>true</IsAotCompatible>`. Policy enforcement is plain
+string/span comparison (prefix checks, `Secure`/`SameSite` inspection) and
+reuse of the model's `ClampLifetime` — no reflection, no regex-with-
+compilation, no runtime code generation.
+
+## Status and non-goals
+
+- **Current status: stub.** `CookiePolicyOptions` is empty and
+  `UseCookiePolicy(...)` is a pass-through that installs no enforcement
+  yet. The cookie model hardening it composes (octet-grammar validation,
+  `HttpCookieLimits`, `HttpCookie.ClampLifetime`) shipped with issue
+  [L01.01.11.30]; the middleware that consumes them is tracked under the
+  Web platform epic (cookie security, issue #30) and is **not** delivered
+  by [L01.01.11.30]. This document records the intended split so that
+  future work implements the policy side without re-litigating the
+  boundary.
+- **Not the wire model.** This package never re-implements cookie parsing,
+  serialization, octet validation, size limits, or the lifetime-cap math —
+  those are `Http.Cookies`' job and are consumed, not duplicated.
+- **Not signing / encryption.** Confidentiality/integrity of cookie
+  payloads is a separate concern (a future `Http.Cookies.Signing`), not
+  policy enforcement.


### PR DESCRIPTION
## Summary

Stage 1 · Lane B · [L01.01.11.30]. Model-level (wire-safety) hardening the `Assimalign.Cohesion.Http.Cookies` library owes per RFC 6265bis. SameSite already worked end-to-end; prefix/pairing **policy** (`__Host-`/`__Secure-`, `SameSite=None`-requires-`Secure`) stays in `Web.CookiePolicy` per the Cookies `DESIGN.md` split and is **not** built here.

Three model mechanisms, all AOT-safe (plain `SearchValues<char>`/span checks — no regex, no reflection):

### 1. Octet-grammar validation at construction (anti header-splitting)
`HttpCookie` now validates `Name` against the RFC 6265 §4.1.1 `token` grammar and `Value` against `*cookie-octet` (optional surrounding DQUOTE pair) in its constructor, throwing `ArgumentException` on a violation. Because `Name`/`Value` are immutable, a constructed cookie can **never** carry a `;`, `,`, whitespace, control character, or CR/LF octet — so neither `ToString()` (Set-Cookie) nor the request-side fold can be split or corrupted. New internal `HttpCookieGrammar` helper. The parser **drops** out-of-grammar cookies (RFC parsing robustness) rather than throwing on hostile inbound data.

### 2. Configurable per-cookie size limits (`HttpCookieLimits`)
`HttpCookieCollection` parsing enforces RFC 6265bis-aligned defaults: name+value ≤ 4096 octets, per-attribute value ≤ 1024 octets, and a bounded retained-attribute count (default 50, a DoS backstop). Oversized cookies/attributes are **ignored per the RFC, not thrown**. Limits are a constructor parameter (`HttpCookieLimits.Default` when omitted); set any dimension to `int.MaxValue` to disable it.

### 3. RFC 6265bis 400-day lifetime cap (`HttpCookie.ClampLifetime`)
The model supplies the 400-day constant (`HttpCookieLimits.DefaultMaxLifetime`) and the **pure, clock-free** clamping math: `ClampLifetime(referenceTime[, maxLifetime])` reduces `Max-Age` to the cap when longer and pulls `Expires` back to `referenceTime + cap` when further out. A zero/negative `Max-Age` (deletion signal, RFC 6265 §5.2.2) and a past/near `Expires` round-trip unchanged. *Deciding when* to apply the cap at emission (which needs a clock) is left to the policy/emitter layer.

## Model vs. policy split (documented on both sides)
- `libraries/Http/Assimalign.Cohesion.Http.Cookies/docs/DESIGN.md` — new "Wire-safety hardening" section + sharpened non-goals.
- `resources/Web/Assimalign.Cohesion.Web.CookiePolicy/docs/DESIGN.md` — **new**, documents which 6265bis rules live in the model vs. the policy middleware. The `Web.CookiePolicy` middleware itself remains a stub (its enforcement is tracked under the Web platform epic, #30) — only its design doc was added here.

## Testing
- **49 new Shouldly tests** (co-located), all green alongside the existing suite (**79 total, 0 failed**):
  - Octet grammar: every forbidden value/name class by code point (NUL, HTAB, LF, CR, SP, DQUOTE, comma, semicolon, backslash, DEL) + a CR/LF header-injection payload; well-formed values incl. base64 and DQUOTE-wrapped; parser drop-on-malformed without throwing.
  - Lifetime: exactly-400-days (unchanged), 400-days-plus-one-second (clamped), zero/negative Max-Age (unchanged), Expires at/over/under cap, default overload, immutability, negative-cap throws.
  - Size limits: name+value at/over 4096, attribute value at/over 1024, attribute-count bound, custom limits, oversized-never-throws; `HttpCookieLimits` defaults.
- Downstream `Http.Connections` build and `Http.Antiforgery` suite (23/23) verified — antiforgery tokens are Base64Url (within cookie-octet), so construction validation is compatible.

## AGENTS.md compliance
File-scoped namespaces · no `Microsoft.Extensions.*` · `IsAotCompatible` (no reflection) · XML docs on all public APIs · interface-first preserved (`HttpCookieLimits` mirrors the existing concrete `HttpCookieOptions` value-object convention) · Shouldly tests with the `Cohesion Test [Http] - …` display-name convention.

## Work items resolved by this PR
Closes #757
