### PR TITLE
[L01.01.11.37] RFC 7239 Forwarded + X-Forwarded-* parsing primitives

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -788,3 +788,128 @@ reflection, no runtime codegen, no dynamic dispatch. Trim-safe by construction
   primitives, reading the `Range` / `If-Range` / conditional fields off an
   `IHttpRequest` and populating `HttpConditionalRequestContext` is the consuming
   middleware's job.
+
+## Forwarding headers (RFC 7239 `Forwarded` + `X-Forwarded-*`)
+
+The core owns the value objects that parse and serialize the proxy-forwarding
+headers — the RFC 7239 `Forwarded` element list and the de-facto
+`X-Forwarded-For` / `X-Forwarded-Proto` / `X-Forwarded-Host` list forms. Every
+Cohesion web service is deployed behind at least one proxy hop (the
+ApplicationModel K8s self-registry gateway, LoadBalancer/NatGateway resources),
+so without these primitives every downstream concern — CORS, cookie `Secure`
+decisions, session partitioning, rate-limit keys, access logging — sees the
+proxy's IP and `http://` scheme instead of the client's.
+
+### The protocol half vs. the trust half
+
+This library is deliberately the **protocol half only**: it turns raw header
+text into typed, validated value objects and back. It contains **no trust
+model**. Deciding *which* forwarded hops to believe — `KnownProxies`,
+`KnownNetworks`, `ForwardLimit`, and the actual overwrite of
+`connection.RemoteIp` / `request.Scheme` — lives in the forwarded-headers
+middleware (issue #778) in the Web runtime, because that is a policy decision
+that depends on the deployment topology, not on the wire grammar. Keeping the
+split here means the security-sensitive code has one job (apply policy to
+already-parsed, already-validated data) and the parser has one job (be a correct,
+total function over hostile input). This mirrors the established seam/feature
+taxonomy: protocol value objects in core, policy in the layer that composes them.
+
+### The surface
+
+Five readonly-struct value objects, in the span-based `TryParse`/`Parse`/
+`Serialize` style of the other core primitives (`HttpMediaType`,
+`HttpRequestTarget`, the `StructuredField*` family):
+
+- **`HttpForwardedNode`** — an RFC 7239 §6 `node` identifier (the `for`/`by`
+  value): `nodename [ ":" node-port ]`. It classifies the nodename as an IPv4
+  literal, a bracketed IPv6 literal, `unknown`, or an obfuscated identifier
+  (`_`-prefixed, §6.3), and the port as numeric or obfuscated (§6.4). `Address`
+  and `PortNumber` give the typed projections; `Name`/`Port` preserve the exact
+  spelling so `ToString` round-trips.
+- **`HttpForwardedParameter`** — one `forwarded-pair` (`token "=" value`),
+  carrying registered *and* extension parameters so an element round-trips
+  losslessly.
+- **`HttpForwardedElement`** — one `forwarded-element` (one proxy hop): typed
+  `For`/`By`/`Host`/`Proto` accessors over an ordered parameter list, plus
+  `TryGetParameter` for extensions and a typed `Create` factory for the
+  proxy-*writing* path.
+- **`HttpForwardedElementCollection`** — the whole `Forwarded` header
+  (`1#forwarded-element`).
+- **`HttpForwardedValues`** — the ordered entry list of any one `X-Forwarded-*`
+  header.
+
+`HttpHeaderKey` gained `Forwarded`, `XForwardedFor`, `XForwardedHost`, and
+`XForwardedProto` alongside the existing keys.
+
+### RFC 7239 strictness vs. `X-Forwarded-*` pragmatism
+
+`HttpForwardedNode` is reused across both header families, so it accepts a
+**bare** IPv6 literal (`2001:db8::1`) in addition to the RFC-mandated bracketed
+form (`[2001:db8::1]`) — bracket-less IPv6 is what real proxies write into
+`X-Forwarded-For`. Because a bare IPv6 literal's own colons cannot be
+distinguished from a trailing `:port`, a bare literal is always taken as the
+whole nodename with no port (which is exactly why RFC 7239 mandates brackets when
+a port is needed). IPv4/IPv6 recognition delegates to `System.Net.IPAddress`, so
+the accepted address forms are precisely the BCL's.
+
+`HttpForwardedValues` owns only the *list structure* — comma splitting
+(quote-aware) and multi-line combining — and keeps entries **verbatim**.
+Interpreting an `X-Forwarded-For` entry as an address is left to the consumer via
+`HttpForwardedNode.TryParse`, so the same list type serves all three
+`X-Forwarded-*` headers even though their entries mean different things (address
+vs. scheme vs. host).
+
+### Deterministic rejection is a security property
+
+Both the node and the element parser are **total**: any malformed input yields
+`TryParse == false` with no exception, no unbounded recursion, and no super-linear
+scanning (the quote-aware delimiter scan and the bracket/colon splits are all
+single passes). The `Forwarded` list parser is **strict and all-or-nothing** — an
+empty slot between commas is ignored per the RFC 7230 §7 list rule, but any
+element that is present and malformed fails the *entire* header. This is
+deliberate: a lenient parser that silently dropped one unparseable hop would let
+the #778 trust evaluator mis-count the chain and attribute the request to the
+wrong client. Strict parsing keeps the "how many hops, and which" question
+answerable only from well-formed input. `for`/`by` values that are present but
+are not valid nodes fail their element for the same reason. The fuzz suite
+(`HttpForwardedFuzzTests`) pins totality and determinism across truncated quotes,
+bracket/colon bombs, embedded NULs, high-plane characters, and multi-kilobyte
+inputs.
+
+### Rightmost-first traversal
+
+Both list types hold entries in **wire order** (left-most = closest to the
+client, right-most = closest to this server) and expose the same rightmost-first
+affordances the trust evaluator needs: index + `Count`, a `Nearest` accessor for
+the hop that handed *us* the request, and a `Reverse()` that returns a same-typed
+list in nearest-hop-first order. `AsSpan()` gives allocation-free traversal.
+
+### Why static-shaped value objects, not interfaces
+
+Like `HttpMediaType` and the `StructuredField*` types, these are immutable
+protocol primitives with exactly one correct parse — there is no injectable
+behavior to abstract, so an `IForwarded…` interface would add allocation and
+virtual dispatch (AOT-hostile) for no substitutability. The surface is kept
+conservative on purpose: as a Stage-1 fan-out primitive (#778 and every
+forwarding-aware concern imports it), it is costly to change once consumed.
+
+### AOT posture
+
+Span-based parsing over BCL `IPAddress`/char primitives — no reflection, no
+runtime codegen, no dynamic serialization. Parameter/entry storage is a plain
+array (no `ImmutableArray` dependency). Builds clean under the trim/AOT analyzers
+(`IsAotCompatible=true`).
+
+### Non-goals
+
+- **The trust model.** `KnownProxies`/`KnownNetworks`/`ForwardLimit` and the
+  mutation of connection/request state belong to the #778 middleware, not here.
+- **Interpreting `X-Forwarded-For` entries as addresses.** `HttpForwardedValues`
+  is a faithful ordered list; turning an entry into an `IPAddress` (and deciding
+  whether to trust it) is the consumer's call via `HttpForwardedNode`.
+- **De-obfuscating identifiers.** RFC 7239 §6.3 obfuscated nodes/ports are
+  recognized and preserved, never reversed — the mapping is private to the proxy
+  that issued them.
+- **`X-Forwarded-Port` and other vendor headers.** The scope is the three
+  ubiquitous `X-Forwarded-*` headers plus RFC 7239; other vendor variants are a
+  consumer overlay if ever needed.

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
@@ -88,4 +88,10 @@ public enum HttpErrorCode
     /// An <c>If-Range</c> conditional-request header (RFC 9110 &#167; 13.1.5) could not be parsed.
     /// </summary>
     InvalidConditional,
+
+    /// <summary>
+    /// An RFC 7239 <c>Forwarded</c> element (or one of its <c>for</c>/<c>by</c> nodes) or an
+    /// <c>X-Forwarded-*</c> list could not be parsed.
+    /// </summary>
+    InvalidForwarded,
 }

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedElement.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedElement.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single parsed RFC 7239 <c>forwarded-element</c>: an ordered set of <c>forwarded-pair</c>s
+/// (<c>token "=" value</c>) recorded by one proxy hop. The four registered parameters —
+/// <c>for</c>, <c>by</c>, <c>host</c>, and <c>proto</c> — are surfaced through typed accessors;
+/// any additional (extension) parameters are preserved in <see cref="Parameters"/> and round-trip
+/// through <see cref="Serialize"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A value that contains characters outside the RFC 9110 <c>token</c> set (a port <c>:</c>, an
+/// IPv6 <c>[</c>/<c>]</c>, a host with a port) is carried on the wire as a quoted-string; parsing
+/// unescapes it and serialization re-quotes it as needed, so consumers always see the logical
+/// value. The <c>for</c> and <c>by</c> values are additionally parsed into <see cref="HttpForwardedNode"/>s,
+/// and an element whose <c>for</c>/<c>by</c> value is not a well-formed node is rejected.
+/// </para>
+/// <para>
+/// This models one element; the comma-separated element <em>list</em> that forms a whole
+/// <c>Forwarded</c> header is <see cref="HttpForwardedElementCollection"/>.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpForwardedElement : IEquatable<HttpForwardedElement>
+{
+    private const string ForName = "for";
+    private const string ByName = "by";
+    private const string HostName = "host";
+    private const string ProtoName = "proto";
+
+    private readonly HttpForwardedParameter[]? parameters;
+    private readonly HttpForwardedNode forNode;
+    private readonly HttpForwardedNode byNode;
+
+    private HttpForwardedElement(HttpForwardedParameter[] parameters, HttpForwardedNode forNode, HttpForwardedNode byNode)
+    {
+        this.parameters = parameters;
+        this.forNode = forNode;
+        this.byNode = byNode;
+    }
+
+    /// <summary>
+    /// Gets the <c>for</c> node (the client or upstream proxy the recording proxy received the
+    /// request from), or <see langword="null"/> when the element has no <c>for</c> parameter.
+    /// </summary>
+    public HttpForwardedNode? For => forNode.IsEmpty ? null : forNode;
+
+    /// <summary>
+    /// Gets the <c>by</c> node (the interface of the recording proxy the request came in on), or
+    /// <see langword="null"/> when the element has no <c>by</c> parameter.
+    /// </summary>
+    public HttpForwardedNode? By => byNode.IsEmpty ? null : byNode;
+
+    /// <summary>
+    /// Gets the <c>host</c> value (the <c>Host</c> header as received by the proxy), or
+    /// <see langword="null"/> when the element has no <c>host</c> parameter.
+    /// </summary>
+    public string? Host => TryGetParameter(HostName, out string? value) ? value : null;
+
+    /// <summary>
+    /// Gets the <c>proto</c> value (the protocol the request was made over, e.g. <c>https</c>), or
+    /// <see langword="null"/> when the element has no <c>proto</c> parameter.
+    /// </summary>
+    public string? Proto => TryGetParameter(ProtoName, out string? value) ? value : null;
+
+    /// <summary>
+    /// Gets the element's parameters in wire order, including the registered
+    /// <c>for</c>/<c>by</c>/<c>host</c>/<c>proto</c> pairs and any extension pairs.
+    /// </summary>
+    public IReadOnlyList<HttpForwardedParameter> Parameters
+        => parameters ?? (IReadOnlyList<HttpForwardedParameter>)Array.Empty<HttpForwardedParameter>();
+
+    /// <summary>Gets a value indicating whether this is the default (unparsed) instance.</summary>
+    public bool IsEmpty => parameters is null;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>
+    /// Creates a forwarded element from typed values, emitting parameters in the canonical order
+    /// <c>for</c>, <c>by</c>, <c>host</c>, <c>proto</c>, then any extensions.
+    /// </summary>
+    /// <param name="for">The <c>for</c> node, or <see langword="null"/> to omit it.</param>
+    /// <param name="by">The <c>by</c> node, or <see langword="null"/> to omit it.</param>
+    /// <param name="host">The <c>host</c> value, or <see langword="null"/> to omit it.</param>
+    /// <param name="proto">The <c>proto</c> value, or <see langword="null"/> to omit it.</param>
+    /// <param name="extensions">Additional extension parameters, or <see langword="null"/>.</param>
+    /// <returns>The constructed element.</returns>
+    /// <exception cref="ArgumentException">
+    /// A provided <paramref name="for"/>/<paramref name="by"/> node is empty, or
+    /// <paramref name="host"/>/<paramref name="proto"/> is empty or whitespace, or an extension
+    /// parameter reuses a registered name.
+    /// </exception>
+    public static HttpForwardedElement Create(
+        HttpForwardedNode? @for = null,
+        HttpForwardedNode? by = null,
+        string? host = null,
+        string? proto = null,
+        IReadOnlyList<HttpForwardedParameter>? extensions = null)
+    {
+        var list = new List<HttpForwardedParameter>(4);
+        HttpForwardedNode forValue = default;
+        HttpForwardedNode byValue = default;
+
+        if (@for is { } forNode)
+        {
+            if (forNode.IsEmpty)
+            {
+                throw new ArgumentException("The 'for' node is empty.", nameof(@for));
+            }
+            forValue = forNode;
+            list.Add(new HttpForwardedParameter(ForName, forNode.ToString()));
+        }
+        if (by is { } byNode)
+        {
+            if (byNode.IsEmpty)
+            {
+                throw new ArgumentException("The 'by' node is empty.", nameof(by));
+            }
+            byValue = byNode;
+            list.Add(new HttpForwardedParameter(ByName, byNode.ToString()));
+        }
+        if (host is not null)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new ArgumentException("The 'host' value is empty.", nameof(host));
+            }
+            list.Add(new HttpForwardedParameter(HostName, host));
+        }
+        if (proto is not null)
+        {
+            if (string.IsNullOrWhiteSpace(proto))
+            {
+                throw new ArgumentException("The 'proto' value is empty.", nameof(proto));
+            }
+            list.Add(new HttpForwardedParameter(ProtoName, proto));
+        }
+        if (extensions is not null)
+        {
+            foreach (HttpForwardedParameter extension in extensions)
+            {
+                if (IsRegisteredName(extension.Name))
+                {
+                    throw new ArgumentException(
+                        $"Extension parameter '{extension.Name}' reuses a registered parameter name.", nameof(extensions));
+                }
+                list.Add(extension);
+            }
+        }
+
+        return new HttpForwardedElement(list.ToArray(), forValue, byValue);
+    }
+
+    /// <summary>
+    /// Attempts to look up a parameter value by name (case-insensitive). The first occurrence wins.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">When this method returns <see langword="true"/>, the parameter value.</param>
+    /// <returns><see langword="true"/> when a parameter with the given name is present.</returns>
+    public bool TryGetParameter(string name, out string? value)
+    {
+        if (parameters is not null)
+        {
+            foreach (HttpForwardedParameter parameter in parameters)
+            {
+                if (parameter.HasName(name))
+                {
+                    value = parameter.Value;
+                    return true;
+                }
+            }
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Parses <paramref name="value"/> as a single RFC 7239 forwarded-element.
+    /// </summary>
+    /// <param name="value">The element text (e.g. <c>for=192.0.2.43;proto=https</c>).</param>
+    /// <returns>The parsed element.</returns>
+    /// <exception cref="HttpException">The value is not a well-formed forwarded-element.</exception>
+    public static HttpForwardedElement Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpForwardedElement result))
+        {
+            throw new HttpInvalidForwardedException($"The value is not a valid forwarded element: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as a single RFC 7239 forwarded-element.
+    /// </summary>
+    /// <param name="value">The element text, or <see langword="null"/>.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed element.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed, non-empty element.</returns>
+    public static bool TryParse(string? value, out HttpForwardedElement result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as a single RFC 7239 forwarded-element. Empty
+    /// <c>;</c>-separated segments are ignored (RFC 7239 &#167; 4 permits them); a segment that is
+    /// present but malformed — a missing <c>=</c>, a non-token name, an empty or non-token/non-quoted
+    /// value, or a <c>for</c>/<c>by</c> value that is not a valid node — fails the whole parse. Never
+    /// throws.
+    /// </summary>
+    /// <param name="value">The element text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed element.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed, non-empty element.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpForwardedElement result)
+    {
+        result = default;
+
+        value = HttpFieldSyntax.TrimOws(value);
+        if (value.IsEmpty)
+        {
+            return false;
+        }
+
+        List<HttpForwardedParameter>? list = null;
+        HttpForwardedNode forNode = default;
+        HttpForwardedNode byNode = default;
+
+        ReadOnlySpan<char> remaining = value;
+        while (!remaining.IsEmpty)
+        {
+            int semicolon = HttpFieldSyntax.IndexOfUnquoted(remaining, ';');
+            ReadOnlySpan<char> segment = HttpFieldSyntax.TrimOws(semicolon < 0 ? remaining : remaining[..semicolon]);
+            remaining = semicolon < 0 ? ReadOnlySpan<char>.Empty : remaining[(semicolon + 1)..];
+
+            if (segment.IsEmpty)
+            {
+                // An empty forwarded-pair (e.g. a leading, trailing, or doubled ';') is permitted.
+                continue;
+            }
+
+            int equals = HttpFieldSyntax.IndexOfUnquoted(segment, '=');
+            if (equals <= 0)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> nameSpan = HttpFieldSyntax.TrimOws(segment[..equals]);
+            ReadOnlySpan<char> valueSpan = HttpFieldSyntax.TrimOws(segment[(equals + 1)..]);
+            if (!HttpFieldSyntax.IsToken(nameSpan))
+            {
+                return false;
+            }
+
+            if (!TryReadValue(valueSpan, out string parameterValue))
+            {
+                return false;
+            }
+
+            string name = ToLowerString(nameSpan);
+            if (name.Equals(ForName, StringComparison.Ordinal))
+            {
+                if (!HttpForwardedNode.TryParse(parameterValue, out forNode))
+                {
+                    return false;
+                }
+            }
+            else if (name.Equals(ByName, StringComparison.Ordinal))
+            {
+                if (!HttpForwardedNode.TryParse(parameterValue, out byNode))
+                {
+                    return false;
+                }
+            }
+
+            (list ??= new List<HttpForwardedParameter>()).Add(new HttpForwardedParameter(name, parameterValue));
+        }
+
+        if (list is null)
+        {
+            // The element consisted solely of empty pairs — nothing to record.
+            return false;
+        }
+
+        result = new HttpForwardedElement(list.ToArray(), forNode, byNode);
+        return true;
+    }
+
+    private static bool TryReadValue(ReadOnlySpan<char> valueSpan, out string value)
+    {
+        value = string.Empty;
+        if (valueSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        if (valueSpan[0] == '"')
+        {
+            if (!HttpFieldSyntax.IsQuotedString(valueSpan))
+            {
+                return false;
+            }
+            value = HttpFieldSyntax.UnquoteValue(valueSpan);
+            return true;
+        }
+
+        if (!HttpFieldSyntax.IsToken(valueSpan))
+        {
+            return false;
+        }
+
+        value = valueSpan.ToString();
+        return true;
+    }
+
+    private static bool IsRegisteredName(string name)
+        => name.Equals(ForName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(ByName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(HostName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(ProtoName, StringComparison.OrdinalIgnoreCase);
+
+    private static string ToLowerString(ReadOnlySpan<char> span)
+    {
+        Span<char> buffer = span.Length <= 64 ? stackalloc char[span.Length] : new char[span.Length];
+        int written = span.ToLowerInvariant(buffer);
+        return new string(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Serializes the element to its RFC 7239 wire form, quoting any value that is not a bare token.
+    /// </summary>
+    /// <returns>The wire form (e.g. <c>for=192.0.2.43;proto=https</c>), or an empty string for the default instance.</returns>
+    public string Serialize()
+    {
+        if (parameters is null || parameters.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(';');
+            }
+            builder.Append(parameters[i].Name).Append('=');
+            AppendValue(builder, parameters[i].Value);
+        }
+        return builder.ToString();
+    }
+
+    private static void AppendValue(StringBuilder builder, string value)
+    {
+        if (value.Length > 0 && HttpFieldSyntax.IsToken(value.AsSpan()))
+        {
+            builder.Append(value);
+            return;
+        }
+
+        builder.Append('"');
+        foreach (char c in value)
+        {
+            if (c is '"' or '\\')
+            {
+                builder.Append('\\');
+            }
+            builder.Append(c);
+        }
+        builder.Append('"');
+    }
+
+    /// <inheritdoc cref="Serialize" />
+    public override string ToString() => Serialize();
+
+    /// <inheritdoc />
+    public bool Equals(HttpForwardedElement other)
+    {
+        int count = parameters?.Length ?? 0;
+        if (count != (other.parameters?.Length ?? 0))
+        {
+            return false;
+        }
+        for (int i = 0; i < count; i++)
+        {
+            if (!parameters![i].Equals(other.parameters![i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpForwardedElement other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        if (parameters is null)
+        {
+            return 0;
+        }
+        var hash = new HashCode();
+        foreach (HttpForwardedParameter parameter in parameters)
+        {
+            hash.Add(parameter);
+        }
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Determines whether two elements are equal.</summary>
+    public static bool operator ==(HttpForwardedElement left, HttpForwardedElement right) => left.Equals(right);
+
+    /// <summary>Determines whether two elements are not equal.</summary>
+    public static bool operator !=(HttpForwardedElement left, HttpForwardedElement right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedElementCollection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedElementCollection.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed RFC 7239 <c>Forwarded</c> header — the comma-separated <c>1#forwarded-element</c> list.
+/// Elements are held in wire order: the left-most element is the hop closest to the client and the
+/// right-most is the hop closest to this server. A downstream trust evaluator walks the list
+/// <em>right-to-left</em>, peeling off hops it trusts; <see cref="Reverse"/> and the index/count
+/// surface support that traversal directly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Parsing is quote-aware (a comma inside a quoted value does not split the list) and strict: an
+/// empty element between commas is ignored (RFC 7230 &#167; 7 list rule), but any element that is
+/// present and malformed fails the whole parse (<see cref="TryParse(ReadOnlySpan{char}, out HttpForwardedElementCollection)"/>
+/// returns <see langword="false"/>). This deterministic all-or-nothing behavior is deliberate: the
+/// forwarded-headers middleware (issue #778) that applies the trust model must not silently drop a
+/// malformed hop and mis-attribute the request to the wrong client. Parsing the protocol strictly
+/// here keeps the security decision — which hops to trust — entirely in the middleware.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("Count = {Count}")]
+public readonly struct HttpForwardedElementCollection : IReadOnlyList<HttpForwardedElement>, IEquatable<HttpForwardedElementCollection>
+{
+    private readonly HttpForwardedElement[]? elements;
+
+    private HttpForwardedElementCollection(HttpForwardedElement[] elements)
+    {
+        this.elements = elements;
+    }
+
+    /// <summary>Gets an empty collection.</summary>
+    public static HttpForwardedElementCollection Empty { get; } = new(Array.Empty<HttpForwardedElement>());
+
+    /// <summary>Gets the number of elements in the list.</summary>
+    public int Count => elements?.Length ?? 0;
+
+    /// <summary>Gets the element at the given index, in wire order (left-most is index 0).</summary>
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>The element at <paramref name="index"/>.</returns>
+    public HttpForwardedElement this[int index]
+        => elements is null ? throw new ArgumentOutOfRangeException(nameof(index)) : elements[index];
+
+    /// <summary>Gets a value indicating whether the list has no elements.</summary>
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>
+    /// Gets the element added by the hop closest to this server (the right-most element), or
+    /// <see langword="null"/> when the list is empty.
+    /// </summary>
+    public HttpForwardedElement? Nearest => Count == 0 ? null : elements![^1];
+
+    /// <summary>Gets the elements as a span for allocation-free traversal in wire order.</summary>
+    /// <returns>A span over the elements.</returns>
+    public ReadOnlySpan<HttpForwardedElement> AsSpan() => elements;
+
+    /// <summary>
+    /// Returns a new collection with the elements in reverse (right-to-left / nearest-hop-first)
+    /// order, the natural direction for trust evaluation.
+    /// </summary>
+    /// <returns>The reversed collection.</returns>
+    public HttpForwardedElementCollection Reverse()
+    {
+        if (elements is null || elements.Length <= 1)
+        {
+            return this;
+        }
+        var reversed = new HttpForwardedElement[elements.Length];
+        for (int i = 0; i < elements.Length; i++)
+        {
+            reversed[i] = elements[elements.Length - 1 - i];
+        }
+        return new HttpForwardedElementCollection(reversed);
+    }
+
+    /// <summary>
+    /// Parses <paramref name="value"/> as a whole RFC 7239 <c>Forwarded</c> header value.
+    /// </summary>
+    /// <param name="value">The header value.</param>
+    /// <returns>The parsed collection.</returns>
+    /// <exception cref="HttpException">The value is not a well-formed, non-empty forwarded-element list.</exception>
+    public static HttpForwardedElementCollection Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpForwardedElementCollection result))
+        {
+            throw new HttpInvalidForwardedException($"The value is not a valid Forwarded header: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a multi-line <c>Forwarded</c> header. Repeated header lines are combined by
+    /// comma (RFC 9110 &#167; 5.3), which is exactly the element separator, so multiple
+    /// <c>Forwarded</c> field lines parse as one continuous list.
+    /// </summary>
+    /// <param name="value">The header value, possibly carrying multiple field lines.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed collection.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed, non-empty list.</returns>
+    public static bool TryParse(HttpHeaderValue value, out HttpForwardedElementCollection result)
+        => TryParse(value.Value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as a whole <c>Forwarded</c> header value.
+    /// </summary>
+    /// <param name="value">The header value, or <see langword="null"/>.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed collection.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed, non-empty list.</returns>
+    public static bool TryParse(string? value, out HttpForwardedElementCollection result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as a whole <c>Forwarded</c> header value. Empty
+    /// comma-separated slots are ignored; any present-but-malformed element fails the whole parse.
+    /// Never throws.
+    /// </summary>
+    /// <param name="value">The header value.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed collection.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed, non-empty list.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpForwardedElementCollection result)
+    {
+        result = default;
+
+        List<HttpForwardedElement>? list = null;
+        ReadOnlySpan<char> remaining = value;
+        while (!remaining.IsEmpty)
+        {
+            int comma = HttpFieldSyntax.IndexOfUnquoted(remaining, ',');
+            ReadOnlySpan<char> segment = HttpFieldSyntax.TrimOws(comma < 0 ? remaining : remaining[..comma]);
+            remaining = comma < 0 ? ReadOnlySpan<char>.Empty : remaining[(comma + 1)..];
+
+            if (segment.IsEmpty)
+            {
+                // Empty list elements are ignored per the RFC 7230 §7 list rule.
+                continue;
+            }
+
+            if (!HttpForwardedElement.TryParse(segment, out HttpForwardedElement element))
+            {
+                return false;
+            }
+
+            (list ??= new List<HttpForwardedElement>()).Add(element);
+        }
+
+        if (list is null)
+        {
+            return false;
+        }
+
+        result = new HttpForwardedElementCollection(list.ToArray());
+        return true;
+    }
+
+    /// <summary>
+    /// Serializes the list to its RFC 7239 wire form (elements joined by <c>", "</c>).
+    /// </summary>
+    /// <returns>The wire form, or an empty string when the list is empty.</returns>
+    public string Serialize()
+    {
+        if (elements is null || elements.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (int i = 0; i < elements.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+            builder.Append(elements[i].Serialize());
+        }
+        return builder.ToString();
+    }
+
+    /// <inheritdoc cref="Serialize" />
+    public override string ToString() => Serialize();
+
+    /// <summary>Returns an enumerator over the elements in wire order.</summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<HttpForwardedElement> GetEnumerator()
+        => ((IEnumerable<HttpForwardedElement>)(elements ?? Array.Empty<HttpForwardedElement>())).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc />
+    public bool Equals(HttpForwardedElementCollection other)
+    {
+        int count = Count;
+        if (count != other.Count)
+        {
+            return false;
+        }
+        for (int i = 0; i < count; i++)
+        {
+            if (!elements![i].Equals(other.elements![i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpForwardedElementCollection other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        if (elements is null)
+        {
+            return 0;
+        }
+        var hash = new HashCode();
+        foreach (HttpForwardedElement element in elements)
+        {
+            hash.Add(element);
+        }
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Determines whether two collections are equal.</summary>
+    public static bool operator ==(HttpForwardedElementCollection left, HttpForwardedElementCollection right) => left.Equals(right);
+
+    /// <summary>Determines whether two collections are not equal.</summary>
+    public static bool operator !=(HttpForwardedElementCollection left, HttpForwardedElementCollection right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedNode.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedNode.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed RFC 7239 &#167; 6 <c>node</c> identifier — the value carried by the <c>for</c> and
+/// <c>by</c> parameters of a <see cref="HttpForwardedElement"/>. A node is a <c>nodename</c> with
+/// an optional <c>node-port</c>: <c>nodename [ ":" node-port ]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>nodename</c> is one of an IPv4 literal, a bracketed IPv6 literal (<c>[2001:db8::1]</c>),
+/// the sentinel <c>unknown</c>, or an obfuscated identifier (RFC 7239 &#167; 6.3, an <c>_</c>-prefixed
+/// token such as <c>_gazonk</c>). The <c>node-port</c> is either a numeric port or an obfuscated
+/// port (RFC 7239 &#167; 6.4). A proxy that wants to hide its address publishes an obfuscated node.
+/// </para>
+/// <para>
+/// This type is deliberately reused for the entries of the de-facto <c>X-Forwarded-For</c> header,
+/// which — unlike the strict RFC 7239 grammar — routinely writes IPv6 addresses <em>without</em>
+/// brackets (<c>2001:db8::1</c>). Parsing therefore also accepts a bare IPv6 literal; when a bare
+/// IPv6 literal is present it is treated as the whole nodename with no port, because there is no
+/// unambiguous way to separate a trailing <c>:port</c> from the address's own colons (which is
+/// precisely why RFC 7239 mandates brackets). <see cref="Name"/> preserves the exact spelling that
+/// was parsed so <see cref="ToString"/> round-trips the wire form.
+/// </para>
+/// <para>
+/// Recognizing an IPv4/IPv6 literal delegates to <see cref="IPAddress.TryParse(ReadOnlySpan{char}, out IPAddress)"/>,
+/// so the address forms this type accepts are exactly those the BCL parser accepts. This type never
+/// throws on hostile input: <see cref="TryParse(ReadOnlySpan{char}, out HttpForwardedNode)"/> returns
+/// <see langword="false"/> for anything that is not a well-formed node.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpForwardedNode : IEquatable<HttpForwardedNode>
+{
+    private const string UnknownName = "unknown";
+
+    private readonly string? name;
+    private readonly string? port;
+    private readonly IPAddress? address;
+
+    private HttpForwardedNode(string name, string? port, IPAddress? address)
+    {
+        this.name = name;
+        this.port = port;
+        this.address = address;
+    }
+
+    /// <summary>The RFC 7239 <c>unknown</c> node identifier.</summary>
+    public static HttpForwardedNode Unknown { get; } = new(UnknownName, null, null);
+
+    /// <summary>
+    /// Gets the raw <c>nodename</c> exactly as parsed — an IPv4 literal, a bracketed
+    /// (<c>[2001:db8::1]</c>) or bare (<c>2001:db8::1</c>) IPv6 literal, <c>unknown</c>, or an
+    /// obfuscated identifier. Empty when this is the default instance.
+    /// </summary>
+    public string Name => name ?? string.Empty;
+
+    /// <summary>
+    /// Gets the raw <c>node-port</c> (a numeric or obfuscated port) exactly as parsed, or
+    /// <see langword="null"/> when the node carries no port.
+    /// </summary>
+    public string? Port => port;
+
+    /// <summary>
+    /// Gets the IP address of the node when <see cref="Name"/> is an IPv4 or IPv6 literal (brackets
+    /// stripped), or <see langword="null"/> for an <c>unknown</c> or obfuscated node.
+    /// </summary>
+    public IPAddress? Address => address;
+
+    /// <summary>
+    /// Gets the numeric port when <see cref="Port"/> is a decimal number, or <see langword="null"/>
+    /// when the node has no port or an obfuscated port.
+    /// </summary>
+    public int? PortNumber
+        => port is not null && IsNumericPort(port.AsSpan()) ? int.Parse(port) : null;
+
+    /// <summary>Gets a value indicating whether the node is the RFC 7239 <c>unknown</c> sentinel.</summary>
+    public bool IsUnknown => name is not null && string.Equals(name, UnknownName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets a value indicating whether the nodename is an RFC 7239 &#167; 6.3 obfuscated identifier
+    /// (begins with <c>_</c>).
+    /// </summary>
+    public bool IsObfuscatedName => name is { Length: > 0 } && name[0] == '_';
+
+    /// <summary>
+    /// Gets a value indicating whether the port is an RFC 7239 &#167; 6.4 obfuscated port
+    /// (begins with <c>_</c>).
+    /// </summary>
+    public bool HasObfuscatedPort => port is { Length: > 0 } && port[0] == '_';
+
+    /// <summary>Gets a value indicating whether this is the default (unparsed) instance.</summary>
+    public bool IsEmpty => name is null;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>
+    /// Creates a node from an <see cref="IPAddress"/> and optional port, emitting the canonical
+    /// RFC 7239 spelling (an IPv6 address is bracketed).
+    /// </summary>
+    /// <param name="address">The node address.</param>
+    /// <param name="port">The optional numeric port.</param>
+    /// <returns>A node whose <see cref="Address"/> is <paramref name="address"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="port"/> is negative.</exception>
+    public static HttpForwardedNode FromIPAddress(IPAddress address, int? port = null)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        if (port is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(port));
+        }
+
+        string name = address.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{address}]"
+            : address.ToString();
+        return new HttpForwardedNode(name, port?.ToString(), address);
+    }
+
+    /// <summary>
+    /// Parses <paramref name="value"/> as an RFC 7239 &#167; 6 node identifier.
+    /// </summary>
+    /// <param name="value">The node text (e.g. <c>192.0.2.60:4711</c>, <c>[2001:db8::1]</c>, <c>_hidden</c>).</param>
+    /// <returns>The parsed node.</returns>
+    /// <exception cref="HttpException">The value is not a well-formed node.</exception>
+    public static HttpForwardedNode Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpForwardedNode result))
+        {
+            throw new HttpInvalidForwardedException($"The value is not a valid forwarded node: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as an RFC 7239 &#167; 6 node identifier.
+    /// </summary>
+    /// <param name="value">The node text, or <see langword="null"/>.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed node.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed node.</returns>
+    public static bool TryParse(string? value, out HttpForwardedNode result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as an RFC 7239 &#167; 6 node identifier. Never
+    /// throws; malformed input yields <see langword="false"/> and a default result.
+    /// </summary>
+    /// <param name="value">The node text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed node.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed node.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpForwardedNode result)
+    {
+        result = default;
+
+        value = HttpFieldSyntax.TrimOws(value);
+        if (value.IsEmpty)
+        {
+            return false;
+        }
+
+        // Bracketed IPv6 literal: "[" IPv6address "]" [ ":" node-port ].
+        if (value[0] == '[')
+        {
+            int close = value.IndexOf(']');
+            if (close < 2)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> inner = value[1..close];
+            if (!IPAddress.TryParse(inner, out IPAddress? ipv6) || ipv6.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> rest = value[(close + 1)..];
+            string? bracketPort = null;
+            if (!rest.IsEmpty)
+            {
+                if (rest[0] != ':' || !TryValidatePort(rest[1..], out bracketPort))
+                {
+                    return false;
+                }
+            }
+
+            result = new HttpForwardedNode($"[{inner.ToString()}]", bracketPort, ipv6);
+            return true;
+        }
+
+        // Bare IPv6 literal (X-Forwarded-For de-facto form): the whole value is the address, and a
+        // trailing port cannot be disambiguated from the address's colons, so none is recognized.
+        if (value.IndexOf(':') >= 0
+            && IPAddress.TryParse(value, out IPAddress? bare)
+            && bare.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            result = new HttpForwardedNode(value.ToString(), null, bare);
+            return true;
+        }
+
+        // nodename [ ":" node-port ] — nodename is IPv4 / "unknown" / obfnode (none contain a colon).
+        ReadOnlySpan<char> nameSpan = value;
+        string? nodePort = null;
+        int colon = value.IndexOf(':');
+        if (colon >= 0)
+        {
+            nameSpan = value[..colon];
+            if (!TryValidatePort(value[(colon + 1)..], out nodePort))
+            {
+                return false;
+            }
+        }
+
+        if (!TryClassifyName(nameSpan, out IPAddress? nameAddress))
+        {
+            return false;
+        }
+
+        result = new HttpForwardedNode(nameSpan.ToString(), nodePort, nameAddress);
+        return true;
+    }
+
+    private static bool TryClassifyName(ReadOnlySpan<char> nameSpan, out IPAddress? nameAddress)
+    {
+        nameAddress = null;
+        if (nameSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        if (nameSpan.Equals(UnknownName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (nameSpan[0] == '_')
+        {
+            return IsObfuscatedToken(nameSpan);
+        }
+
+        // An IPv4 literal is the only remaining valid nodename form (colon-free, non-obfuscated).
+        if (IPAddress.TryParse(nameSpan, out IPAddress? parsed) && parsed.AddressFamily == AddressFamily.InterNetwork)
+        {
+            nameAddress = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryValidatePort(ReadOnlySpan<char> portSpan, out string? port)
+    {
+        port = null;
+        if (portSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        if (portSpan[0] == '_')
+        {
+            if (!IsObfuscatedToken(portSpan))
+            {
+                return false;
+            }
+        }
+        else if (!IsNumericPort(portSpan))
+        {
+            return false;
+        }
+
+        port = portSpan.ToString();
+        return true;
+    }
+
+    // port = 1*5DIGIT (RFC 7239 §6.4).
+    private static bool IsNumericPort(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty || value.Length > 5)
+        {
+            return false;
+        }
+        foreach (char c in value)
+        {
+            if (c is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // obfnode / obfport = "_" 1*( ALPHA / DIGIT / "." / "_" / "-" ) (RFC 7239 §6.3, §6.4).
+    private static bool IsObfuscatedToken(ReadOnlySpan<char> value)
+    {
+        if (value.Length < 2 || value[0] != '_')
+        {
+            return false;
+        }
+        for (int i = 1; i < value.Length; i++)
+        {
+            char c = value[i];
+            bool ok = c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '.' or '_' or '-';
+            if (!ok)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>Returns the node in its RFC 7239 wire form (e.g. <c>[2001:db8::1]:4711</c>).</summary>
+    /// <returns>The wire form, or an empty string for the default instance.</returns>
+    public override string ToString()
+        => IsEmpty ? string.Empty : port is null ? name! : string.Concat(name, ":", port);
+
+    /// <inheritdoc />
+    public bool Equals(HttpForwardedNode other)
+        => string.Equals(name, other.name, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(port, other.port, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpForwardedNode other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(
+            name is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(name),
+            port is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(port));
+
+    /// <summary>Determines whether two nodes are equal.</summary>
+    public static bool operator ==(HttpForwardedNode left, HttpForwardedNode right) => left.Equals(right);
+
+    /// <summary>Determines whether two nodes are not equal.</summary>
+    public static bool operator !=(HttpForwardedNode left, HttpForwardedNode right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedParameter.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedParameter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single RFC 7239 &#167; 4 <c>forwarded-pair</c> — a <c>token "=" value</c> pair inside a
+/// <see cref="HttpForwardedElement"/>, such as <c>for=192.0.2.60</c>, <c>proto=https</c>, or an
+/// extension parameter a proxy defines. Parameter names are case-insensitive and stored
+/// lower-cased; the value is stored already unescaped from any quoted-string form.
+/// </summary>
+[DebuggerDisplay("{Name}={Value}")]
+public readonly struct HttpForwardedParameter : IEquatable<HttpForwardedParameter>
+{
+    /// <summary>
+    /// Initializes a new forwarded parameter.
+    /// </summary>
+    /// <param name="name">The parameter name (an RFC 9110 token, e.g. <c>for</c>).</param>
+    /// <param name="value">The parameter value, already unescaped from any quoted-string form.</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public HttpForwardedParameter(string name, string? value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        Name = name;
+        Value = value ?? string.Empty;
+    }
+
+    /// <summary>Gets the parameter name (e.g. <c>for</c>, <c>proto</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the parameter value, with any quoted-string escaping already resolved.</summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Determines whether this parameter has the given name (case-insensitive).
+    /// </summary>
+    /// <param name="name">The name to test.</param>
+    /// <returns><see langword="true"/> when the names match ignoring case.</returns>
+    public bool HasName(string name) => string.Equals(Name, name, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public bool Equals(HttpForwardedParameter other)
+        => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpForwardedParameter other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Name),
+            StringComparer.Ordinal.GetHashCode(Value));
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Name}={Value}";
+
+    /// <summary>Determines whether two parameters are equal.</summary>
+    public static bool operator ==(HttpForwardedParameter left, HttpForwardedParameter right) => left.Equals(right);
+
+    /// <summary>Determines whether two parameters are not equal.</summary>
+    public static bool operator !=(HttpForwardedParameter left, HttpForwardedParameter right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedValues.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpForwardedValues.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The ordered list of entries carried by one of the de-facto <c>X-Forwarded-For</c>,
+/// <c>X-Forwarded-Proto</c>, or <c>X-Forwarded-Host</c> headers. Each proxy <em>appends</em> the
+/// value it observed, so entries are in wire order — the left-most is the original client (or the
+/// value seen at the first hop) and the right-most is what the nearest proxy observed. A trust
+/// evaluator walks the list right-to-left; <see cref="Reverse"/>, <see cref="Nearest"/>, and the
+/// index/count surface support that traversal.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This value object owns only the <em>list structure</em>: it splits a header value on commas
+/// (quote-aware), trims optional whitespace, and joins the multiple field lines that arise when a
+/// header occurs more than once (RFC 9110 &#167; 5.3 combines repeated lines by comma, which is the
+/// same separator). Entries are preserved verbatim; interpreting an <c>X-Forwarded-For</c> entry as
+/// an address is a consumer concern — pass it to <see cref="HttpForwardedNode.TryParse(ReadOnlySpan{char}, out HttpForwardedNode)"/>,
+/// which accepts the bracketed and bare IPv6 spellings that appear in the wild. Keeping the address
+/// and trust semantics out of this type lets the same primitive serve all three headers, whose
+/// entry meanings differ (address vs. scheme vs. host).
+/// </para>
+/// <para>
+/// Parsing never throws and is deterministic on hostile input: empty comma slots are dropped, and a
+/// value that yields no entries returns <see langword="false"/> from
+/// <see cref="TryParse(ReadOnlySpan{char}, out HttpForwardedValues)"/>.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("Count = {Count}")]
+public readonly struct HttpForwardedValues : IReadOnlyList<string>, IEquatable<HttpForwardedValues>
+{
+    private readonly string[]? entries;
+
+    private HttpForwardedValues(string[] entries)
+    {
+        this.entries = entries;
+    }
+
+    /// <summary>Gets an empty list.</summary>
+    public static HttpForwardedValues Empty { get; } = new(Array.Empty<string>());
+
+    /// <summary>Gets the number of entries.</summary>
+    public int Count => entries?.Length ?? 0;
+
+    /// <summary>Gets the entry at the given index, in wire order (left-most is index 0).</summary>
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>The entry at <paramref name="index"/>.</returns>
+    public string this[int index]
+        => entries is null ? throw new ArgumentOutOfRangeException(nameof(index)) : entries[index];
+
+    /// <summary>Gets a value indicating whether the list has no entries.</summary>
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>
+    /// Gets the entry recorded by the hop closest to this server (the right-most entry), or
+    /// <see langword="null"/> when the list is empty.
+    /// </summary>
+    public string? Nearest => Count == 0 ? null : entries![^1];
+
+    /// <summary>Gets the entries as a span for allocation-free traversal in wire order.</summary>
+    /// <returns>A span over the entries.</returns>
+    public ReadOnlySpan<string> AsSpan() => entries;
+
+    /// <summary>
+    /// Returns a new list with the entries in reverse (right-to-left / nearest-hop-first) order, the
+    /// natural direction for trust evaluation.
+    /// </summary>
+    /// <returns>The reversed list.</returns>
+    public HttpForwardedValues Reverse()
+    {
+        if (entries is null || entries.Length <= 1)
+        {
+            return this;
+        }
+        var reversed = new string[entries.Length];
+        for (int i = 0; i < entries.Length; i++)
+        {
+            reversed[i] = entries[entries.Length - 1 - i];
+        }
+        return new HttpForwardedValues(reversed);
+    }
+
+    /// <summary>
+    /// Parses <paramref name="value"/> as an <c>X-Forwarded-*</c> list value.
+    /// </summary>
+    /// <param name="value">The header value.</param>
+    /// <returns>The parsed list.</returns>
+    /// <exception cref="HttpException">The value contains no entries.</exception>
+    public static HttpForwardedValues Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpForwardedValues result))
+        {
+            throw new HttpInvalidForwardedException($"The value is not a valid X-Forwarded-* list: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a possibly multi-line <c>X-Forwarded-*</c> header. Repeated header lines are
+    /// combined by comma, so multiple occurrences parse as one continuous list in arrival order.
+    /// </summary>
+    /// <param name="value">The header value, possibly carrying multiple field lines.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed list.</param>
+    /// <returns><see langword="true"/> when at least one entry was parsed.</returns>
+    public static bool TryParse(HttpHeaderValue value, out HttpForwardedValues result)
+        => TryParse(value.Value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as an <c>X-Forwarded-*</c> list value.
+    /// </summary>
+    /// <param name="value">The header value, or <see langword="null"/>.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed list.</param>
+    /// <returns><see langword="true"/> when at least one entry was parsed.</returns>
+    public static bool TryParse(string? value, out HttpForwardedValues result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as an <c>X-Forwarded-*</c> list value. Empty
+    /// comma slots are dropped; a value with no entries yields <see langword="false"/>. Never throws.
+    /// </summary>
+    /// <param name="value">The header value.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed list.</param>
+    /// <returns><see langword="true"/> when at least one entry was parsed.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpForwardedValues result)
+    {
+        result = default;
+
+        List<string>? list = null;
+        ReadOnlySpan<char> remaining = value;
+        while (!remaining.IsEmpty)
+        {
+            int comma = HttpFieldSyntax.IndexOfUnquoted(remaining, ',');
+            ReadOnlySpan<char> segment = HttpFieldSyntax.TrimOws(comma < 0 ? remaining : remaining[..comma]);
+            remaining = comma < 0 ? ReadOnlySpan<char>.Empty : remaining[(comma + 1)..];
+
+            if (segment.IsEmpty)
+            {
+                continue;
+            }
+
+            (list ??= new List<string>()).Add(segment.ToString());
+        }
+
+        if (list is null)
+        {
+            return false;
+        }
+
+        result = new HttpForwardedValues(list.ToArray());
+        return true;
+    }
+
+    /// <summary>
+    /// Serializes the list to wire form (entries joined by <c>", "</c>).
+    /// </summary>
+    /// <returns>The wire form, or an empty string when the list is empty.</returns>
+    public string Serialize()
+        => entries is null || entries.Length == 0 ? string.Empty : string.Join(", ", entries);
+
+    /// <inheritdoc cref="Serialize" />
+    public override string ToString() => Serialize();
+
+    /// <summary>Returns an enumerator over the entries in wire order.</summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<string> GetEnumerator()
+        => ((IEnumerable<string>)(entries ?? Array.Empty<string>())).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc />
+    public bool Equals(HttpForwardedValues other)
+    {
+        int count = Count;
+        if (count != other.Count)
+        {
+            return false;
+        }
+        for (int i = 0; i < count; i++)
+        {
+            if (!string.Equals(entries![i], other.entries![i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpForwardedValues other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        if (entries is null)
+        {
+            return 0;
+        }
+        var hash = new HashCode();
+        foreach (string entry in entries)
+        {
+            hash.Add(entry, StringComparer.Ordinal);
+        }
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Determines whether two lists are equal.</summary>
+    public static bool operator ==(HttpForwardedValues left, HttpForwardedValues right) => left.Equals(right);
+
+    /// <summary>Determines whether two lists are not equal.</summary>
+    public static bool operator !=(HttpForwardedValues left, HttpForwardedValues right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
@@ -168,6 +168,9 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
     /// <summary>Gets the <c>Expect</c> HTTP header name.</summary>
     public static HttpHeaderKey Expect {get;}= new( "Expect");
 
+    /// <summary>Gets the <c>Forwarded</c> HTTP header name (RFC 7239).</summary>
+    public static HttpHeaderKey Forwarded {get;}= new( "Forwarded");
+
     /// <summary>Gets the <c>From</c> HTTP header name.</summary>
     public static HttpHeaderKey From {get;}= new( "From");
 
@@ -371,6 +374,15 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
 
     /// <summary>Gets the <c>X-Content-Type-Options</c> HTTP header name.</summary>
     public static HttpHeaderKey XContentTypeOptions {get;}= new( "X-Content-Type-Options");
+
+    /// <summary>Gets the <c>X-Forwarded-For</c> HTTP header name (de-facto proxy client-chain header).</summary>
+    public static HttpHeaderKey XForwardedFor {get;}= new( "X-Forwarded-For");
+
+    /// <summary>Gets the <c>X-Forwarded-Host</c> HTTP header name (de-facto original-host header).</summary>
+    public static HttpHeaderKey XForwardedHost {get;}= new( "X-Forwarded-Host");
+
+    /// <summary>Gets the <c>X-Forwarded-Proto</c> HTTP header name (de-facto original-scheme header).</summary>
+    public static HttpHeaderKey XForwardedProto {get;}= new( "X-Forwarded-Proto");
 
     /// <summary>Gets the <c>X-Frame-Options</c> HTTP header name.</summary>
     public static HttpHeaderKey XFrameOptions {get;}= new( "X-Frame-Options");

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidForwardedException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidForwardedException.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+internal sealed class HttpInvalidForwardedException : HttpException
+{
+    public HttpInvalidForwardedException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidForwarded;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/HttpFieldSyntax.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/HttpFieldSyntax.cs
@@ -88,6 +88,45 @@ internal static class HttpFieldSyntax
     }
 
     /// <summary>
+    /// Determines whether <paramref name="value"/> is a well-formed RFC 9110 &#167; 5.6.4
+    /// <c>quoted-string</c> that spans the entire span: it opens and closes with <c>"</c>, every
+    /// backslash is followed by an escaped character, and the closing quote is the final character
+    /// (an unterminated or prematurely-closed quote fails).
+    /// </summary>
+    /// <param name="value">The candidate value.</param>
+    /// <returns><see langword="true"/> when the span is a complete quoted-string.</returns>
+    public static bool IsQuotedString(ReadOnlySpan<char> value)
+    {
+        if (value.Length < 2 || value[0] != '"')
+        {
+            return false;
+        }
+
+        int i = 1;
+        while (i < value.Length)
+        {
+            char c = value[i];
+            if (c == '\\')
+            {
+                // A quoted-pair must have a character to escape; a trailing backslash is malformed.
+                if (i + 1 >= value.Length)
+                {
+                    return false;
+                }
+                i += 2;
+                continue;
+            }
+            if (c == '"')
+            {
+                // The closing quote is only valid as the final character.
+                return i == value.Length - 1;
+            }
+            i++;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Unwraps an RFC 9110 &#167; 5.6.4 quoted-string, removing the surrounding quotes and
     /// resolving <c>\</c> escapes. When <paramref name="value"/> is not a quoted-string it is
     /// returned unchanged (already a bare token value).

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedElementCollectionTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedElementCollectionTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// Tests for <see cref="HttpForwardedElementCollection"/>: the RFC 7239 <c>Forwarded</c> element
+/// list — quote-aware comma splitting, multi-hop ordering, rightmost-first traversal, multi-line
+/// header combining, and strict (all-or-nothing) rejection of malformed lists.
+/// </summary>
+public class HttpForwardedElementCollectionTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should parse a multi-hop chain in wire order")]
+    public void TryParse_MultiHop_ShouldPreserveOrder()
+    {
+        bool ok = HttpForwardedElementCollection.TryParse("for=192.0.2.43, for=\"[2001:db8:cafe::17]\"", out HttpForwardedElementCollection list);
+
+        ok.ShouldBeTrue();
+        list.Count.ShouldBe(2);
+        list[0].For!.Value.Address.ShouldBe(IPAddress.Parse("192.0.2.43"));
+        list[1].For!.Value.Address.ShouldBe(IPAddress.Parse("2001:db8:cafe::17"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should expose the nearest hop as the right-most element")]
+    public void Nearest_ShouldBeRightmostElement()
+    {
+        HttpForwardedElementCollection.TryParse("for=192.0.2.43, for=198.51.100.17, for=203.0.113.9", out HttpForwardedElementCollection list).ShouldBeTrue();
+
+        list.Nearest.ShouldNotBeNull();
+        list.Nearest!.Value.For!.Value.Address.ShouldBe(IPAddress.Parse("203.0.113.9"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should reverse into nearest-hop-first order")]
+    public void Reverse_ShouldYieldNearestFirst()
+    {
+        HttpForwardedElementCollection.TryParse("for=192.0.2.43, for=198.51.100.17, for=203.0.113.9", out HttpForwardedElementCollection list).ShouldBeTrue();
+
+        HttpForwardedElementCollection reversed = list.Reverse();
+
+        reversed[0].For!.Value.Address.ShouldBe(IPAddress.Parse("203.0.113.9"));
+        reversed[2].For!.Value.Address.ShouldBe(IPAddress.Parse("192.0.2.43"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should not split on a comma inside a quoted value")]
+    public void TryParse_QuotedComma_ShouldNotSplit()
+    {
+        bool ok = HttpForwardedElementCollection.TryParse("host=\"a,b\";proto=http", out HttpForwardedElementCollection list);
+
+        ok.ShouldBeTrue();
+        list.Count.ShouldBe(1);
+        list[0].Host.ShouldBe("a,b");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should combine multiple header occurrences by comma")]
+    public void TryParse_MultipleHeaderLines_ShouldCombine()
+    {
+        var headerValue = new HttpHeaderValue(new[] { "for=192.0.2.43", "for=198.51.100.17" });
+
+        bool ok = HttpForwardedElementCollection.TryParse(headerValue, out HttpForwardedElementCollection list);
+
+        ok.ShouldBeTrue();
+        list.Count.ShouldBe(2);
+        list[1].For!.Value.Address.ShouldBe(IPAddress.Parse("198.51.100.17"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should ignore empty list slots")]
+    public void TryParse_EmptySlots_ShouldBeIgnored()
+    {
+        bool ok = HttpForwardedElementCollection.TryParse("for=192.0.2.43, , for=198.51.100.17", out HttpForwardedElementCollection list);
+
+        ok.ShouldBeTrue();
+        list.Count.ShouldBe(2);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should round-trip a chain through Serialize")]
+    public void TryParse_ThenSerialize_ShouldRoundTrip()
+    {
+        const string raw = "for=192.0.2.43, for=\"[2001:db8:cafe::17]\"";
+        HttpForwardedElementCollection.TryParse(raw, out HttpForwardedElementCollection list).ShouldBeTrue();
+
+        list.Serialize().ShouldBe(raw);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should enumerate elements in wire order")]
+    public void Enumerate_ShouldYieldWireOrder()
+    {
+        HttpForwardedElementCollection.TryParse("for=192.0.2.43, for=198.51.100.17", out HttpForwardedElementCollection list).ShouldBeTrue();
+
+        var addresses = new System.Collections.Generic.List<IPAddress?>();
+        foreach (HttpForwardedElement element in list)
+        {
+            addresses.Add(element.For?.Address);
+        }
+
+        addresses.ShouldBe(new IPAddress?[] { IPAddress.Parse("192.0.2.43"), IPAddress.Parse("198.51.100.17") });
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedList: Should reject the whole list when any element is malformed")]
+    [InlineData("for=192.0.2.43, for=notanode")]
+    [InlineData("for=bad, for=192.0.2.43")]
+    [InlineData("for=192.0.2.43, forgot-an-equals")]
+    public void TryParse_MalformedElement_ShouldRejectWholeList(string raw)
+    {
+        bool ok = true;
+        Should.NotThrow(() => ok = HttpForwardedElementCollection.TryParse(raw, out _));
+
+        ok.ShouldBeFalse();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedList: Should fail on empty or content-free input")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",,,")]
+    public void TryParse_NoElements_ShouldFail(string raw)
+    {
+        HttpForwardedElementCollection.TryParse(raw, out _).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should throw HttpException from Parse on malformed input")]
+    public void Parse_Malformed_ShouldThrowHttpException()
+    {
+        Should.Throw<HttpException>(() => HttpForwardedElementCollection.Parse("for=192.0.2.43, bad"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedList: Should treat the static Empty as empty")]
+    public void Empty_ShouldHaveNoElements()
+    {
+        HttpForwardedElementCollection.Empty.Count.ShouldBe(0);
+        HttpForwardedElementCollection.Empty.IsEmpty.ShouldBeTrue();
+        HttpForwardedElementCollection.Empty.Nearest.ShouldBeNull();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedElementTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedElementTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 7239 &#167; 4 compliance tests for <see cref="HttpForwardedElement"/>: forwarded-pair parsing,
+/// typed <c>for</c>/<c>by</c>/<c>host</c>/<c>proto</c> access, quoted-string handling, extension-pair
+/// preservation, serialization round-trips, and deterministic rejection.
+/// </summary>
+public class HttpForwardedElementTests
+{
+    // ============================================================================
+    // Registered parameters
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should parse a single for pair")]
+    public void TryParse_ForOnly_ShouldExposeForNode()
+    {
+        bool ok = HttpForwardedElement.TryParse("for=192.0.2.43", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.For.ShouldNotBeNull();
+        element.For!.Value.Address.ShouldBe(IPAddress.Parse("192.0.2.43"));
+        element.By.ShouldBeNull();
+        element.Host.ShouldBeNull();
+        element.Proto.ShouldBeNull();
+        element.Parameters.Count.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should parse for, by, host and proto together")]
+    public void TryParse_AllRegistered_ShouldExposeEach()
+    {
+        bool ok = HttpForwardedElement.TryParse("for=192.0.2.43;by=203.0.113.43;host=example.com;proto=https", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.For!.Value.Address.ShouldBe(IPAddress.Parse("192.0.2.43"));
+        element.By!.Value.Address.ShouldBe(IPAddress.Parse("203.0.113.43"));
+        element.Host.ShouldBe("example.com");
+        element.Proto.ShouldBe("https");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should lower-case parameter names but preserve value case")]
+    public void TryParse_MixedCaseNames_ShouldLowerNamesKeepValues()
+    {
+        bool ok = HttpForwardedElement.TryParse("For=192.0.2.43;pRoTo=HTTPS", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.Parameters[0].Name.ShouldBe("for");
+        element.Parameters[1].Name.ShouldBe("proto");
+        element.Proto.ShouldBe("HTTPS");
+    }
+
+    // ============================================================================
+    // Quoted values — ports, IPv6, host:port
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should parse a quoted IPv6 node with a port")]
+    public void TryParse_QuotedIPv6ForWithPort_ShouldUnquoteAndParse()
+    {
+        bool ok = HttpForwardedElement.TryParse("for=\"[2001:db8:cafe::17]:4711\"", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.For!.Value.Address.ShouldBe(IPAddress.Parse("2001:db8:cafe::17"));
+        element.For!.Value.PortNumber.ShouldBe(4711);
+        element.Parameters[0].Value.ShouldBe("[2001:db8:cafe::17]:4711");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should parse a quoted host with a port")]
+    public void TryParse_QuotedHostWithPort_ShouldUnquote()
+    {
+        bool ok = HttpForwardedElement.TryParse("host=\"example.com:8080\"", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.Host.ShouldBe("example.com:8080");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should resolve backslash escapes inside a quoted value")]
+    public void TryParse_QuotedValueWithEscape_ShouldUnescape()
+    {
+        bool ok = HttpForwardedElement.TryParse("host=\"a\\\"b\"", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.Host.ShouldBe("a\"b");
+    }
+
+    // ============================================================================
+    // Extension parameters + empty-pair tolerance
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should preserve extension parameters")]
+    public void TryParse_ExtensionParameter_ShouldBePreserved()
+    {
+        bool ok = HttpForwardedElement.TryParse("for=192.0.2.43;secret=value", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.TryGetParameter("secret", out string? value).ShouldBeTrue();
+        value.ShouldBe("value");
+        element.Parameters.Count.ShouldBe(2);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should ignore empty forwarded-pairs")]
+    public void TryParse_EmptyPairs_ShouldBeSkipped()
+    {
+        bool ok = HttpForwardedElement.TryParse(";for=192.0.2.43;;proto=http;", out HttpForwardedElement element);
+
+        ok.ShouldBeTrue();
+        element.Parameters.Count.ShouldBe(2);
+        element.Proto.ShouldBe("http");
+    }
+
+    // ============================================================================
+    // Serialization + Create
+    // ============================================================================
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should round-trip through Serialize")]
+    [InlineData("for=192.0.2.43")]
+    [InlineData("for=192.0.2.43;proto=https")]
+    [InlineData("for=\"[2001:db8:cafe::17]:4711\"")]
+    [InlineData("host=\"example.com:8080\";proto=https")]
+    public void TryParse_ThenSerialize_ShouldRoundTrip(string raw)
+    {
+        HttpForwardedElement.TryParse(raw, out HttpForwardedElement element).ShouldBeTrue();
+
+        element.Serialize().ShouldBe(raw);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should serialize a quoted value with escaped quotes")]
+    public void Serialize_ValueWithQuote_ShouldEscape()
+    {
+        HttpForwardedElement.TryParse("host=\"a\\\"b\"", out HttpForwardedElement element).ShouldBeTrue();
+
+        element.Serialize().ShouldBe("host=\"a\\\"b\"");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should build an element from typed values")]
+    public void Create_TypedValues_ShouldSerializeCanonically()
+    {
+        HttpForwardedElement element = HttpForwardedElement.Create(
+            @for: HttpForwardedNode.FromIPAddress(IPAddress.Parse("192.0.2.43")),
+            proto: "https");
+
+        element.Serialize().ShouldBe("for=192.0.2.43;proto=https");
+        element.For!.Value.Address.ShouldBe(IPAddress.Parse("192.0.2.43"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should quote a for node with a port built via Create")]
+    public void Create_ForWithPort_ShouldQuoteOnSerialize()
+    {
+        HttpForwardedElement element = HttpForwardedElement.Create(
+            @for: HttpForwardedNode.FromIPAddress(IPAddress.Parse("2001:db8::1"), 4711));
+
+        element.Serialize().ShouldBe("for=\"[2001:db8::1]:4711\"");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should reject an extension that reuses a registered name")]
+    public void Create_ExtensionReusingRegisteredName_ShouldThrow()
+    {
+        Should.Throw<System.ArgumentException>(() => HttpForwardedElement.Create(
+            proto: "https",
+            extensions: new[] { new HttpForwardedParameter("proto", "http") }));
+    }
+
+    // ============================================================================
+    // Malformed — deterministic rejection, never throws
+    // ============================================================================
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should reject malformed elements without throwing")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("for")]                       // no '='
+    [InlineData("=192.0.2.43")]               // empty name
+    [InlineData("for=")]                       // empty value
+    [InlineData("for=notanode")]
+    [InlineData("for=1.2.3.4;by=notanode")]
+    [InlineData("for=192.0.2.43:47011")]      // ':' requires quoting; bare is malformed
+    [InlineData("for=[2001:db8::1]")]         // IPv6 must be quoted
+    [InlineData("bad name=value")]            // name is not a token
+    [InlineData("proto=\"unterminated")]      // unterminated quoted-string
+    [InlineData("proto=\"a\\\"")]              // quote closed only by an escaped quote
+    [InlineData(";;;")]                        // only empty pairs
+    public void TryParse_Malformed_ShouldFail(string raw)
+    {
+        bool ok = true;
+        Should.NotThrow(() => ok = HttpForwardedElement.TryParse(raw, out _));
+
+        ok.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedElement: Should throw HttpException from Parse on malformed input")]
+    public void Parse_Malformed_ShouldThrowHttpException()
+    {
+        Should.Throw<HttpException>(() => HttpForwardedElement.Parse("for=notanode"));
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedFuzzTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedFuzzTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// Hostile-input / fuzz-style tests over the forwarded-header primitives. Every parser must be
+/// <em>total</em> on adversarial input: it returns a deterministic <see langword="bool"/> and never
+/// throws, never hangs, and never overflows the stack — no matter how malformed, truncated, or
+/// pathologically large the input is. These are the inputs a proxy chain (hostile or buggy) can put
+/// in front of the trust-model middleware (issue #778), so getting deterministic rejection here is a
+/// security property, not a nicety.
+/// </summary>
+public class HttpForwardedFuzzTests
+{
+    public static IEnumerable<object[]> HostileInputs()
+    {
+        var inputs = new List<string>
+        {
+            // Empty / whitespace / lone delimiters.
+            "", " ", "\t", "\n", "\r\n",
+            "=", "==", "===", ";", ";;;", ",", ",,,", ":", "::::", "\"", "\"\"",
+
+            // Truncated / unterminated structure.
+            "for", "for=", "by=", "host=", "proto=",
+            "for=;by=;host=;proto=",
+            "for=\"", "for=\"\\", "for=\"\\\"", "for=\"unterminated",
+            "[", "]", "[]", "][", "for=[", "for=[]", "for=[::1", "for=::1]",
+
+            // Ports gone wrong.
+            "for=1.2.3.4:", "for=:80", "for=1.2.3.4:99999999999", "for=1.2.3.4:-1",
+            "[2001:db8::1]:", "[2001:db8::1]:abc",
+
+            // Registered-name confusion / repeats.
+            "for=1.2.3.4;for=5.6.7.8;for=9.10.11.12",
+            "FOR=1.2.3.4;FoR=5.6.7.8",
+
+            // Whitespace / non-token content.
+            "for = 1.2.3.4", "proto=ht tp", "bad name=value", "for\t=\t1.2.3.4",
+
+            // Embedded control / null / high-plane characters.
+            "\0", "for=\0", "for=a\0b", "host=", "for=￿", "🙂=🙂", "for=🙂",
+
+            // Mixed valid + junk in a list.
+            "for=1.2.3.4, , , , for=5.6.7.8, bad,",
+            "203.0.113.1, , 70.41.3.18, ,,",
+
+            // Pathologically large inputs (must terminate, must not overflow).
+            new string('a', 5000),
+            new string('[', 2000),
+            new string(']', 2000),
+            new string(';', 2000),
+            new string(',', 2000),
+            new string(':', 2000),
+            "for=" + new string('9', 5000),
+            "\"" + new string('a', 5000),
+            "for=\"" + new string('\\', 2000) + "\"",
+            "for=1.2.3.4" + new string(':', 500),
+            string.Join(",", System.Linq.Enumerable.Repeat("for=1.2.3.4", 500)),
+        };
+
+        foreach (string input in inputs)
+        {
+            yield return new object[] { input };
+        }
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedFuzz: HttpForwardedNode should be total and deterministic")]
+    [MemberData(nameof(HostileInputs))]
+    public void Node_ShouldBeTotalAndDeterministic(string input)
+    {
+        bool first = false;
+        bool second = false;
+        HttpForwardedNode firstNode = default;
+        HttpForwardedNode secondNode = default;
+
+        Should.NotThrow(() => first = HttpForwardedNode.TryParse(input, out firstNode));
+        Should.NotThrow(() => second = HttpForwardedNode.TryParse(input, out secondNode));
+
+        second.ShouldBe(first);
+        if (first)
+        {
+            firstNode.ToString().ShouldBe(secondNode.ToString());
+        }
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedFuzz: HttpForwardedElement should be total and deterministic")]
+    [MemberData(nameof(HostileInputs))]
+    public void Element_ShouldBeTotalAndDeterministic(string input)
+    {
+        bool first = false;
+        bool second = false;
+        HttpForwardedElement firstElement = default;
+        HttpForwardedElement secondElement = default;
+
+        Should.NotThrow(() => first = HttpForwardedElement.TryParse(input, out firstElement));
+        Should.NotThrow(() => second = HttpForwardedElement.TryParse(input, out secondElement));
+
+        second.ShouldBe(first);
+        if (first)
+        {
+            firstElement.Serialize().ShouldBe(secondElement.Serialize());
+        }
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedFuzz: HttpForwardedElementCollection should be total and deterministic")]
+    [MemberData(nameof(HostileInputs))]
+    public void Collection_ShouldBeTotalAndDeterministic(string input)
+    {
+        bool first = false;
+        bool second = false;
+        HttpForwardedElementCollection firstList = default;
+        HttpForwardedElementCollection secondList = default;
+
+        Should.NotThrow(() => first = HttpForwardedElementCollection.TryParse(input, out firstList));
+        Should.NotThrow(() => second = HttpForwardedElementCollection.TryParse(input, out secondList));
+
+        second.ShouldBe(first);
+        if (first)
+        {
+            firstList.Serialize().ShouldBe(secondList.Serialize());
+        }
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedFuzz: HttpForwardedValues should be total and deterministic")]
+    [MemberData(nameof(HostileInputs))]
+    public void Values_ShouldBeTotalAndDeterministic(string input)
+    {
+        bool first = false;
+        bool second = false;
+        HttpForwardedValues firstValues = default;
+        HttpForwardedValues secondValues = default;
+
+        Should.NotThrow(() => first = HttpForwardedValues.TryParse(input, out firstValues));
+        Should.NotThrow(() => second = HttpForwardedValues.TryParse(input, out secondValues));
+
+        second.ShouldBe(first);
+        if (first)
+        {
+            firstValues.Serialize().ShouldBe(secondValues.Serialize());
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedNodeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedNodeTests.cs
@@ -1,0 +1,244 @@
+using System.Net;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 7239 &#167; 6 compliance tests for <see cref="HttpForwardedNode"/>: nodename/node-port
+/// parsing across IPv4, bracketed and bare IPv6, <c>unknown</c>, and obfuscated forms, plus the
+/// deterministic rejection of malformed input.
+/// </summary>
+public class HttpForwardedNodeTests
+{
+    // ============================================================================
+    // IPv4
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse a bare IPv4 literal")]
+    public void TryParse_IPv4_ShouldExposeAddress()
+    {
+        bool ok = HttpForwardedNode.TryParse("192.0.2.60", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Name.ShouldBe("192.0.2.60");
+        node.Address.ShouldBe(IPAddress.Parse("192.0.2.60"));
+        node.Port.ShouldBeNull();
+        node.PortNumber.ShouldBeNull();
+        node.IsUnknown.ShouldBeFalse();
+        node.IsObfuscatedName.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse an IPv4 literal with a numeric port")]
+    public void TryParse_IPv4WithPort_ShouldExposeAddressAndPort()
+    {
+        bool ok = HttpForwardedNode.TryParse("192.0.2.60:4711", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Address.ShouldBe(IPAddress.Parse("192.0.2.60"));
+        node.Port.ShouldBe("4711");
+        node.PortNumber.ShouldBe(4711);
+    }
+
+    // ============================================================================
+    // IPv6 (bracketed = RFC 7239, bare = X-Forwarded-For de-facto)
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse a bracketed IPv6 literal")]
+    public void TryParse_BracketedIPv6_ShouldStripBracketsForAddress()
+    {
+        bool ok = HttpForwardedNode.TryParse("[2001:db8:cafe::17]", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Name.ShouldBe("[2001:db8:cafe::17]");
+        node.Address.ShouldBe(IPAddress.Parse("2001:db8:cafe::17"));
+        node.Port.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse a bracketed IPv6 literal with a port")]
+    public void TryParse_BracketedIPv6WithPort_ShouldExposeAddressAndPort()
+    {
+        bool ok = HttpForwardedNode.TryParse("[2001:db8:cafe::17]:4711", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Address.ShouldBe(IPAddress.Parse("2001:db8:cafe::17"));
+        node.PortNumber.ShouldBe(4711);
+        node.ToString().ShouldBe("[2001:db8:cafe::17]:4711");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should accept a bare IPv6 literal as the whole nodename")]
+    [InlineData("2001:db8::1")]
+    [InlineData("::1")]
+    [InlineData("fe80::1")]
+    public void TryParse_BareIPv6_ShouldExposeAddressWithoutPort(string raw)
+    {
+        bool ok = HttpForwardedNode.TryParse(raw, out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Address.ShouldBe(IPAddress.Parse(raw));
+        node.Port.ShouldBeNull();
+    }
+
+    // ============================================================================
+    // unknown + obfuscated identifiers
+    // ============================================================================
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse the unknown sentinel case-insensitively")]
+    [InlineData("unknown")]
+    [InlineData("Unknown")]
+    [InlineData("UNKNOWN")]
+    public void TryParse_Unknown_ShouldFlagUnknown(string raw)
+    {
+        bool ok = HttpForwardedNode.TryParse(raw, out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.IsUnknown.ShouldBeTrue();
+        node.Address.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse an obfuscated node identifier")]
+    public void TryParse_ObfuscatedName_ShouldFlagObfuscated()
+    {
+        bool ok = HttpForwardedNode.TryParse("_gazonk", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.IsObfuscatedName.ShouldBeTrue();
+        node.Address.ShouldBeNull();
+        node.IsUnknown.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse an obfuscated node and obfuscated port")]
+    public void TryParse_ObfuscatedNameAndPort_ShouldFlagBoth()
+    {
+        bool ok = HttpForwardedNode.TryParse("_gazonk:_secret", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.IsObfuscatedName.ShouldBeTrue();
+        node.HasObfuscatedPort.ShouldBeTrue();
+        node.PortNumber.ShouldBeNull();
+        node.Port.ShouldBe("_secret");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should parse an IPv4 literal with an obfuscated port")]
+    public void TryParse_IPv4WithObfuscatedPort_ShouldExposeObfuscatedPort()
+    {
+        bool ok = HttpForwardedNode.TryParse("192.0.2.60:_obf", out HttpForwardedNode node);
+
+        ok.ShouldBeTrue();
+        node.Address.ShouldBe(IPAddress.Parse("192.0.2.60"));
+        node.HasObfuscatedPort.ShouldBeTrue();
+    }
+
+    // ============================================================================
+    // FromIPAddress + round-trip
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should emit canonical brackets from an IPv6 address")]
+    public void FromIPAddress_IPv6_ShouldBracket()
+    {
+        HttpForwardedNode node = HttpForwardedNode.FromIPAddress(IPAddress.Parse("2001:db8::1"), 8080);
+
+        node.ToString().ShouldBe("[2001:db8::1]:8080");
+        node.Address.ShouldBe(IPAddress.Parse("2001:db8::1"));
+        node.PortNumber.ShouldBe(8080);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should emit an IPv4 address without brackets")]
+    public void FromIPAddress_IPv4_ShouldNotBracket()
+    {
+        HttpForwardedNode node = HttpForwardedNode.FromIPAddress(IPAddress.Parse("203.0.113.7"));
+
+        node.ToString().ShouldBe("203.0.113.7");
+        node.Port.ShouldBeNull();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should round-trip through ToString")]
+    [InlineData("192.0.2.60")]
+    [InlineData("192.0.2.60:4711")]
+    [InlineData("[2001:db8:cafe::17]")]
+    [InlineData("[2001:db8:cafe::17]:4711")]
+    [InlineData("unknown")]
+    [InlineData("_gazonk")]
+    [InlineData("_gazonk:_secret")]
+    public void TryParse_ThenToString_ShouldRoundTrip(string raw)
+    {
+        HttpForwardedNode.TryParse(raw, out HttpForwardedNode node).ShouldBeTrue();
+
+        node.ToString().ShouldBe(raw);
+    }
+
+    // ============================================================================
+    // Equality
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should compare equal for the same node text")]
+    public void Equals_SameText_ShouldBeEqual()
+    {
+        HttpForwardedNode.TryParse("192.0.2.60:4711", out HttpForwardedNode left).ShouldBeTrue();
+        HttpForwardedNode.TryParse("192.0.2.60:4711", out HttpForwardedNode right).ShouldBeTrue();
+
+        left.ShouldBe(right);
+        (left == right).ShouldBeTrue();
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should not compare equal for different ports")]
+    public void Equals_DifferentPort_ShouldNotBeEqual()
+    {
+        HttpForwardedNode.TryParse("192.0.2.60:1", out HttpForwardedNode left).ShouldBeTrue();
+        HttpForwardedNode.TryParse("192.0.2.60:2", out HttpForwardedNode right).ShouldBeTrue();
+
+        (left != right).ShouldBeTrue();
+    }
+
+    // ============================================================================
+    // Malformed — deterministic rejection, never throws
+    // ============================================================================
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should reject malformed input without throwing")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[2001:db8::1")]      // unterminated bracket
+    [InlineData("[]")]                 // empty brackets
+    [InlineData("[notipv6]")]
+    [InlineData("[1.2.3.4]")]          // IPv4 is not valid inside brackets
+    [InlineData("[2001:db8::1]x")]     // junk after bracket
+    [InlineData("[2001:db8::1]:")]     // empty port after bracket
+    [InlineData("[2001:db8::1]:x")]    // non-numeric, non-obf port
+    [InlineData("192.0.2.60:")]        // empty port
+    [InlineData("192.0.2.60:abc")]     // non-numeric, non-obf port
+    [InlineData("192.0.2.60:999999")]  // > 5 digits
+    [InlineData(":4711")]              // empty name
+    [InlineData("256.1.1.1")]          // not a valid IPv4
+    [InlineData("example.com")]        // hostnames are not nodes
+    [InlineData("example.com:80")]
+    [InlineData("_")]                  // obf token needs at least one char after '_'
+    [InlineData("_bad$char")]          // invalid obf char
+    [InlineData("unknown:")]           // empty port
+    [InlineData("nota node")]
+    public void TryParse_Malformed_ShouldFail(string raw)
+    {
+        bool ok = false;
+        Should.NotThrow(() => ok = HttpForwardedNode.TryParse(raw, out _));
+
+        ok.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should throw HttpException from Parse on malformed input")]
+    public void Parse_Malformed_ShouldThrowHttpException()
+    {
+        Should.Throw<HttpException>(() => HttpForwardedNode.Parse("not-a-node"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedNode: Should treat the default instance as empty")]
+    public void Default_ShouldBeEmpty()
+    {
+        HttpForwardedNode node = default;
+
+        node.IsEmpty.ShouldBeTrue();
+        node.Name.ShouldBe(string.Empty);
+        node.ToString().ShouldBe(string.Empty);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedValuesTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpForwardedValuesTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// Tests for <see cref="HttpForwardedValues"/>: the ordered <c>X-Forwarded-For</c> /
+/// <c>X-Forwarded-Proto</c> / <c>X-Forwarded-Host</c> list form — comma splitting, multiple header
+/// occurrences, rightmost-first traversal, and interoperation with <see cref="HttpForwardedNode"/>
+/// and the RFC 7239 <c>Forwarded</c> parser.
+/// </summary>
+public class HttpForwardedValuesTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should parse a comma-separated X-Forwarded-For chain in order")]
+    public void TryParse_XForwardedFor_ShouldPreserveOrder()
+    {
+        bool ok = HttpForwardedValues.TryParse("203.0.113.195, 70.41.3.18, 150.172.238.178", out HttpForwardedValues values);
+
+        ok.ShouldBeTrue();
+        values.Count.ShouldBe(3);
+        values[0].ShouldBe("203.0.113.195");
+        values[2].ShouldBe("150.172.238.178");
+        values.Nearest.ShouldBe("150.172.238.178");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should reverse into nearest-hop-first order")]
+    public void Reverse_ShouldYieldNearestFirst()
+    {
+        HttpForwardedValues.TryParse("203.0.113.195, 70.41.3.18, 150.172.238.178", out HttpForwardedValues values).ShouldBeTrue();
+
+        HttpForwardedValues reversed = values.Reverse();
+
+        reversed[0].ShouldBe("150.172.238.178");
+        reversed[2].ShouldBe("203.0.113.195");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should combine multiple header occurrences in arrival order")]
+    public void TryParse_MultipleHeaderLines_ShouldCombine()
+    {
+        var headerValue = new HttpHeaderValue(new[] { "203.0.113.195", "70.41.3.18, 150.172.238.178" });
+
+        bool ok = HttpForwardedValues.TryParse(headerValue, out HttpForwardedValues values);
+
+        ok.ShouldBeTrue();
+        values.Count.ShouldBe(3);
+        values[0].ShouldBe("203.0.113.195");
+        values[1].ShouldBe("70.41.3.18");
+        values[2].ShouldBe("150.172.238.178");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should parse a single X-Forwarded-Proto value")]
+    public void TryParse_XForwardedProto_ShouldExposeSingleEntry()
+    {
+        HttpForwardedValues.TryParse("https", out HttpForwardedValues values).ShouldBeTrue();
+
+        values.Count.ShouldBe(1);
+        values[0].ShouldBe("https");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should preserve an X-Forwarded-Host value verbatim")]
+    public void TryParse_XForwardedHost_ShouldPreserveVerbatim()
+    {
+        HttpForwardedValues.TryParse("example.com:8080", out HttpForwardedValues values).ShouldBeTrue();
+
+        values[0].ShouldBe("example.com:8080");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should drop empty comma slots")]
+    public void TryParse_EmptySlots_ShouldBeDropped()
+    {
+        HttpForwardedValues.TryParse("203.0.113.195, , 70.41.3.18", out HttpForwardedValues values).ShouldBeTrue();
+
+        values.Count.ShouldBe(2);
+    }
+
+    // ============================================================================
+    // Interop with HttpForwardedNode (IPv6 / port edge cases in X-Forwarded-For)
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should interpret X-Forwarded-For entries as nodes incl. bare IPv6")]
+    public void Entries_ShouldParseAsNodes()
+    {
+        HttpForwardedValues.TryParse("203.0.113.195, 2001:db8::1, [2001:db8::2]:8443", out HttpForwardedValues values).ShouldBeTrue();
+
+        HttpForwardedNode.TryParse(values[0], out HttpForwardedNode v4).ShouldBeTrue();
+        v4.Address.ShouldBe(IPAddress.Parse("203.0.113.195"));
+
+        HttpForwardedNode.TryParse(values[1], out HttpForwardedNode bareV6).ShouldBeTrue();
+        bareV6.Address.ShouldBe(IPAddress.Parse("2001:db8::1"));
+
+        HttpForwardedNode.TryParse(values[2], out HttpForwardedNode bracketV6).ShouldBeTrue();
+        bracketV6.Address.ShouldBe(IPAddress.Parse("2001:db8::2"));
+        bracketV6.PortNumber.ShouldBe(8443);
+    }
+
+    // ============================================================================
+    // Mixed RFC 7239 + X-Forwarded-For — the two representations agree on the client
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should agree with the Forwarded header on the original client")]
+    public void Mixed_ForwardedAndXForwardedFor_ShouldAgreeOnClient()
+    {
+        // Same chain expressed two ways; the left-most entry is the original client in both.
+        HttpForwardedElementCollection.TryParse("for=203.0.113.195, for=70.41.3.18", out HttpForwardedElementCollection forwarded).ShouldBeTrue();
+        HttpForwardedValues.TryParse("203.0.113.195, 70.41.3.18", out HttpForwardedValues xff).ShouldBeTrue();
+
+        IPAddress? forwardedClient = forwarded[0].For?.Address;
+        HttpForwardedNode.TryParse(xff[0], out HttpForwardedNode xffClient).ShouldBeTrue();
+
+        forwardedClient.ShouldBe(IPAddress.Parse("203.0.113.195"));
+        xffClient.Address.ShouldBe(forwardedClient);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should round-trip through Serialize")]
+    public void TryParse_ThenSerialize_ShouldRoundTrip()
+    {
+        const string raw = "203.0.113.195, 70.41.3.18, 150.172.238.178";
+        HttpForwardedValues.TryParse(raw, out HttpForwardedValues values).ShouldBeTrue();
+
+        values.Serialize().ShouldBe(raw);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should fail on empty or content-free input")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",,,")]
+    public void TryParse_NoEntries_ShouldFail(string raw)
+    {
+        HttpForwardedValues.TryParse(raw, out _).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - ForwardedValues: Should treat the static Empty as empty")]
+    public void Empty_ShouldHaveNoEntries()
+    {
+        HttpForwardedValues.Empty.Count.ShouldBe(0);
+        HttpForwardedValues.Empty.IsEmpty.ShouldBeTrue();
+        HttpForwardedValues.Empty.Nearest.ShouldBeNull();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpHeaderKeyTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpHeaderKeyTests.cs
@@ -69,4 +69,37 @@ public class HttpHeaderKeyTests
         pair.Key.Value.ShouldBe("Sec-WebSocket-Protocol");
         pair.Value.Value.ShouldBe("chat");
     }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - HeaderKey: Should expose the forwarding header names")]
+    [InlineData("Forwarded")]
+    [InlineData("X-Forwarded-For")]
+    [InlineData("X-Forwarded-Host")]
+    [InlineData("X-Forwarded-Proto")]
+    public void ForwardingKeys_ShouldMapToCanonicalNames(string expected)
+    {
+        // Arrange
+        var keysByName = new Dictionary<string, HttpHeaderKey>
+        {
+            ["Forwarded"] = HttpHeaderKey.Forwarded,
+            ["X-Forwarded-For"] = HttpHeaderKey.XForwardedFor,
+            ["X-Forwarded-Host"] = HttpHeaderKey.XForwardedHost,
+            ["X-Forwarded-Proto"] = HttpHeaderKey.XForwardedProto,
+        };
+
+        // Act & Assert
+        keysByName[expected].Value.ShouldBe(expected);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HeaderKey: Should round-trip Forwarded through IHttpHeaderCollection")]
+    public void Forwarded_RoundTripThroughHeaderCollection_ShouldMatchCaseInsensitively()
+    {
+        // Arrange
+        IHttpHeaderCollection headers = new HttpHeaderCollection();
+        headers.Add(HttpHeaderKey.Forwarded, "for=192.0.2.43;proto=https");
+
+        // Act & Assert
+        headers.ContainsKey("forwarded").ShouldBeTrue();
+        headers.TryGetValue(HttpHeaderKey.Forwarded, out HttpHeaderValue value).ShouldBeTrue();
+        value.Value.ShouldBe("for=192.0.2.43;proto=https");
+    }
 }


### PR DESCRIPTION
## Summary

Adds the **protocol-layer** primitives for proxy-forwarding headers to `libraries/Http/Assimalign.Cohesion.Http` — typed, span-based, AOT-safe value objects for the RFC 7239 `Forwarded` element list and the de-facto `X-Forwarded-For` / `X-Forwarded-Proto` / `X-Forwarded-Host` list forms. This is the **protocol half only**; the trust model (`KnownProxies` / `KnownNetworks` / `ForwardLimit`, and the actual overwrite of `RemoteIp`/`Scheme`) lives in the Web forwarded-headers middleware item **#778**, which consumes these types.

Program context: `docs/HTTP_WEB_PROGRAM_PLAN.md` §4 — Stage 1, Lane B (HTTP primitives), no blockers.

## What's added

**Value objects** (span-based `TryParse`/`Parse`/`Serialize`, the established `HttpMediaType`/`StructuredField*` style):

- **`HttpForwardedNode`** — RFC 7239 §6 `node` identifier (`for`/`by`): IPv4, bracketed IPv6 (`[2001:db8::1]`), **bare** IPv6 (the `X-Forwarded-For` de-facto form), `unknown`, and `_`-prefixed obfuscated names/ports. Typed `Address`/`PortNumber`; `Name`/`Port` preserve wire spelling for exact round-trip.
- **`HttpForwardedParameter`** — one `forwarded-pair`, preserving registered *and* extension parameters.
- **`HttpForwardedElement`** — one `forwarded-element`: typed `For`/`By`/`Host`/`Proto` + `TryGetParameter` for extensions + quoted-value handling + `Serialize` round-trip + a typed `Create` factory for the proxy-writing path.
- **`HttpForwardedElementCollection`** — the whole `Forwarded` header (`1#forwarded-element`): quote-aware comma splitting, multi-line (`HttpHeaderValue`) combining, and **strict all-or-nothing rejection** (a present-but-malformed element fails the whole header, so #778 can't mis-attribute a chain).
- **`HttpForwardedValues`** — the ordered `X-Forwarded-*` list form (multi-hop, multiple header occurrences), entries kept verbatim.

**Rightmost-first traversal** on both list types: index + `Count`, a `Nearest` accessor (the hop that handed *us* the request), a `Reverse()` returning nearest-hop-first, and `AsSpan()` for allocation-free traversal.

**Supporting wiring:** `Forwarded` / `X-Forwarded-For` / `X-Forwarded-Host` / `X-Forwarded-Proto` `HttpHeaderKey`s; `HttpErrorCode.InvalidForwarded` + internal `HttpInvalidForwardedException`; an `IsQuotedString` validator on the shared `HttpFieldSyntax`.

## Acceptance criteria

- [x] `Forwarded` element model parses `for`/`by`/`host`/`proto`, quoted values, obfuscated identifiers, IPv6 bracket literals, and serializes back to wire form.
- [x] `X-Forwarded-*` parse as ordered lists honoring comma-separated multi-hop values and multiple header occurrences, with rightmost-first traversal support.
- [x] Malformed input is rejected deterministically (`TryParse` false, no exceptions), with a fuzz battery over hostile inputs (`HttpForwardedFuzzTests` — truncated quotes, bracket/colon bombs, embedded NULs, high-plane chars, multi-kilobyte inputs; asserts totality + determinism).
- [x] `HttpHeaderKey` gains `Forwarded` alongside the `X-Forwarded-*` keys; all types are span-based, allocation-lean, AOT/trim-safe.
- [x] Unit tests cover multi-hop chains, mixed RFC 7239 + X-Forwarded inputs, and IPv6/port edge cases.
- [x] AGENTS.md throughout: file-scoped namespaces, `CohesionProjectReference` only (no new deps — `System.Net` is BCL), no `Microsoft.Extensions.*`, XML docs on all public APIs, `IsAotCompatible=true` with no reflection, Shouldly tests co-located under `tests/`, `docs/DESIGN.md` updated.

## Design notes

- **Value objects, not interface-first services.** These are immutable protocol primitives with one correct parse — the same reasoning that makes `HttpHeaderKey`, `HttpRequestTarget`, `HttpMediaType`, and the `StructuredField*` family public `readonly struct`s. An interface would add AOT-hostile virtual dispatch and allocation for no substitutability. Rationale recorded in `docs/DESIGN.md`.
- **Strict `Forwarded`, pragmatic `X-Forwarded-*`.** RFC 7239 nodes are parsed strictly; `HttpForwardedNode` additionally accepts bare IPv6 because real proxies write it into `X-Forwarded-For`. `HttpForwardedValues` owns only list structure and keeps entries verbatim, so the same type serves all three `X-Forwarded-*` headers.

## Testing

`dotnet test libraries/Http/Assimalign.Cohesion.Http/tests` → **870 passed, 0 failed** (warning-clean build under the trim/AOT analyzers).

## Collision note

`HttpHeaderKey.cs` additions are localized (near `From` and within the `X-*` block); rebase against sibling Http-core PRs (#792/#755/#753/#756) if one merges first.

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
