### PR TITLE
[L01.01.11.22] Complete graceful GOAWAY drain: HTTP/2 stream-drain window and HTTP/3 GOAWAY lifecycle

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -76,7 +76,8 @@ The connection-is-the-pipe model shows up at three points:
 - Stream parsing (HTTP/1.1, HTTP/2) adapts the duplex pipe once via
   `connection.AsStream()`.
 - Graceful teardown completes `connection.Output` directly (HTTP/2
-  GOAWAY drain, HTTP/1.1 response drain) before disposal.
+  GOAWAY + bounded stream drain, HTTP/1.1 response drain) before disposal
+  (see "HTTP/2 graceful close").
 - HTTP/3 reads each accepted stream's `Input` (`PipeReader`) for
   unidirectional streams and `AsStream()` for request streams.
 
@@ -732,9 +733,10 @@ fires its `RequestAborted` so a handler parked reading it observes cancellation
 rather than a clean end-of-stream (which would let it treat a truncated upload as
 complete), while a **fully-received** body stays readable to completion. Aborting
 before completing the channel makes the abort observable to a consumer that is
-about to see the enumerable end. Graceful close cancels and awaits the pump
-before emitting the final GOAWAY, so the shutdown GOAWAY never races the pump's
-writes.
+about to see the enumerable end. Graceful close emits the shutdown GOAWAY while
+the pump is still running — the write scheduler serializes it against the pump's
+writes — then drains in-flight exchanges (bounded) and only then cancels and
+awaits the pump (see "HTTP/2 graceful close").
 
 ### AOT posture
 
@@ -751,6 +753,69 @@ are value-type octet counters guarded by monitors.
 - **A configurable initial window.** The advertised
   `SETTINGS_INITIAL_WINDOW_SIZE` is the fixed RFC default (65535). Exposing a
   tunable stream/connection window (Kestrel-style) is a later refinement.
+
+## HTTP/2 graceful close (GOAWAY + stream drain)
+
+RFC 9113 §6.8 makes an orderly HTTP/2 shutdown a two-part gesture: announce
+the close with `GOAWAY(NO_ERROR)`, then let the streams already accepted
+finish before the wire goes away. `Http2ConnectionContext.GracefulCloseAsync`
+performs both, in order:
+
+1. **Refuse new streams.** Setting `_gracefulCloseStarted` (an interlocked
+   one-shot) makes `OpenInboundStream` answer any HEADERS opening a *new*
+   stream with `RST_STREAM(REFUSED_STREAM)`. The connection stays alive and
+   keeps draining; the client may retry the refused request on a fresh
+   connection (RFC 9113 §8.1.4). Refused streams never bump the observed
+   last-stream-id, which is what makes the GOAWAY snapshot below exact.
+2. **Emit `GOAWAY(NO_ERROR)`** carrying the highest inbound stream ID
+   observed (snapshotted under the stream-table lock — the pump is still
+   processing frames concurrently), so the peer learns exactly which streams
+   will still be processed.
+3. **Drain, bounded.** `DrainActiveExchangesAsync` waits for every request
+   already dispatched to the application to finish — its response sent, its
+   stream reset, or its truncated request shutdown-aborted — before teardown
+   proceeds. Without this wait the previous behavior completed
+   `connection.Output` immediately, cutting off a response a handler was
+   still writing. The wait is capped by `GracefulDrainWindow` (a fixed
+   internal ceiling, not host-configurable): a stuck or slow response cannot
+   delay teardown indefinitely, and when the window elapses the remaining
+   exchanges are abandoned.
+4. **Stop the pump, then complete the output** so the transport's send loop
+   flushes its backlog and closes the socket (the #686 ordering).
+
+The pump deliberately keeps running through the drain window — this is what
+distinguishes the drain from a passive sleep. A live pump is what refuses
+newly opened streams *on the wire*, keeps feeding in-flight request bodies,
+replenishes send-window credit so a streaming response writer parked on flow
+control can finish, and observes peer `RST_STREAM`s that release the drain
+early. GOAWAY-vs-pump write interleaving is prevented by the connection
+write scheduler (control frames use `ControlUrgency`), not by stopping the
+reader. If the pump exits on its own during the drain (peer end-of-stream or
+wire failure), its shutdown abort releases the accounting of **truncated**
+requests only — a fully-received request stays counted because its handler
+can still respond through the pump-independent write path, and the drain
+exists precisely to give it that chance.
+
+The drain tracks an interlocked `_activeExchangeCount` rather than reading
+the `_streams` table from the close thread. A stream is counted by the pump
+(`MarkExchangeCounted`, immediately before its context is handed to the
+consumer) and released exactly once through the stream's tri-state
+accounting latch (`TryClaimExchangeAccounting`) — every exchange-terminating
+path funnels through `RemoveStreamAsync` (response sent on the buffered or
+streaming path, local reset, peer reset), with the pump's shutdown abort
+covering truncated requests. When the count reaches zero a draining close is
+woken through a published `TaskCompletionSource` (no polling); a re-check
+after publishing the signal closes the lost-wakeup window. When nothing is
+in flight the whole step is skipped.
+
+> The **host-facing** variant — a "drain now, close later" trigger the host
+> calls before dispose, rather than draining inside dispose — is a separate
+> public-surface decision (interface-first, implementation internal) and is
+> deliberately out of scope here. This section covers only the
+> drain-inside-`GracefulCloseAsync` behavior. The optional RFC 9113 §6.8
+> dual-`GOAWAY` pattern (a first `GOAWAY` at max stream ID, a second at the
+> true last-stream-ID after draining) is likewise not implemented; the
+> single `GOAWAY` carrying the real last-stream-ID is sufficient and simpler.
 
 ## HTTP/3 stream model and SETTINGS engine
 
@@ -843,12 +908,14 @@ a **background drain** (`DrainPeerControlStreamAsync`) that parses and
 discards subsequent control frames for the connection lifetime. Draining on
 a background task is load-bearing: the control stream is long-lived, so
 draining it inline would block the accept loop from ever serving another
-request. Post-SETTINGS frames are read but inert in this subset — `GOAWAY`
-(§7.2.6) is discarded (graceful-drain handling is deferred to the GOAWAY
-work item), and `MAX_PUSH_ID` (§7.2.7) is discarded because the server never
-pushes. The drain exists so those frames cannot accumulate unread in the
-pipe; it stops on end-of-stream, connection teardown, or a per-stream parse
-failure and never throws into the receive loop.
+request. Post-SETTINGS frames are read but inert in this subset — a peer
+`GOAWAY` (§7.2.6) is discarded rather than acted on (the server does not
+implement the *client* role of graceful shutdown — reacting to a peer's
+`GOAWAY` — only the server role of *emitting* one, see "Graceful GOAWAY on
+the control stream"), and `MAX_PUSH_ID` (§7.2.7) is discarded because the
+server never pushes. The drain exists so those frames cannot accumulate
+unread in the pipe; it stops on end-of-stream, connection teardown, or a
+per-stream parse failure and never throws into the receive loop.
 
 ### QPACK encoder/decoder streams
 
@@ -881,15 +948,20 @@ lifetime: the server's **own outbound control stream**, and the accepted
 them all *critical* streams — a peer that observes one of them terminate
 (FIN, RESET, or a STOP_SENDING request) before the connection close MUST
 fail the whole connection with `H3_CLOSED_CRITICAL_STREAM`. Teardown is
-therefore connection-first: `Http3Connection.DisposeAsync` delegates to the
-multiplexed connection, whose dispose completes bidirectional (request)
-streams — delivering any in-flight response data — then closes the QUIC
-connection (`CONNECTION_CLOSE` with the transport's configured close
-code, `H3_NO_ERROR` by default on the QUIC driver's options), and only
-then releases the unidirectional streams locally, after the close means no
-stream-level frames can reach the peer. The ordering lives in the QUIC
-driver (`QuicMultiplexedConnection`), not here: any multiplexed protocol
-with long-lived unidirectional control channels needs the same discipline.
+therefore connection-first: `Http3Connection.DisposeAsync` first emits the
+graceful-shutdown `GOAWAY` on the outbound control stream (see "Graceful
+GOAWAY on the control stream" below), then delegates to the multiplexed
+connection, whose dispose completes bidirectional (request) streams —
+delivering any in-flight response data — then closes the QUIC connection
+(`CONNECTION_CLOSE` with the transport's configured close code,
+`H3_NO_ERROR` by default on the QUIC driver's options), and only then
+releases the unidirectional streams locally, after the close means no
+stream-level frames can reach the peer. The `CONNECTION_CLOSE` ordering and
+critical-stream close discipline live in the QUIC driver
+(`QuicMultiplexedConnection`), not here: any multiplexed protocol with
+long-lived unidirectional control channels needs the same discipline. Only
+the `GOAWAY` emission — an HTTP/3 concern — is added ahead of it in this
+layer.
 
 The context's own teardown (`ShutdownAsync`, run from the receive loop's
 `finally`) is deliberately minimal: it cancels the inbound control-stream
@@ -897,9 +969,39 @@ drain and awaits it, but **never completes, aborts, or FINs the outbound
 control stream**. Completing it early — before the connection close — is
 exactly the `H3_CLOSED_CRITICAL_STREAM` violation the connection-first
 ordering exists to avoid, so the context leaves the outbound critical stream
-for the multiplexed connection's dispose to release alongside the close. A
-`GOAWAY`-announced graceful drain ahead of the close remains future work
-(see Non-goals).
+for the multiplexed connection's dispose to release alongside the close. The
+`GOAWAY` written during dispose rides on that still-open critical stream and
+does not complete it.
+
+### Graceful GOAWAY on the control stream
+
+RFC 9114 §5.2 shuts a connection down by sending `GOAWAY` on the control
+stream ahead of the `CONNECTION_CLOSE`. Its payload is a single QUIC
+variable-length integer (RFC 9114 §5.2 / §7.2.6) — for a server, the
+client-initiated bidirectional stream ID that marks the processing
+boundary: requests on streams **below** the announced value may have been
+processed and are allowed to finish; requests at or above it are not
+processed and the client may safely retry them elsewhere.
+
+`Http3GoAwayFrame.Encode` serializes that frame (type `0x07`, a length
+prefix, then the varint stream ID) as pure buffer arithmetic. The boundary
+value is derived from `_processedRequestStreamCount` — the number of
+bidirectional request streams the receive loop has accepted — using QUIC's
+client-bidi numbering (ID = `4 × n`), so after *k* accepted streams the
+announced ID is `4 × k`: the *k* accepted streams (IDs `0 … 4(k-1)`) fall
+below the boundary and may complete, while `4k` and above are rejected. The
+count advances at *accept*, not at dispatch, so a malformed stream the
+server touched and dropped still falls inside "may have been processed" and
+the client will not retry a request whose side effects may have run. The
+connection abstraction surfaces only an opaque `ConnectionId`, not the
+numeric QUIC stream ID, so this count-based derivation is how the HTTP/3
+layer reconstructs the boundary.
+
+`SendGoAwayAsync` writes the frame to the retained outbound control stream
+and is best-effort and one-shot: if the receive loop never ran (no control
+stream, no advertised SETTINGS) there is nothing to announce and it is a
+no-op; a wire/QUIC failure while writing is swallowed because the
+`CONNECTION_CLOSE` that follows conveys the shutdown regardless.
 
 ### Incremental reads off the PipeReader
 
@@ -958,14 +1060,17 @@ the peer-settings store is a plain dictionary.
 
 ### Non-goals
 
-- **Acting on post-SETTINGS control frames.** `GOAWAY`, `MAX_PUSH_ID`,
-  and friends are now *drained* (parsed and discarded by the background
-  control-stream drain, so they cannot accumulate unread) but are not
-  *acted on* in this subset: the server never pushes, so `MAX_PUSH_ID` is
-  inert, and graceful `GOAWAY`-driven drain is future work.
-- **Emitting server GOAWAY / MAX_PUSH_ID.** The server control stream
-  carries only the opening SETTINGS frame today; sending `GOAWAY` (for
-  graceful drain) rides on it as future work.
+- **Acting on a peer's post-SETTINGS control frames.** A peer `GOAWAY`
+  and `MAX_PUSH_ID` are *drained* (parsed and discarded by the background
+  control-stream drain, so they cannot accumulate unread) but not *acted
+  on*: the server never pushes, so `MAX_PUSH_ID` is inert, and reacting to
+  a peer's `GOAWAY` (the client role of graceful shutdown) is future work.
+  Note this is distinct from *emitting* the server's own `GOAWAY`, which
+  now ships — see "Graceful GOAWAY on the control stream".
+- **Emitting server `MAX_PUSH_ID`.** The server control stream carries its
+  opening SETTINGS frame and, at teardown, a graceful-shutdown `GOAWAY`
+  (RFC 9114 §5.2). `MAX_PUSH_ID` is never emitted because the server never
+  pushes.
 - **QPACK dynamic table (when disabled).** With the default
   `QPACK_MAX_TABLE_CAPACITY = 0`, the encoder/decoder streams are accepted but
   not processed and field sections resolve against the static table only. The

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
@@ -17,6 +17,15 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
 {
     private static readonly byte[] ClientPreface = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
+    // RFC 9113 §6.8 — the graceful close waits for streams already accepted
+    // to finish, but that wait is bounded: a slow or stuck in-flight
+    // response must not delay connection teardown indefinitely. When the
+    // window elapses the remaining exchanges are cut off and the output is
+    // completed regardless. Not host-configurable in this package (a
+    // host-facing drain trigger is a separate public-surface decision); a
+    // conservative fixed ceiling keeps shutdown latency bounded.
+    private static readonly TimeSpan GracefulDrainWindow = TimeSpan.FromSeconds(5);
+
     private readonly HPackDecoder _headerDecoder;
     private readonly Dictionary<int, Http2Stream> _streams;
     // Guards the shared mutable state the frame pump and the application threads
@@ -85,6 +94,19 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     private bool _receivedClientSettings;
     private int _lastInboundStreamId;
     private int _gracefulCloseStarted;
+    // RFC 9113 §6.8 — the number of dispatched request exchanges whose
+    // response has not yet been sent (nor whose stream has been reset or
+    // shutdown-aborted). GracefulCloseAsync waits for this to reach zero —
+    // within the bounded GracefulDrainWindow — before stopping the pump and
+    // completing the connection output, so an in-flight response is not cut
+    // off by the graceful close. Mutated with Interlocked from the pump and
+    // application threads.
+    private int _activeExchangeCount;
+    // A one-shot signal completed when _activeExchangeCount reaches zero
+    // while a graceful close is draining. Null until the drain begins;
+    // published (volatile) by DrainActiveExchangesAsync so a decrementing
+    // thread can wake the waiter without polling.
+    private volatile TaskCompletionSource? _drainSignal;
     // RFC 9113 §6.8 — after the peer sends GOAWAY, the server MUST NOT
     // process new streams with id higher than the GOAWAY's last-stream-id.
     // -1 means no GOAWAY received yet; int.MaxValue would mean "accept
@@ -222,6 +244,14 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
                         processed.Context.RunResponseInterceptors(_responseInterceptors, new Http2ResponseBodyStream(this, processed.Context));
                     }
 
+                    // RFC 9113 §6.8 — the request is now an in-flight exchange the
+                    // graceful-close drain must wait on. Count it before handing it
+                    // to the consumer; the accounting is released exactly once when
+                    // the response completes, the stream is reset, or a shutdown
+                    // abort truncates the request.
+                    processed.Context.Stream.MarkExchangeCounted();
+                    Interlocked.Increment(ref _activeExchangeCount);
+
                     _readyContexts.Writer.TryWrite(processed.Context);
                 }
             }
@@ -274,7 +304,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
 
         foreach (Http2Stream stream in streams)
         {
-            stream.AbortOnShutdown();
+            // A truncated request (input still incoming when the pump stopped)
+            // can never complete normally — release its graceful-close drain
+            // accounting so the drain does not wait the full window for it. A
+            // fully-received request stays counted: the handler can still send
+            // its response after the pump exits (the write path does not need
+            // the pump), and the drain exists precisely to give it that chance.
+            if (stream.AbortOnShutdown())
+            {
+                AccountExchangeComplete(stream);
+            }
         }
     }
 
@@ -1430,7 +1469,36 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             await EmitWindowUpdateAsync(0, reclaimed, cancellationToken).ConfigureAwait(false);
         }
 
+        // RFC 9113 §6.8 — every exchange-terminating path funnels through this
+        // removal (response sent on the buffered or streaming path, a local
+        // RST_STREAM, a peer RST_STREAM), so releasing the graceful-close drain
+        // accounting here covers them all. The stream-level one-shot latch makes
+        // a second arrival (e.g. reset racing the response) a no-op.
+        AccountExchangeComplete(stream);
+
         return stream;
+    }
+
+    /// <summary>
+    /// Releases the graceful-close drain accounting for a dispatched
+    /// <paramref name="stream"/>. Idempotent per stream via the stream's one-shot
+    /// accounting latch — and a no-op for streams that were never counted (refused,
+    /// reset, or torn down before dispatch). When the in-flight count reaches zero
+    /// a graceful close that is currently draining is woken (RFC 9113 §6.8).
+    /// </summary>
+    private void AccountExchangeComplete(Http2Stream stream)
+    {
+        if (!stream.TryClaimExchangeAccounting())
+        {
+            return;
+        }
+
+        if (Interlocked.Decrement(ref _activeExchangeCount) == 0)
+        {
+            // Wake a draining GracefulCloseAsync. No-op when no close is in
+            // progress (the signal is only published while draining).
+            _drainSignal?.TrySetResult();
+        }
     }
 
     private async Task WriteHeaderBlockAsync(int streamId, byte[] headerBlock, bool endStream, CancellationToken cancellationToken)
@@ -1791,8 +1859,20 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     {
         try
         {
+            // Snapshot under the stream-table lock: during a graceful close the
+            // pump is still processing HEADERS concurrently with this write, and
+            // announcing an id lower than a stream we actually accepted would
+            // invite the client to retry a request we are about to answer. Any
+            // stream arriving after _gracefulCloseStarted is refused without
+            // bumping _lastInboundStreamId, so the locked read is exact.
+            int lastStreamId;
+            lock (_syncRoot)
+            {
+                lastStreamId = _lastInboundStreamId;
+            }
+
             Http2Frame goAway = new();
-            goAway.PrepareGoAway(_lastInboundStreamId, errorCode);
+            goAway.PrepareGoAway(lastStreamId, errorCode);
             await AcquireControlWriteAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -1880,8 +1960,10 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     }
 
     /// <summary>
-    /// Performs an RFC 9113 §6.8 graceful close: stops the frame pump, emits a
-    /// <c>GOAWAY</c> frame carrying <see cref="Http2ErrorCode.NoError"/>, then
+    /// Performs an RFC 9113 §6.8 graceful close: refuses new streams, emits a
+    /// <c>GOAWAY</c> frame carrying <see cref="Http2ErrorCode.NoError"/>, waits —
+    /// bounded by <see cref="GracefulDrainWindow"/> — for the request exchanges
+    /// already dispatched to finish their responses, then stops the frame pump and
     /// signals the transport's send pipeline that no further bytes will be
     /// written. The transport's send task reads the remaining bytes, performs its
     /// final <c>Socket.SendAsync</c> (which waits for the kernel to accept the
@@ -1889,6 +1971,15 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     /// through the transport's own teardown path.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// The frame pump deliberately keeps running through the drain window: it is
+    /// what refuses newly opened streams with <c>RST_STREAM(REFUSED_STREAM)</c> on
+    /// the wire, keeps feeding in-flight request bodies, replenishes send-window
+    /// credit for a streaming response writer, and observes peer resets that
+    /// release the drain early. It is stopped only after the drain completes (or
+    /// its bounded window elapses); GOAWAY-vs-pump write interleaving is prevented
+    /// by the connection write scheduler.
+    /// </para>
     /// <para>
     /// Closes the gap identified by #686: previously, <see cref="Http2Connection.DisposeAsync"/>
     /// invoked <c>IConnection.DisposeAsync</c> directly, which
@@ -1909,16 +2000,13 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             return;
         }
 
-        // Stop the frame pump first so it cannot race the GOAWAY write or keep
-        // reading after we announce the close. Cancelling unblocks its in-flight
-        // wire read; awaiting it guarantees no further inbound processing.
-        await StopPumpAsync().ConfigureAwait(false);
-
-        // EnsureInitializedAsync may not have run if the pump never started. Skip
-        // GOAWAY in that case; the peer has not seen any HTTP/2 traffic from us
-        // yet, so closing the underlying socket is enough.
+        // EnsureInitializedAsync may not have run if the pump never started (or
+        // has not reached initialization yet). Skip GOAWAY in that case; the peer
+        // has not seen any HTTP/2 traffic from us yet — and nothing can have been
+        // dispatched — so stopping the pump and closing the socket is enough.
         if (!_initialized)
         {
+            await StopPumpAsync().ConfigureAwait(false);
             await CompleteOutputAsync().ConfigureAwait(false);
             return;
         }
@@ -1926,10 +2014,64 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         try
         {
             await EmitGoAwayAsync(Http2ErrorCode.NoError, cancellationToken).ConfigureAwait(false);
+
+            // RFC 9113 §6.8 — after announcing GOAWAY, let the streams already
+            // accepted finish their responses before the pump is stopped and the
+            // output writer completed. New streams opened after this point are
+            // refused with RST_STREAM(REFUSED_STREAM) (see OpenInboundStream /
+            // _gracefulCloseStarted), so the in-flight set only shrinks. The wait
+            // is bounded by GracefulDrainWindow so a stuck response cannot stall
+            // teardown.
+            await DrainActiveExchangesAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
+            await StopPumpAsync().ConfigureAwait(false);
             await CompleteOutputAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Waits — bounded by <see cref="GracefulDrainWindow"/> — for every request
+    /// exchange already dispatched to the application to finish (its response
+    /// sent, its stream reset, or its truncated request shutdown-aborted) before
+    /// the caller stops the pump and completes the connection output. Returns
+    /// immediately when nothing is in flight. When the window elapses (or
+    /// <paramref name="cancellationToken"/> fires) the remaining exchanges are
+    /// abandoned and the caller proceeds to teardown, so shutdown latency stays
+    /// bounded (RFC 9113 §6.8).
+    /// </summary>
+    private async Task DrainActiveExchangesAsync(CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _activeExchangeCount) == 0)
+        {
+            return;
+        }
+
+        TaskCompletionSource signal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _drainSignal = signal;
+
+        // Re-check after publishing the signal: a decrement to zero that ran
+        // between the initial read and the publish would not have observed the
+        // signal, so close that lost-wakeup window here.
+        if (Volatile.Read(ref _activeExchangeCount) == 0)
+        {
+            return;
+        }
+
+        using CancellationTokenSource timeout = new(GracefulDrainWindow);
+        using CancellationTokenSource linked =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
+        try
+        {
+            await signal.Task.WaitAsync(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Bounded window elapsed (or the caller cancelled). Fall through:
+            // any exchange that did not finish is cut off by the pump stop and
+            // output completion that follow, but the connection tears down
+            // within the window.
         }
     }
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Stream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Stream.cs
@@ -61,6 +61,16 @@ internal sealed class Http2Stream
     // undrained body) can race to complete it.
     private int _bodyCompleted;
 
+    // RFC 9113 §6.8 — graceful-close drain accounting, a tri-state latch:
+    // 0 = this stream was never counted as an in-flight exchange;
+    // 1 = counted (the pump dispatched its context and incremented the
+    //     connection's active-exchange count);
+    // 2 = accounted complete (exactly one completion path — response sent,
+    //     stream reset, or a truncated-input shutdown abort — claimed the
+    //     decrement). Interlocked because the pump, the request handler, and
+    //     the graceful-close path race for the transitions.
+    private int _exchangeAccounting;
+
     /// <summary>
     /// Send-side flow-control window — the number of DATA octets we
     /// may transmit on this stream before the peer credits us with a
@@ -158,6 +168,31 @@ internal sealed class Http2Stream
     /// block is complete and it has not already been dispatched or closed.
     /// </summary>
     public bool IsHeadReady => HeadersCompleted && !ContextDispatched && State != Http2StreamState.Closed;
+
+    /// <summary>
+    /// Marks this stream as counted toward the connection's in-flight exchange
+    /// total for the RFC 9113 §6.8 graceful-close drain. Called by the pump,
+    /// paired with the connection-level increment, immediately before the
+    /// request context is handed to the consumer.
+    /// </summary>
+    public void MarkExchangeCounted()
+    {
+        Interlocked.CompareExchange(ref _exchangeAccounting, 1, 0);
+    }
+
+    /// <summary>
+    /// Atomically claims the single "exchange complete" accounting slot for this
+    /// stream. Returns <see langword="true"/> only for the first caller — and only
+    /// when the stream was previously counted via <see cref="MarkExchangeCounted"/>
+    /// — so the connection decrements its in-flight exchange count at most once
+    /// per counted stream and never for a stream that was refused, reset, or torn
+    /// down before dispatch.
+    /// </summary>
+    /// <returns><see langword="true"/> if the caller won the accounting slot.</returns>
+    public bool TryClaimExchangeAccounting()
+    {
+        return Interlocked.CompareExchange(ref _exchangeAccounting, 2, 1) == 1;
+    }
 
     /// <summary>
     /// Whether the stream has reached the terminal <see cref="Http2StreamState.Closed"/>
@@ -436,7 +471,14 @@ internal sealed class Http2Stream
     /// reading the body observes cancellation — not a clean end-of-stream, which
     /// would let it mistake a truncated body for a complete one.
     /// </summary>
-    public void AbortOnShutdown()
+    /// <returns>
+    /// <see langword="true"/> when the request was actually aborted (its input was
+    /// still incoming — the exchange can no longer complete normally, so the
+    /// graceful-close drain should stop waiting on it); <see langword="false"/>
+    /// when the fully-received request remains answerable and the drain should
+    /// keep waiting for its response.
+    /// </returns>
+    public bool AbortOnShutdown()
     {
         CompleteBody();
 
@@ -446,7 +488,10 @@ internal sealed class Http2Stream
         if (!InputCompleted)
         {
             TryFireAbort();
+            return true;
         }
+
+        return false;
     }
 
     private void CompleteBody()

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Frames/Http3GoAwayFrame.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Frames/Http3GoAwayFrame.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+
+namespace Assimalign.Cohesion.Http.Connections.Internal.Http3.Frames;
+
+/// <summary>
+/// Serializer for the HTTP/3 <c>GOAWAY</c> frame (RFC 9114 §7.2.6). The frame
+/// announces graceful connection shutdown on the control stream: its payload is
+/// a single identifier — for a server, the stream ID of a client-initiated
+/// bidirectional request stream — that marks the boundary of what the endpoint
+/// will process. Requests on streams with an ID less than the announced value
+/// may have been processed; requests at or above it are not (RFC 9114 §5.2).
+/// </summary>
+/// <remarks>
+/// The payload is a QUIC variable-length integer (RFC 9000 §16 / RFC 9114 §5.2),
+/// so unlike the malformed zero-length precursor this frame carries a non-zero
+/// <c>Length</c>. Pure buffer arithmetic — no reflection — matching the AOT
+/// posture of the surrounding transport.
+/// </remarks>
+internal static class Http3GoAwayFrame
+{
+    /// <summary>
+    /// Encodes a complete <c>GOAWAY</c> frame: the frame type (0x07), the payload
+    /// length, and the payload — <paramref name="streamId"/> as a QUIC
+    /// variable-length integer (RFC 9114 §5.2 / §7.2.6).
+    /// </summary>
+    /// <param name="streamId">
+    /// The client-initiated bidirectional stream ID marking the processing
+    /// boundary. Must be non-negative; QUIC stream IDs are unsigned varints.
+    /// </param>
+    /// <returns>The serialized frame bytes, ready to write to the control stream.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="streamId"/> is negative.
+    /// </exception>
+    public static byte[] Encode(long streamId)
+    {
+        if (streamId < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamId), streamId, "An HTTP/3 GOAWAY stream identifier must be non-negative.");
+        }
+
+        // Encode the varint payload first so the frame's Length prefix reflects
+        // the actual encoded width (1, 2, 4, or 8 octets per RFC 9000 §16).
+        using MemoryStream payload = new();
+        QuicVariableLengthInteger.Write(payload, streamId);
+        byte[] payloadBytes = payload.ToArray();
+
+        using MemoryStream frame = new();
+        QuicVariableLengthInteger.Write(frame, (long)Http3FrameType.GoAway);
+        QuicVariableLengthInteger.Write(frame, payloadBytes.Length);
+        frame.Write(payloadBytes, 0, payloadBytes.Length);
+
+        return frame.ToArray();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3Connection.cs
@@ -57,9 +57,21 @@ internal sealed class Http3Connection : HttpConnection
         return new ValueTask<HttpConnectionContext>(Open());
     }
 
-    public override ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        return _connection.DisposeAsync();
+        // RFC 9114 §5.2 — announce graceful shutdown by writing GOAWAY on the
+        // server's control stream before the QUIC CONNECTION_CLOSE, so streams
+        // at or below the announced ID may finish their responses. GOAWAY
+        // emission lives here in the HTTP/3 layer; the connection-first close
+        // ordering (bidirectional streams drained, then CONNECTION_CLOSE, then
+        // the critical unidirectional streams released) stays in the QUIC
+        // driver's DisposeAsync. Emission is best-effort and precedes it.
+        if (_openContext is not null)
+        {
+            await _openContext.SendGoAwayAsync().ConfigureAwait(false);
+        }
+
+        await _connection.DisposeAsync().ConfigureAwait(false);
     }
 
     [SupportedOSPlatformGuard("windows")]

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
@@ -30,6 +30,20 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
     private bool _controlStreamReceived;
     private bool _qpackEncoderStreamReceived;
     private bool _qpackDecoderStreamReceived;
+    // RFC 9114 §5.2 — the number of client-initiated bidirectional request
+    // streams this connection has accepted. At teardown the GOAWAY announces
+    // the lowest stream ID the server will NOT process; with QUIC's
+    // client-bidi numbering (0, 4, 8, …) that boundary is
+    // (accepted count) × 4, so every stream already accepted (IDs below the
+    // boundary) falls inside "may have been processed" while later streams
+    // are rejected. Counted at accept — not at dispatch — so a malformed
+    // stream the server touched and dropped is still inside the boundary and
+    // the client will not retry a request whose side effects may have run.
+    // Mutated with Interlocked from the receive loop; read by the dispose path.
+    private int _processedRequestStreamCount;
+    // Guards single GOAWAY emission across the receive-loop teardown and the
+    // connection dispose path (Interlocked one-shot latch).
+    private int _goAwaySent;
     private readonly IHttpResponseInterceptor[] _responseInterceptors;
     // RFC 9218 §7.2 — the effective priority of request streams the peer has
     // re-prioritized via a control-stream PRIORITY_UPDATE. This is the HTTP/3
@@ -160,6 +174,12 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
 
                     continue;
                 }
+
+                // RFC 9114 §5.2 — this bidirectional stream is now an accepted
+                // request stream; advance the boundary the teardown GOAWAY
+                // announces so it falls inside "may have been processed" whether
+                // it yields a context or is dropped as malformed below.
+                Interlocked.Increment(ref _processedRequestStreamCount);
 
                 RequestReadOutcome outcome = await TryReadRequestAsync(streamConnection, cancellationToken).ConfigureAwait(false);
 
@@ -311,6 +331,72 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
         }
 
         _teardownSource.Dispose();
+    }
+
+    /// <summary>
+    /// Emits the server's <c>GOAWAY</c> frame on the outbound control stream
+    /// (RFC 9114 §5.2 / §7.2.6) to announce graceful shutdown before the QUIC
+    /// connection is closed. The announced identifier is the lowest
+    /// client-initiated bidirectional stream ID the server will not process —
+    /// derived from the count of request streams already accepted using QUIC's
+    /// client-bidi numbering (ID = 4 × <c>n</c>) — so requests at or below the
+    /// highest accepted stream may finish while later streams are rejected.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the control-stream write.</param>
+    /// <returns>A task that completes once the GOAWAY has been written (or skipped).</returns>
+    /// <remarks>
+    /// <para>
+    /// One-shot: repeated calls after the first are no-ops. When the receive loop
+    /// never ran (no control stream was opened) there is nothing to announce and
+    /// the call returns without writing.
+    /// </para>
+    /// <para>
+    /// Best-effort, like the SETTINGS emission: writing GOAWAY requires a live
+    /// control stream, so a wire-level or QUIC failure here is swallowed — the
+    /// connection is tearing down regardless, and the QUIC <c>CONNECTION_CLOSE</c>
+    /// that follows conveys the shutdown even if the frame did not land.
+    /// </para>
+    /// </remarks>
+    internal async Task SendGoAwayAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _goAwaySent, 1) == 1)
+        {
+            return;
+        }
+
+        IConnection? controlStream = _controlStream;
+        if (controlStream is null)
+        {
+            // The server never opened its control stream (the receive loop did
+            // not run), so it advertised no SETTINGS and has no critical stream
+            // to carry GOAWAY. The QUIC close alone tears the connection down.
+            return;
+        }
+
+        try
+        {
+            // RFC 9114 §5.2 — streams with an ID below the announced value may
+            // have been processed. The lowest unprocessed client-initiated
+            // bidirectional stream is (accepted count) × 4.
+            long goAwayStreamId = (long)Volatile.Read(ref _processedRequestStreamCount) * 4L;
+            byte[] frame = Http3GoAwayFrame.Encode(goAwayStreamId);
+            await controlStream.Output.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (QuicException)
+        {
+        }
+        catch (ConnectionException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (Exception ex) when (IsWireLevelFailure(ex))
+        {
+        }
     }
 
     /// <summary>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http2TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http2TransportTests.cs
@@ -126,6 +126,153 @@ public class Http2TransportTests
         lastStreamId.ShouldBe(1u);
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http2: Should drain an in-flight response before completing the connection output")]
+    public async Task Http2_OnGracefulCloseWithInFlightStream_ShouldDrainBeforeCompletingOutput()
+    {
+        // RFC 9113 §6.8 — after GOAWAY, streams already accepted continue to
+        // completion within a bounded drain window before the connection output
+        // is completed. Without the drain, GracefulCloseAsync would complete the
+        // output writer immediately and cut off a response still being written.
+        // The finite input also exercises the pump-exit path: the frame pump
+        // observes end-of-stream during the drain, but the fully-received
+        // request stays answerable (only truncated requests are abandoned), so
+        // the drain keeps holding until the response is sent.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        Http2ConnectionContext http2Context = (Http2ConnectionContext)httpConnectionContext;
+
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext request = enumerator.Current;
+
+        // Begin the graceful close while the request is dispatched but not yet
+        // answered. It emits GOAWAY, then blocks in the bounded drain window
+        // waiting for this in-flight exchange — it MUST NOT complete the output
+        // and cut the response off.
+        Task closeTask = http2Context.GracefulCloseAsync().AsTask();
+        await Task.Delay(100);
+        closeTask.IsCompleted.ShouldBeFalse();
+
+        // Sending the response completes the exchange, which releases the drain
+        // and lets the graceful close finish (completing the output).
+        request.Response.StatusCode = HttpStatusCode.Ok;
+        request.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes("drained"));
+        await httpConnectionContext.SendAsync(request);
+
+        await closeTask;
+
+        // The wire carries the in-flight response's HEADERS + DATA ("drained")
+        // and a graceful GOAWAY(NO_ERROR); the response was not truncated.
+        byte[] output = await connection.ReadOutputAsync();
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(output);
+
+        bool sawResponseData = false;
+        bool sawGoAway = false;
+        foreach ((long frameType, byte[] framePayload) in frames)
+        {
+            if (frameType == 0 && Encoding.UTF8.GetString(framePayload) == "drained")
+            {
+                sawResponseData = true;
+            }
+
+            if (frameType == 7) // GOAWAY
+            {
+                sawGoAway = true;
+                uint errorCode = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(framePayload.AsSpan(4, 4));
+                errorCode.ShouldBe(0u); // NO_ERROR
+            }
+        }
+
+        sawResponseData.ShouldBeTrue();
+        sawGoAway.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http2: Should refuse a new stream after graceful close with RST_STREAM(REFUSED_STREAM)")]
+    public async Task Http2_OnNewStreamAfterGracefulClose_ShouldRefuseWithRstStream()
+    {
+        // RFC 9113 §6.8 — once graceful close has started, a HEADERS frame that
+        // opens a NEW stream is answered with RST_STREAM(REFUSED_STREAM) while
+        // the connection survives to finish draining the streams already
+        // accepted. The client may safely retry the refused request on a fresh
+        // connection (RFC §8.1.4). The input stays live (completeInput: false)
+        // so the frame pump — which deliberately keeps running through the
+        // drain window — processes a stream opened AFTER the close began.
+        byte[] first = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/one", "https", "api.test");
+        TestConnection connection = new(first, completeInput: false);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        Http2ConnectionContext http2Context = (Http2ConnectionContext)httpConnectionContext;
+
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext firstRequest = enumerator.Current;
+        firstRequest.Request.Path.Value.ShouldBe("/one");
+
+        // Start the graceful close (the _gracefulCloseStarted flag is set
+        // synchronously before the first await). Stream 1 is still in flight, so
+        // the drain holds the pump and output open — the connection stays alive
+        // to refuse new streams on the wire.
+        Task closeTask = http2Context.GracefulCloseAsync().AsTask();
+
+        // The peer now opens stream 3 — a NEW stream after graceful close began.
+        // The still-running pump must answer it with RST_STREAM(REFUSED_STREAM).
+        byte[] second = HttpProtocolPayloadFactory.CreateHttp2Request(3, "GET", "/two", "https", "api.test");
+        byte[] secondWithoutPreface = new byte[second.Length - 24];
+        Array.Copy(second, 24, secondWithoutPreface, 0, secondWithoutPreface.Length);
+        await connection.WriteInputAsync(secondWithoutPreface);
+
+        // Accumulate wire output until the refusal appears (each read blocks
+        // until the holder writes more; a partial trailing frame just means
+        // "keep reading"). Bound the wait so a missing refusal fails the test
+        // rather than hanging it.
+        List<byte> accumulated = new();
+        bool sawRefusedStream = false;
+        while (!sawRefusedStream)
+        {
+            Task<byte[]> readTask = connection.ReadOutputAsync();
+            Task completedTask = await Task.WhenAny(readTask, Task.Delay(TimeSpan.FromSeconds(10)));
+            completedTask.ShouldBe(readTask); // expected RST_STREAM(REFUSED_STREAM) on the wire
+            accumulated.AddRange(await readTask);
+
+            try
+            {
+                foreach ((long frameType, byte[] framePayload) in HttpProtocolPayloadFactory.ParseHttp2Frames(accumulated.ToArray()))
+                {
+                    if (frameType == 3 // RST_STREAM
+                        && framePayload.Length == 4
+                        && System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(framePayload) == (uint)Http2ErrorCode.RefusedStream)
+                    {
+                        sawRefusedStream = true;
+                    }
+                }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // A frame is split across reads; accumulate more bytes.
+            }
+        }
+
+        // The refusal happened while the close was still draining — the
+        // connection survived the refused stream to keep serving stream 1.
+        closeTask.IsCompleted.ShouldBeFalse();
+
+        // Answer stream 1 to release the drain and let the close finish.
+        firstRequest.Response.StatusCode = HttpStatusCode.Ok;
+        await httpConnectionContext.SendAsync(firstRequest);
+        await closeTask;
+
+        connection.CompleteInput();
+        sawRefusedStream.ShouldBeTrue();
+    }
+
     [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http2: Should serialize concurrent SendAsync writes without frame interleaving")]
     public async Task Http2_OnConcurrentSendAsync_ShouldNotInterleaveFrames()
     {

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3FrameTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3FrameTests.cs
@@ -1,0 +1,75 @@
+using System;
+
+using Assimalign.Cohesion.Http.Connections.Internal.Http3;
+using Assimalign.Cohesion.Http.Connections.Internal.Http3.Frames;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+public class Http3FrameTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: GOAWAY frame should encode a single-byte stream id as a varint payload")]
+    public void Http3GoAwayFrame_OnSmallStreamId_ShouldEncodeVarintPayload()
+    {
+        // RFC 9114 §7.2.6 — GOAWAY is frame type 0x07, a length prefix, then the
+        // stream id as a QUIC variable-length integer (§5.2). A stream id below
+        // 64 encodes as one octet, so the frame is exactly [0x07, 0x01, id] —
+        // and critically the Length is NON-zero (the precursor was a malformed
+        // zero-length frame).
+        byte[] frame = Http3GoAwayFrame.Encode(4);
+
+        frame.ShouldBe(new byte[] { 0x07, 0x01, 0x04 });
+
+        int index = 0;
+        long frameType = QuicVariableLengthInteger.Decode(frame, ref index);
+        long length = QuicVariableLengthInteger.Decode(frame, ref index);
+        long streamId = QuicVariableLengthInteger.Decode(frame, ref index);
+
+        frameType.ShouldBe((long)Http3FrameType.GoAway);
+        length.ShouldBe(1L);
+        streamId.ShouldBe(4L);
+        index.ShouldBe(frame.Length); // every octet accounted for
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: GOAWAY frame should encode a multi-byte stream id as a two-octet varint")]
+    public void Http3GoAwayFrame_OnLargeStreamId_ShouldEncodeTwoOctetVarint()
+    {
+        // RFC 9000 §16 — a value in [64, 16383] uses the 2-octet varint form
+        // (0x40 prefix), so 8192 encodes as 0x60 0x00 and the frame Length is 2.
+        byte[] frame = Http3GoAwayFrame.Encode(8192);
+
+        frame.ShouldBe(new byte[] { 0x07, 0x02, 0x60, 0x00 });
+
+        int index = 0;
+        long frameType = QuicVariableLengthInteger.Decode(frame, ref index);
+        long length = QuicVariableLengthInteger.Decode(frame, ref index);
+        long streamId = QuicVariableLengthInteger.Decode(frame, ref index);
+
+        frameType.ShouldBe((long)Http3FrameType.GoAway);
+        length.ShouldBe(2L);
+        streamId.ShouldBe(8192L);
+        index.ShouldBe(frame.Length);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: GOAWAY frame should encode stream id zero with a non-zero length")]
+    public void Http3GoAwayFrame_OnZeroStreamId_ShouldStillCarryNonZeroLength()
+    {
+        // A GOAWAY announcing stream id 0 (no request processed) still carries a
+        // one-octet payload — the frame is [0x07, 0x01, 0x00], never a bare
+        // zero-length frame.
+        byte[] frame = Http3GoAwayFrame.Encode(0);
+
+        frame.ShouldBe(new byte[] { 0x07, 0x01, 0x00 });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: GOAWAY frame should reject a negative stream id")]
+    public void Http3GoAwayFrame_OnNegativeStreamId_ShouldThrow()
+    {
+        // QUIC stream identifiers are unsigned varints; a negative value is a
+        // programming error, not a wire value.
+        Should.Throw<ArgumentOutOfRangeException>(() => Http3GoAwayFrame.Encode(-1));
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3TransportTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3TransportTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using Assimalign.Cohesion.Connections;
 using Assimalign.Cohesion.Http.Connections.Internal;
+using Assimalign.Cohesion.Http.Connections.Internal.Http3;
+using Assimalign.Cohesion.Http.Connections.Internal.Http3.Frames;
 using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
 
 using Shouldly;
@@ -280,6 +282,108 @@ public class Http3TransportTests
 
         // ...and the connection then completes cleanly — draining did not error.
         (await enumerator.MoveNextAsync()).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should emit GOAWAY on the control stream before the connection is disposed")]
+    public async Task Http3_OnDispose_ShouldEmitControlStreamGoAwayBeforeClose()
+    {
+        // RFC 9114 §5.2 / §7.2.6 — during connection teardown the server sends
+        // GOAWAY on its control stream (carrying the lowest client-initiated
+        // bidirectional stream id it will not process) before the QUIC
+        // CONNECTION_CLOSE. One request was surfaced (client-bidi stream 0), so
+        // the announced boundary is 4 — stream 0 may complete, streams >= 4 are
+        // rejected.
+        TestConnection request = new(HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/g", "https", "a"));
+        TestMultiplexedConnection connection = new(request);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp3(new TestMultiplexedConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnection httpConnection = await listener.AcceptOrListenAsync();
+        IHttpConnectionContext httpConnectionContext = await httpConnection.OpenAsync();
+
+        // Surface the request so the server opens its control stream (SETTINGS)
+        // and counts one processed request stream.
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+        httpContext.Request.Path.Value.ShouldBe("/g");
+
+        // Dispose the HTTP/3 connection — GOAWAY is written on the control stream
+        // before the underlying multiplexed connection is disposed.
+        await httpConnection.DisposeAsync();
+        connection.IsDisposed.ShouldBeTrue();
+
+        TestConnection? controlStream = connection.ControlStream;
+        controlStream.ShouldNotBeNull();
+
+        (long streamType, IReadOnlyList<(long FrameType, byte[] Payload)> frames) =
+            HttpProtocolPayloadFactory.ParseHttp3UnidirectionalStream(await controlStream!.ReadOutputAsync());
+
+        streamType.ShouldBe(0x00L); // control stream
+
+        // The control stream carries SETTINGS then GOAWAY (0x07).
+        byte[]? goAwayPayload = null;
+        foreach ((long frameType, byte[] payload) in frames)
+        {
+            if (frameType == (long)Http3FrameType.GoAway)
+            {
+                goAwayPayload = payload;
+            }
+        }
+
+        goAwayPayload.ShouldNotBeNull();
+        goAwayPayload!.Length.ShouldBeGreaterThan(0); // RFC 9114 §5.2 varint payload
+
+        int index = 0;
+        long announcedStreamId = QuicVariableLengthInteger.Decode(goAwayPayload, ref index);
+        announcedStreamId.ShouldBe(4L);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should announce the processed-stream boundary in the teardown GOAWAY")]
+    public async Task Http3_OnDisposeAfterTwoRequests_GoAwayShouldAnnounceProcessedBoundary()
+    {
+        // RFC 9114 §5.2 — the GOAWAY id marks the boundary of what was processed:
+        // streams below it may have been processed, streams at or above it are
+        // rejected. Two requests surfaced (client-bidi streams 0 and 4), so the
+        // announced boundary is 8: streams 0 and 4 may finish, stream 8+ will not.
+        TestConnection first = new(HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/1", "https", "a"));
+        TestConnection second = new(HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/2", "https", "a"));
+        TestMultiplexedConnection connection = new(first, second);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp3(new TestMultiplexedConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnection httpConnection = await listener.AcceptOrListenAsync();
+        IHttpConnectionContext httpConnectionContext = await httpConnection.OpenAsync();
+
+        await using (IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator())
+        {
+            (await enumerator.MoveNextAsync()).ShouldBeTrue();
+            enumerator.Current.Request.Path.Value.ShouldBe("/1");
+            (await enumerator.MoveNextAsync()).ShouldBeTrue();
+            enumerator.Current.Request.Path.Value.ShouldBe("/2");
+        }
+
+        await httpConnection.DisposeAsync();
+
+        TestConnection? controlStream = connection.ControlStream;
+        controlStream.ShouldNotBeNull();
+
+        (_, IReadOnlyList<(long FrameType, byte[] Payload)> frames) =
+            HttpProtocolPayloadFactory.ParseHttp3UnidirectionalStream(await controlStream!.ReadOutputAsync());
+
+        byte[]? goAwayPayload = null;
+        foreach ((long frameType, byte[] payload) in frames)
+        {
+            if (frameType == (long)Http3FrameType.GoAway)
+            {
+                goAwayPayload = payload;
+            }
+        }
+
+        goAwayPayload.ShouldNotBeNull();
+        int index = 0;
+        long announcedStreamId = QuicVariableLengthInteger.Decode(goAwayPayload!, ref index);
+        announcedStreamId.ShouldBe(8L);
     }
 
     [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should decode a Huffman-coded request field section")]


### PR DESCRIPTION
## Summary

Completes the graceful GOAWAY story on both HTTP versions (RFC 9113 §6.8 for h2, RFC 9114 §3.3/§5.2 for h3). Stage 2 · Lane A. Unblocked by #748 (h3 server control stream, merged as #802).

> **Rebased onto the merged transport wave** (#849 flow-control frame pump, #845 streaming response path, #846 RFC 9218 write scheduler, #848 QPACK dynamic table) — the drain is re-implemented on the pump architecture, and all of that wave's functionality is preserved (its full test suites pass unchanged).

### HTTP/2 — bounded stream-drain window on the frame-pump architecture
`Http2ConnectionContext.GracefulCloseAsync` previously stopped the frame pump, emitted `GOAWAY(NO_ERROR)`, and completed the connection output **immediately** — cutting off any response a handler was still writing (and, post-#849, killing send-credit and aborting request bodies first). It now:

1. **Refuses new streams** — `_gracefulCloseStarted` still answers a HEADERS opening a new stream with `RST_STREAM(REFUSED_STREAM)` while the connection survives (previously untested; now covered by a test that injects the new stream *live, mid-drain*).
2. **Emits `GOAWAY(NO_ERROR)` while the pump keeps running** — the RFC 9218 write scheduler serializes it against pump writes; the last-stream-id is snapshotted under the stream-table lock so the concurrent pump can't skew it (refused streams never bump it, keeping the snapshot exact).
3. **Drains, bounded** — waits for dispatched exchanges to finish before teardown, capped by a fixed internal window. The pump deliberately stays alive through the drain: it feeds in-flight request bodies, replenishes send-window credit for streaming writers parked on flow control, refuses new streams on the wire, and observes peer resets that release the drain early.
4. **Stops the pump, then completes the output** (the #686 ordering preserved).

Exchange accounting is a tri-state interlocked latch on `Http2Stream`: counted at pump dispatch, released exactly once via the `RemoveStreamAsync` funnel (buffered + streaming response completion, local reset, peer reset) or the pump-exit shutdown abort — which releases **truncated requests only**. A fully-received request stays counted after pump EOF because its handler can still respond through the pump-independent write path — the zero-drop rolling-restart case, covered by a test that drains across pump end-of-stream.

### HTTP/3 — GOAWAY frame + lifecycle
- **`Http3GoAwayFrame.Encode`** (new) serializes the frame with the RFC 9114 §5.2 variable-length-integer stream-id payload (**non-zero Length**), replacing the malformed zero-length `PrepareGoAway` precursor named in the issue.
- **`Http3ConnectionContext.SendGoAwayAsync`** (one-shot, best-effort) writes GOAWAY on the server's retained control stream. The announced id is `4 × (accepted bidi request streams)` — counted at **accept**, not dispatch, so a malformed stream the server touched still falls inside "may have been processed" and the client won't retry a request whose side effects may have run. (The connection abstraction exposes only an opaque `ConnectionId`, hence the count-based derivation.)
- **`Http3Connection.DisposeAsync`** emits GOAWAY before delegating to the QUIC connection dispose. `CONNECTION_CLOSE` ordering and critical-stream close discipline stay in the QUIC driver, untouched.

## Acceptance criteria
- [x] h2: streams already accepted complete within a bounded drain window before output is completed; test proves in-flight HEADERS/DATA on the wire + GOAWAY(NO_ERROR).
- [x] h2: new stream after graceful close → `RST_STREAM(REFUSED_STREAM)`, connection survives draining (deterministic via live input injection mid-drain).
- [x] h3: GOAWAY encodes the §5.2 varint stream-id payload with non-zero Length (serialized-bytes unit tests).
- [x] h3: server emits GOAWAY on the control stream before `CONNECTION_CLOSE` (test asserts GOAWAY on the control stream + disposal).
- [x] h3: streams at/below the announced id may complete; above are not processed (boundary = 4·(accepted count), asserted for one and two requests).
- [x] Existing `Http2_OnDispose_ShouldEmitGracefulGoAway` still passes.
- [x] `docs/DESIGN.md` non-goals no longer list GOAWAY-driven drain as future work for the shipped parts (server GOAWAY emission ships; reacting to a **peer** GOAWAY — the client role — remains scoped out). Also corrected the lifecycle note that said graceful close stops the pump before GOAWAY.

## Tests
`dotnet test` on `Assimalign.Cohesion.Http.Connections.Tests`: **325 passed, 0 failed** — the full post-wave suite (flow-control backpressure, response streaming, RFC 9218 priorities, QPACK dynamic table, write scheduler, h1 upgrade) plus 8 new tests; the timing-sensitive drain/refusal tests were run repeatedly without flakes.

## Standards
File-scoped namespaces, internal types only (Lane A), no `Microsoft.Extensions.*`, AOT-safe (buffer arithmetic / `Interlocked` / `TaskCompletionSource`, no reflection), XML docs, Shouldly tests with the `Cohesion Test [Http.Connections] - ...` DisplayName convention, `docs/DESIGN.md` updated in the same change.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)