### PR TITLE
[L01.01.11.29] Implement RFC 9530 Digest Fields (Content-Digest, Repr-Digest, Want-*)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/README.md
@@ -1,0 +1,10 @@
+# Assimalign.Cohesion.Http.DigestFields
+
+RFC 9530 integrity digest fields for the Cohesion HTTP stack — `Content-Digest`, `Repr-Digest`,
+`Want-Content-Digest`, `Want-Repr-Digest` — as structured-fields value objects with `sha-256` /
+`sha-512` computation and verification (BCL incremental hashing, no reflection), plus an opt-in
+server-side request verifier that rejects a `Content-Digest` mismatch with `400` at parse time
+through the core `IHttpRequestInterceptor` seam.
+
+- `docs/OVERVIEW.md` — purpose, dependencies, usage
+- `docs/DESIGN.md` — value-model placement, algorithm registry, verification model, and scope

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/DESIGN.md
@@ -1,0 +1,167 @@
+# Assimalign.Cohesion.Http.DigestFields — Design
+
+RFC 9530 integrity digest fields — `Content-Digest`, `Repr-Digest`, `Want-Content-Digest`,
+`Want-Repr-Digest` — for the Cohesion HTTP stack: a value model over the structured-fields
+toolkit, `sha-256` / `sha-512` computation and verification via BCL incremental hashing, and an
+opt-in server-side request verifier. The package references only core `Assimalign.Cohesion.Http`;
+the transport never references this package.
+
+## Why this package exists (seams vs. features)
+
+RFC 9530 digest fields are RFC 9651 Structured Field **Dictionaries** (`algorithm=:base64:` for a
+digest, `algorithm=preference` for a want-preference). Two facts from the core design pin the
+placement of this code:
+
+- **Core parses field *names*, not field *values*.** `HttpFieldRules` is name-classification only;
+  the core `docs/DESIGN.md` names "Per-field parsers" as an explicit non-goal and says value
+  parsing "belongs to the field-specific consumer, and the shared toolkit those consumers build on
+  for RFC 9651 syntax is the structured-fields surface." This package is exactly that consumer: it
+  builds on core's `StructuredFieldDictionary` and adds only the digest-specific schema on top.
+- **Features live outside core.** Like `Http.Cookies`, `Http.Sessions`, and `Http.RequestLimits`,
+  a concrete capability (here: integrity verification) ships in its own package that references
+  only core. The one core change this feature needs — the four well-known `HttpHeaderKey` entries —
+  is a name registration, not a parser, so it stays in core alongside the existing ~90 keys.
+
+The result: core gained four header-name constants; everything else (the value model, the
+algorithm registry, computation, verification, and the interceptor) lives here.
+
+## The value model
+
+`HttpDigestField` is the parsed value of a `Content-Digest` **or** `Repr-Digest` field, and
+`HttpWantDigestField` the parsed value of a `Want-Content-Digest` **or** `Want-Repr-Digest` field.
+One model serves both members of each pair because the syntax is identical — the only difference is
+which header carries it and what the digest is taken over. Both are thin readonly-struct views over
+the parsed `StructuredFieldDictionary`, which stays the round-trip source of truth (so `Serialize()`
+reproduces every member, including ones the typed view skips).
+
+Design points:
+
+- **`TryParse` is the primary entry point** (span- and `HttpHeaderValue`-based, `out string? error`
+  for diagnosis); `Parse` is a throwing convenience that raises the area-scoped
+  `HttpDigestException`. This matches the structured-fields toolkit and the Lane-B "value objects
+  with `TryParse`/serialize, span-based, AOT-safe" guardrail.
+- **Malformed is rejected, not silently dropped.** Bad base64, missing colons, or unbalanced quotes
+  fail in the structured-fields parser; a member whose value is not a Byte Sequence (for a digest)
+  or not an Integer (for a want-preference) is rejected by the schema check with a diagnostic naming
+  the offending key; an empty dictionary is rejected. Each surfaces through `TryParse` returning
+  `false` with an `error`.
+- **All entries are preserved.** A multi-algorithm value (`sha-256=:…:, sha-512=:…:`) keeps every
+  entry in order. Deprecated algorithms are surfaced as typed `Entries` (so a recipient can *see*
+  them) but flagged unsupported; unregistered-but-well-formed keys are preserved for round-tripping
+  and omitted from the typed view, because a recipient cannot act on an unknown algorithm (RFC 9530
+  says to ignore unknown algorithms — not to reject the whole field).
+
+## The algorithm registry
+
+`HttpDigestAlgorithm` models the RFC 9530 §5.2 registry as a small readonly struct keyed by the
+lowercase registry token. It draws the line the RFC draws:
+
+- **Active / supported** — `sha-256`, `sha-512`. `IsSupported` is `true`; these are the only
+  algorithms used to **generate or validate** a digest.
+- **Deprecated / recognized** — `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`. `TryParse` recognizes
+  them (so they can be enumerated and skipped), but `IsSupported` is `false` and any attempt to hash
+  with one throws. This is the RFC 9530 §5 rule ("recognized on parse but never used") made
+  type-level: `CreateIncrementalHash()` — the only path to a hash — exists only for supported
+  algorithms.
+
+There is deliberately no provider/string-name indirection: supported algorithms map to fixed
+`HashAlgorithmName` values and BCL `IncrementalHash`, so the whole path is AOT-safe (no reflection,
+no runtime codegen, no dynamic algorithm lookup).
+
+## Computation and the incremental digester
+
+Every hash goes through `IncrementalHash`, honoring the issue's "BCL incremental hashing, no
+reflection" mandate literally:
+
+- `HttpDigestField.ForContent(content, …algorithms)` computes a buffered digest for one or more
+  algorithms.
+- `HttpDigestField.ForContentAsync(stream, algorithms, ct)` reads a stream **once**, feeding every
+  algorithm's running hash in parallel — the path a caller uses when the representation is only
+  available as a stream.
+- `HttpContentDigester` is the standalone "hash as you write" primitive: a server feeds each body
+  chunk to `Append` as it writes it to the wire and calls `ToField()` when the body is complete.
+  `ToField()` snapshots without resetting, so it can be called at end-of-body without preventing
+  further appends. This is the primitive behind the **trailer-borne** case: for a streamed body the
+  digest is not known until the body is written, so it is emitted in the trailer section. RFC 9530
+  permits digest fields as trailers, and `HttpFieldRules.IsProhibitedInTrailers` does **not** list
+  them (a guard test locks this) — so the field is trailer-eligible today even though wiring the
+  actual trailer emission into a streaming response writer rides on the streaming write path (#769).
+
+## Server-side verification (the interceptor)
+
+`HttpDigestFields.CreateContentDigestVerifier()` returns a stateless `IHttpRequestInterceptor` — the
+#818 request-parse seam is the natural hook for request-digest validation. It hooks `OnRequestBody`:
+
+1. No `Content-Digest`, or only deprecated/unregistered algorithms → pass the body through
+   untouched (nothing this library can verify).
+2. A malformed `Content-Digest` → **fail closed**: throw `HttpRequestRejectedException(400)`. RFC
+   9530 §2 lets a recipient either ignore or reject; an *operator-installed verifier* should not
+   silently accept a field it cannot parse.
+3. Otherwise read the (already-materialized) body in full, verify it against every supported digest
+   with constant-time comparison (`CryptographicOperations.FixedTimeEquals`), and either reject a
+   mismatch with `HttpRequestRejectedException(400)` or return a replay stream so the application
+   still observes the body.
+
+Why **eager buffer-and-replay** rather than a lazy verify-on-read wrapper: on HTTP/1.1 the transport
+already materializes the request body into a `MemoryStream` **before** the body hook runs (and
+catches `HttpRequestRejectedException` on its parse path, ahead of dispatch). Reading it there is
+therefore CPU-only — it adds no wire wait — and lets the rejection happen **before the application
+runs**, so the transport answers a real, deterministic `400` and closes the connection. A lazy
+wrapper would only discover the mismatch mid-application-read, after dispatch, where there is no
+transport-answered status today. The cost is one transient extra copy of the body, bounded by the
+`HttpServerLimits.MaxRequestBodySize` cap the request-limits package enforces.
+
+Two ordering/coverage notes:
+
+- **Register the verifier first**, before any content-decoding interceptor. `Content-Digest` is
+  taken over the message content *as received* (post-content-coding, on the wire), so it must be
+  verified against the raw body before a decompression wrapper transforms it.
+- **HTTP/1.1 today.** Like `Http.RequestLimits`, the interceptor seam runs on the h1 parse path;
+  h2/h3 invoke head/body hooks from their own context-construction sites as that wiring lands
+  (#819). Nothing here implies h2/h3 request-digest verification exists yet.
+
+The replay stream (`HttpDigestReplayStream`) owns the original body it replaced and disposes it when
+the exchange disposes the stream chain, honoring the seam's "a wrapper owns the stream it wraps"
+contract.
+
+## Response stamping and Want-* honoring
+
+`HttpDigestFieldsExtensions` adds the response-side surface:
+
+- `IHttpResponse.SetContentDigest(content, algorithm)` / `SetContentDigest(field)` stamp an explicit
+  or precomputed digest.
+- `IHttpResponse.SetContentDigest(content)` honors the request's `Want-Content-Digest`:
+  `HttpWantDigestField.TrySelectPreferred` picks the supported algorithm the client most prefers
+  (highest integer preference, ties broken toward the stronger algorithm, `0`/deprecated skipped),
+  falling back to `sha-256` when the request expressed no usable preference.
+- `IHttpRequest.TryGetContentDigest` / `TryGetWantContentDigest` read the parsed request fields for
+  application code that wants them directly.
+
+## Content-Digest vs Repr-Digest scope
+
+`Content-Digest` is implemented end-to-end: header key, value model, computation, and server-side
+verification. `Repr-Digest` is **modeled** — the header key exists and `HttpDigestField` parses,
+serializes, and computes it identically — but the verifier does not enforce it, because
+representation-data reconstruction depends on content-coding and range layers not yet present.
+When those land, `Repr-Digest` verification is a drop-in on the same value model.
+
+## AOT posture
+
+No reflection, no runtime codegen. Hashing is BCL `IncrementalHash` over fixed `HashAlgorithmName`
+values; comparison is `CryptographicOperations.FixedTimeEquals`; parsing reuses core's span-based
+structured-fields parser. The value objects are readonly structs over a single array; the
+interceptor is one small allocation per verified request (only when a `Content-Digest` is present
+and verifiable).
+
+## Non-goals and honest gaps
+
+- **Repr-Digest enforcement** — modeled, not verified (see above).
+- **HTTP/2 / HTTP/3 request verification** — the interceptor seam is h1-only at runtime today
+  (mirrors `Http.RequestLimits`); h2/h3 hook wiring is tracked follow-up (#819).
+- **Trailer emission into a streaming response** — the `HttpContentDigester` primitive and the
+  trailer-eligibility guarantee exist; wiring the emitted field into the response trailer section
+  rides on the streaming write path (#769).
+- **HTTP Message Signatures** — RFC 9530 digests are a building block for signatures covering
+  content; the signature layer itself is out of scope.
+- **Client-side response-digest verification** — this package's verifier is a server-side request
+  surface; the value model and `VerifyContent` are reusable by a future client consumer.

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/OVERVIEW.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/OVERVIEW.md
@@ -1,0 +1,41 @@
+# Assimalign.Cohesion.Http.DigestFields — Overview
+
+RFC 9530 integrity digest fields for the Cohesion HTTP stack: `Content-Digest`, `Repr-Digest`,
+`Want-Content-Digest`, and `Want-Repr-Digest`. Provides a structured-fields value model, `sha-256`
+/ `sha-512` computation and verification over BCL incremental hashing, and an opt-in server-side
+request verifier.
+
+- **Depends on:** `Assimalign.Cohesion.Http` (core) only — for the four `HttpHeaderKey` constants,
+  the `StructuredFieldDictionary` toolkit the field values are built on, and the
+  `IHttpRequestInterceptor` request-parse seam. The server transport
+  (`Assimalign.Cohesion.Http.Connections`) never references this package.
+- **Value model:** `HttpDigestField` (a `Content-Digest` / `Repr-Digest` value — an ordered map of
+  algorithm → digest bytes) and `HttpWantDigestField` (a `Want-*` value — algorithm → integer
+  preference). Both offer span-based `TryParse`/`Serialize` and are AOT-safe.
+- **Algorithms:** `HttpDigestAlgorithm` — `sha-256` and `sha-512` are supported for compute and
+  verify; the deprecated registry entries (`md5`, `sha`, `unixsum`, `unixcksum`) are recognized on
+  parse but never used (RFC 9530 §5).
+- **Server verification:** `HttpDigestFields.CreateContentDigestVerifier()` returns an
+  `IHttpRequestInterceptor` the composition root registers on its listener; it verifies an inbound
+  `Content-Digest` against the request body and rejects a mismatch (or a malformed field) with
+  `400 Bad Request` before dispatch.
+- **Response stamping:** `IHttpResponse.SetContentDigest(...)` computes and stamps `Content-Digest`,
+  honoring the request's `Want-Content-Digest` preference ordering; `HttpContentDigester` is the
+  incremental "hash as you write" primitive for the trailer-borne streamed case.
+
+Usage:
+
+```csharp
+// Server: verify inbound Content-Digest (register before any content-decoding interceptor).
+listenerOptions.Interceptors.Add(HttpDigestFields.CreateContentDigestVerifier());
+
+// Response: stamp Content-Digest, honoring the client's Want-Content-Digest.
+context.Response.SetContentDigest(body);
+
+// Value model: parse and verify directly.
+if (HttpDigestField.TryParse(headerValue, out var field) &&
+    field.VerifyContent(content) == HttpDigestVerificationResult.Matched) { /* trusted */ }
+```
+
+See `docs/DESIGN.md` for the placement rationale (consumer of the structured-fields toolkit), the
+eager buffer-and-replay verification model, and the Content-Digest vs Repr-Digest scope.

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Assimalign.Cohesion.Http.DigestFields.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Assimalign.Cohesion.Http.DigestFields.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- Deviates from AGENTS.md namespace-matches-assembly per design decision:
+		     HTTP feature packages surface their types in the Assimalign.Cohesion.Http
+		     namespace so IHttpContext / IHttpResponse extension members are discoverable
+		     without an extra using (matches Assimalign.Cohesion.Http.RequestLimits and
+		     Assimalign.Cohesion.Http.ExtendedConnect). -->
+		<RootNamespace>Assimalign.Cohesion.Http</RootNamespace>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+	</ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Extensions/HttpDigestFieldsExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Extensions/HttpDigestFieldsExtensions.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Convenience members for reading RFC 9530 digest fields off a request and stamping
+/// <c>Content-Digest</c> onto a response.
+/// </summary>
+public static class HttpDigestFieldsExtensions
+{
+    extension(IHttpRequest request)
+    {
+        /// <summary>
+        /// Attempts to read and parse the request's <c>Content-Digest</c> field.
+        /// </summary>
+        /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+        /// <returns><see langword="true"/> if the header was present and well-formed; otherwise <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        public bool TryGetContentDigest(out HttpDigestField field)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Headers.TryGetValue(HttpHeaderKey.ContentDigest, out HttpHeaderValue value) && !value.IsEmpty)
+            {
+                return HttpDigestField.TryParse(value, out field);
+            }
+            field = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to read and parse the request's <c>Want-Content-Digest</c> preference field.
+        /// </summary>
+        /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+        /// <returns><see langword="true"/> if the header was present and well-formed; otherwise <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        public bool TryGetWantContentDigest(out HttpWantDigestField field)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Headers.TryGetValue(HttpHeaderKey.WantContentDigest, out HttpHeaderValue value) && !value.IsEmpty)
+            {
+                return HttpWantDigestField.TryParse(value, out field);
+            }
+            field = default;
+            return false;
+        }
+    }
+
+    extension(IHttpResponse response)
+    {
+        /// <summary>
+        /// Stamps the response with a precomputed <c>Content-Digest</c> field, replacing any existing
+        /// value.
+        /// </summary>
+        /// <param name="field">The digest field to write.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="response"/> is <see langword="null"/>.</exception>
+        public void SetContentDigest(HttpDigestField field)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            response.Headers[HttpHeaderKey.ContentDigest] = field.Serialize();
+        }
+
+        /// <summary>
+        /// Computes <c>Content-Digest</c> over <paramref name="content"/> with an explicit algorithm
+        /// and stamps it onto the response.
+        /// </summary>
+        /// <param name="content">The response content to hash.</param>
+        /// <param name="algorithm">The algorithm to compute with; must be supported.</param>
+        /// <returns>The digest field written to the response.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="response"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="algorithm"/> is not supported for computation.</exception>
+        public HttpDigestField SetContentDigest(ReadOnlySpan<byte> content, HttpDigestAlgorithm algorithm)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            HttpDigestField field = HttpDigestField.ForContent(content, algorithm);
+            response.Headers[HttpHeaderKey.ContentDigest] = field.Serialize();
+            return field;
+        }
+
+        /// <summary>
+        /// Computes <c>Content-Digest</c> over <paramref name="content"/> and stamps it onto the
+        /// response, honoring the request's <c>Want-Content-Digest</c> preference when present. Falls
+        /// back to <see cref="HttpDigestAlgorithm.Sha256"/> when the request expressed no supported,
+        /// acceptable preference.
+        /// </summary>
+        /// <param name="content">The response content to hash.</param>
+        /// <returns>The digest field written to the response.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="response"/> is <see langword="null"/>.</exception>
+        public HttpDigestField SetContentDigest(ReadOnlySpan<byte> content)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+
+            HttpDigestAlgorithm algorithm = HttpDigestAlgorithm.Sha256;
+            if (response.HttpContext.Request.TryGetWantContentDigest(out HttpWantDigestField want)
+                && want.TrySelectPreferred(out HttpDigestAlgorithm preferred))
+            {
+                algorithm = preferred;
+            }
+
+            HttpDigestField field = HttpDigestField.ForContent(content, algorithm);
+            response.Headers[HttpHeaderKey.ContentDigest] = field.Serialize();
+            return field;
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpContentDigester.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpContentDigester.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Computes one or more RFC 9530 digests incrementally as content is written, then produces the
+/// <see cref="HttpDigestField"/> for it. This is the "hash as you write" primitive behind
+/// streamed-response digest stamping: a server feeds each body chunk to <see cref="Append"/> as it
+/// writes it to the wire, and calls <see cref="ToField"/> once the body is complete to obtain the
+/// field value to emit — for a streamed body, in the trailer section (RFC 9530 permits digest
+/// fields as trailers, and <see cref="HttpFieldRules.IsProhibitedInTrailers"/> does not reject
+/// them).
+/// </summary>
+/// <remarks>
+/// Backed by the BCL <see cref="IncrementalHash"/> per algorithm, so no full-body buffer is
+/// required and the type stays AOT-safe. <see cref="ToField"/> snapshots the digest without
+/// resetting, so it may be called at the end of the body (the normal case) without preventing
+/// further appends. The instance owns its hashes and must be disposed.
+/// </remarks>
+public sealed class HttpContentDigester : IDisposable
+{
+    private readonly HttpDigestAlgorithm[] _algorithms;
+    private readonly IncrementalHash[] _hashes;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a digester for the given algorithms.
+    /// </summary>
+    /// <param name="algorithms">The algorithms to compute; each must be supported.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="algorithms"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="algorithms"/> is empty or contains an unsupported algorithm.</exception>
+    public HttpContentDigester(params HttpDigestAlgorithm[] algorithms)
+    {
+        ArgumentNullException.ThrowIfNull(algorithms);
+        if (algorithms.Length == 0)
+        {
+            throw new ArgumentException("At least one algorithm is required.", nameof(algorithms));
+        }
+
+        _algorithms = new HttpDigestAlgorithm[algorithms.Length];
+        _hashes = new IncrementalHash[algorithms.Length];
+        for (int i = 0; i < algorithms.Length; i++)
+        {
+            HttpDigestAlgorithm algorithm = algorithms[i];
+            if (!algorithm.IsSupported)
+            {
+                // Dispose the hashes already created before failing.
+                for (int j = 0; j < i; j++)
+                {
+                    _hashes[j].Dispose();
+                }
+                throw new ArgumentException(
+                    $"The digest algorithm '{algorithm}' cannot be used to generate a digest (RFC 9530 §5).", nameof(algorithms));
+            }
+            _algorithms[i] = algorithm;
+            _hashes[i] = algorithm.CreateIncrementalHash();
+        }
+    }
+
+    /// <summary>
+    /// Feeds the next span of content to every algorithm's running hash.
+    /// </summary>
+    /// <param name="content">The content chunk written to the body.</param>
+    /// <exception cref="ObjectDisposedException">The digester has been disposed.</exception>
+    public void Append(ReadOnlySpan<byte> content)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        foreach (IncrementalHash hash in _hashes)
+        {
+            hash.AppendData(content);
+        }
+    }
+
+    /// <summary>
+    /// Produces the digest field for the content appended so far, without resetting the running
+    /// hashes.
+    /// </summary>
+    /// <returns>The digest field carrying one entry per configured algorithm.</returns>
+    /// <exception cref="ObjectDisposedException">The digester has been disposed.</exception>
+    public HttpDigestField ToField()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var entries = new HttpDigestEntry[_algorithms.Length];
+        Span<byte> buffer = stackalloc byte[64]; // large enough for SHA-512
+        for (int i = 0; i < _algorithms.Length; i++)
+        {
+            int written = _hashes[i].GetCurrentHash(buffer);
+            entries[i] = new HttpDigestEntry(_algorithms[i], buffer[..written].ToArray());
+        }
+        return HttpDigestField.FromEntries(entries);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        foreach (IncrementalHash hash in _hashes)
+        {
+            hash.Dispose();
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestAlgorithm.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestAlgorithm.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// An algorithm from the RFC 9530 &#167; 5.2 "Hash Algorithms for HTTP Digest Fields" registry,
+/// identified by its lowercase registry key (for example <c>sha-256</c>). The type distinguishes
+/// the two <em>active</em>, cryptographically sound algorithms this library computes and verifies
+/// with — <see cref="Sha256"/> and <see cref="Sha512"/> — from the <em>deprecated/insecure</em>
+/// registry entries (<see cref="Md5"/>, <see cref="Sha"/>, <see cref="UnixSum"/>,
+/// <see cref="UnixCksum"/>) which are recognized on parse but, per RFC 9530 &#167; 5, are never
+/// used to generate or validate a digest.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A digest field carries a dictionary keyed by these algorithm tokens. Recognizing an insecure
+/// entry (rather than rejecting it) lets a recipient enumerate every offered algorithm and pick a
+/// supported one, while <see cref="IsSupported"/> gates whether the entry may participate in
+/// computation or verification.
+/// </para>
+/// <para>
+/// The default value of this struct is the unregistered, unsupported algorithm
+/// (<see cref="IsRegistered"/> and <see cref="IsSupported"/> are both <see langword="false"/>);
+/// it models a token that is syntactically a valid key but absent from the registry.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{Key,nq} (Supported={IsSupported})")]
+public readonly struct HttpDigestAlgorithm : IEquatable<HttpDigestAlgorithm>
+{
+    private readonly string? _key;
+    private readonly HashAlgorithmName _hashName;
+    private readonly int _hashLengthInBytes;
+    private readonly bool _supported;
+
+    private HttpDigestAlgorithm(string key, bool supported, HashAlgorithmName hashName, int hashLengthInBytes)
+    {
+        _key = key;
+        _supported = supported;
+        _hashName = hashName;
+        _hashLengthInBytes = hashLengthInBytes;
+    }
+
+    /// <summary>The <c>sha-256</c> algorithm (RFC 9530 &#167; 5.2) — active, supported.</summary>
+    public static HttpDigestAlgorithm Sha256 { get; } = new("sha-256", supported: true, HashAlgorithmName.SHA256, 32);
+
+    /// <summary>The <c>sha-512</c> algorithm (RFC 9530 &#167; 5.2) — active, supported.</summary>
+    public static HttpDigestAlgorithm Sha512 { get; } = new("sha-512", supported: true, HashAlgorithmName.SHA512, 64);
+
+    /// <summary>The <c>md5</c> algorithm (RFC 9530 &#167; 5.2) — deprecated, recognized but never used.</summary>
+    public static HttpDigestAlgorithm Md5 { get; } = new("md5", supported: false, default, 0);
+
+    /// <summary>The <c>sha</c> (SHA-1) algorithm (RFC 9530 &#167; 5.2) — deprecated, recognized but never used.</summary>
+    public static HttpDigestAlgorithm Sha { get; } = new("sha", supported: false, default, 0);
+
+    /// <summary>The <c>unixsum</c> algorithm (RFC 9530 &#167; 5.2) — deprecated, recognized but never used.</summary>
+    public static HttpDigestAlgorithm UnixSum { get; } = new("unixsum", supported: false, default, 0);
+
+    /// <summary>The <c>unixcksum</c> algorithm (RFC 9530 &#167; 5.2) — deprecated, recognized but never used.</summary>
+    public static HttpDigestAlgorithm UnixCksum { get; } = new("unixcksum", supported: false, default, 0);
+
+    /// <summary>
+    /// Gets the lowercase RFC 9530 registry key for this algorithm (for example <c>sha-256</c>),
+    /// or <see langword="null"/> for the default (unregistered) value.
+    /// </summary>
+    public string? Key => _key;
+
+    /// <summary>
+    /// Gets a value indicating whether this algorithm is a recognized RFC 9530 registry entry —
+    /// <see langword="true"/> for both the active algorithms and the deprecated ones.
+    /// </summary>
+    public bool IsRegistered => _key is not null;
+
+    /// <summary>
+    /// Gets a value indicating whether this library will compute and verify digests with this
+    /// algorithm. Only the active, cryptographically sound algorithms (<see cref="Sha256"/>,
+    /// <see cref="Sha512"/>) are supported; deprecated entries return <see langword="false"/>.
+    /// </summary>
+    public bool IsSupported => _supported;
+
+    /// <summary>
+    /// Gets the length, in bytes, of a digest produced by this algorithm (32 for
+    /// <see cref="Sha256"/>, 64 for <see cref="Sha512"/>). Zero for unsupported algorithms.
+    /// </summary>
+    public int HashLengthInBytes => _hashLengthInBytes;
+
+    /// <summary>
+    /// Attempts to resolve a registry key (case-insensitive) to a recognized
+    /// <see cref="HttpDigestAlgorithm"/>, including the deprecated entries.
+    /// </summary>
+    /// <param name="key">The algorithm key, for example <c>sha-256</c>.</param>
+    /// <param name="algorithm">
+    /// When this method returns <see langword="true"/>, the recognized algorithm; otherwise the
+    /// default value.
+    /// </param>
+    /// <returns><see langword="true"/> if <paramref name="key"/> is a registered algorithm; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(string? key, out HttpDigestAlgorithm algorithm)
+    {
+        // RFC 9530 keys are lowercase tokens; match case-insensitively and canonicalize to the
+        // well-known instance so callers always observe the registry spelling.
+        if (key is not null)
+        {
+            if (string.Equals(key, "sha-256", StringComparison.OrdinalIgnoreCase)) { algorithm = Sha256; return true; }
+            if (string.Equals(key, "sha-512", StringComparison.OrdinalIgnoreCase)) { algorithm = Sha512; return true; }
+            if (string.Equals(key, "md5", StringComparison.OrdinalIgnoreCase)) { algorithm = Md5; return true; }
+            if (string.Equals(key, "sha", StringComparison.OrdinalIgnoreCase)) { algorithm = Sha; return true; }
+            if (string.Equals(key, "unixsum", StringComparison.OrdinalIgnoreCase)) { algorithm = UnixSum; return true; }
+            if (string.Equals(key, "unixcksum", StringComparison.OrdinalIgnoreCase)) { algorithm = UnixCksum; return true; }
+        }
+
+        algorithm = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Creates a BCL <see cref="IncrementalHash"/> for this algorithm. Used by the computation and
+    /// verification paths so hashing is always incremental and AOT-safe (no reflection, no runtime
+    /// codegen).
+    /// </summary>
+    /// <returns>An incremental hash for this algorithm; the caller owns and disposes it.</returns>
+    /// <exception cref="NotSupportedException">This algorithm is not supported for hashing (<see cref="IsSupported"/> is <see langword="false"/>).</exception>
+    internal IncrementalHash CreateIncrementalHash()
+    {
+        if (!_supported)
+        {
+            throw new NotSupportedException(
+                $"The digest algorithm '{_key ?? "(unregistered)"}' is not supported for computation or validation (RFC 9530 §5).");
+        }
+
+        return IncrementalHash.CreateHash(_hashName);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(HttpDigestAlgorithm other) => string.Equals(_key, other._key, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpDigestAlgorithm other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => _key is null ? 0 : StringComparer.Ordinal.GetHashCode(_key);
+
+    /// <summary>Returns the algorithm's registry key, or <c>"(unregistered)"</c> for the default value.</summary>
+    /// <returns>The registry key.</returns>
+    public override string ToString() => _key ?? "(unregistered)";
+
+    /// <summary>Determines whether two algorithms are the same registry entry.</summary>
+    /// <param name="left">The first algorithm.</param>
+    /// <param name="right">The second algorithm.</param>
+    /// <returns><see langword="true"/> if the algorithms are equal; otherwise <see langword="false"/>.</returns>
+    public static bool operator ==(HttpDigestAlgorithm left, HttpDigestAlgorithm right) => left.Equals(right);
+
+    /// <summary>Determines whether two algorithms are different registry entries.</summary>
+    /// <param name="left">The first algorithm.</param>
+    /// <param name="right">The second algorithm.</param>
+    /// <returns><see langword="true"/> if the algorithms are unequal; otherwise <see langword="false"/>.</returns>
+    public static bool operator !=(HttpDigestAlgorithm left, HttpDigestAlgorithm right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestEntry.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestEntry.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single entry of an RFC 9530 digest field: an <see cref="HttpDigestAlgorithm"/> paired with
+/// the raw (already base64-decoded) digest bytes carried for it. Order within a
+/// <see cref="HttpDigestField"/> mirrors the field's dictionary order.
+/// </summary>
+/// <remarks>
+/// Entries for deprecated algorithms (<see cref="HttpDigestAlgorithm.IsSupported"/> is
+/// <see langword="false"/>) and for unregistered algorithm keys are preserved so a recipient sees
+/// every offered digest; the verification path simply skips the ones it cannot compute.
+/// </remarks>
+public readonly struct HttpDigestEntry
+{
+    /// <summary>
+    /// Initializes a new <see cref="HttpDigestEntry"/>.
+    /// </summary>
+    /// <param name="algorithm">The algorithm the digest was computed with.</param>
+    /// <param name="digest">The raw digest bytes (base64-decoded).</param>
+    public HttpDigestEntry(HttpDigestAlgorithm algorithm, ReadOnlyMemory<byte> digest)
+    {
+        Algorithm = algorithm;
+        Digest = digest;
+    }
+
+    /// <summary>Gets the algorithm the digest was computed with.</summary>
+    public HttpDigestAlgorithm Algorithm { get; }
+
+    /// <summary>Gets the raw digest bytes (base64-decoded on parse; base64-encoded on serialize).</summary>
+    public ReadOnlyMemory<byte> Digest { get; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestException.cs
@@ -1,0 +1,25 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Thrown when an RFC 9530 digest field cannot be parsed into a well-formed
+/// <see cref="HttpDigestField"/> or <see cref="HttpWantDigestField"/> — for example malformed
+/// structured-field syntax, a digest member that is not a Byte Sequence, or a preference member
+/// that is not an Integer. Inherits the HTTP area exception root <see cref="HttpException"/>.
+/// </summary>
+/// <remarks>
+/// Only the throwing <c>Parse</c> convenience methods raise this; the <c>TryParse</c> methods
+/// report the same failures through a <see langword="bool"/> result and an <c>out</c> diagnostic
+/// string, and are the preferred entry point on hot parse paths.
+/// </remarks>
+public sealed class HttpDigestException : HttpException
+{
+    /// <summary>
+    /// Initializes a new <see cref="HttpDigestException"/> with a diagnostic message.
+    /// </summary>
+    /// <param name="message">A human-readable description of why the digest field was rejected.</param>
+    public HttpDigestException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidHeader;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestField.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestField.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The parsed value of an RFC 9530 <c>Content-Digest</c> or <c>Repr-Digest</c> field: an ordered
+/// map from <see cref="HttpDigestAlgorithm"/> to the raw digest bytes computed for it. Both fields
+/// share the identical RFC 9651 Structured Field Dictionary syntax
+/// (<c>algorithm=:base64-digest:</c>), so one value model serves both; the distinction is only
+/// which header name carries it and what the digest is taken over (message content versus
+/// representation data).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The field is a thin, allocation-light view over the parsed dictionary. Parsing preserves every
+/// well-formed dictionary member — including deprecated and unregistered algorithms — so a
+/// recipient can enumerate every offered digest; <see cref="Entries"/> surfaces the recognized
+/// registry entries in field order, and verification silently skips any whose algorithm this
+/// library cannot compute (RFC 9530 &#167; 5).
+/// </para>
+/// <para>
+/// Hashing is always performed through the BCL <see cref="IncrementalHash"/> primitive, so the
+/// type is AOT-safe: no reflection, no runtime code generation, no algorithm lookup by string into
+/// a provider model.
+/// </para>
+/// </remarks>
+public readonly struct HttpDigestField
+{
+    private readonly StructuredFieldDictionary _dictionary;
+    private readonly HttpDigestEntry[]? _entries;
+
+    private HttpDigestField(StructuredFieldDictionary dictionary, HttpDigestEntry[] entries)
+    {
+        _dictionary = dictionary;
+        _entries = entries;
+    }
+
+    /// <summary>
+    /// Gets the recognized RFC 9530 registry entries carried by the field, in field order. Members
+    /// whose algorithm key is not in the registry are preserved for round-tripping (see
+    /// <see cref="Serialize"/>) but are not surfaced here, because a recipient cannot act on an
+    /// unknown algorithm.
+    /// </summary>
+    public IReadOnlyList<HttpDigestEntry> Entries => _entries ?? Array.Empty<HttpDigestEntry>();
+
+    /// <summary>
+    /// Gets a value indicating whether the field carries at least one entry whose algorithm this
+    /// library can compute and verify with (<see cref="HttpDigestAlgorithm.IsSupported"/>).
+    /// </summary>
+    public bool HasSupportedAlgorithm
+    {
+        get
+        {
+            if (_entries is not null)
+            {
+                foreach (HttpDigestEntry entry in _entries)
+                {
+                    if (entry.Algorithm.IsSupported)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to get the digest bytes carried for <paramref name="algorithm"/>.
+    /// </summary>
+    /// <param name="algorithm">The algorithm to look up.</param>
+    /// <param name="digest">When this method returns <see langword="true"/>, the raw digest bytes.</param>
+    /// <returns><see langword="true"/> if the field carried a digest for the algorithm; otherwise <see langword="false"/>.</returns>
+    public bool TryGetDigest(HttpDigestAlgorithm algorithm, out ReadOnlyMemory<byte> digest)
+    {
+        if (_entries is not null && algorithm.IsRegistered)
+        {
+            foreach (HttpDigestEntry entry in _entries)
+            {
+                if (entry.Algorithm == algorithm)
+                {
+                    digest = entry.Digest;
+                    return true;
+                }
+            }
+        }
+        digest = default;
+        return false;
+    }
+
+    #region Parse
+
+    /// <summary>
+    /// Parses a <c>Content-Digest</c> / <c>Repr-Digest</c> field value.
+    /// </summary>
+    /// <param name="value">The header field value; repeated field lines are combined by comma per RFC 9651 &#167; 4.2.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(HttpHeaderValue value, out HttpDigestField field)
+        => TryParse(value.Value.AsSpan(), out field, out _);
+
+    /// <summary>
+    /// Parses a <c>Content-Digest</c> / <c>Repr-Digest</c> field value.
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out HttpDigestField field)
+        => TryParse(input, out field, out _);
+
+    /// <summary>
+    /// Parses a <c>Content-Digest</c> / <c>Repr-Digest</c> field value. On failure,
+    /// <paramref name="error"/> carries a human-readable explanation (malformed dictionary syntax,
+    /// a member that is not a Byte Sequence, or an empty field).
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <param name="error">When this method returns <see langword="false"/>, the reason parsing failed.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out HttpDigestField field, out string? error)
+    {
+        field = default;
+
+        if (!StructuredFieldDictionary.TryParse(input, out StructuredFieldDictionary dictionary, out error))
+        {
+            // Malformed structured-field syntax: bad base64, missing colons, unbalanced quotes, etc.
+            return false;
+        }
+
+        if (dictionary.Count == 0)
+        {
+            error = "A digest field must carry at least one algorithm entry.";
+            return false;
+        }
+
+        var entries = new List<HttpDigestEntry>(dictionary.Count);
+        foreach (KeyValuePair<string, StructuredFieldMember> member in dictionary)
+        {
+            StructuredFieldMember value = member.Value;
+            if (value.IsInnerList || value.Item.Value.Type != StructuredFieldType.ByteSequence)
+            {
+                error = $"The digest field member '{member.Key}' must be a Byte Sequence (RFC 9530 §2/§3).";
+                return false;
+            }
+
+            if (HttpDigestAlgorithm.TryParse(member.Key, out HttpDigestAlgorithm algorithm))
+            {
+                entries.Add(new HttpDigestEntry(algorithm, value.Item.Value.AsByteSequence()));
+            }
+            // An unregistered but well-formed key is preserved in `dictionary` for round-tripping
+            // and deliberately not surfaced as a typed entry (RFC 9530: ignore unknown algorithms).
+        }
+
+        field = new HttpDigestField(dictionary, entries.ToArray());
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a <c>Content-Digest</c> / <c>Repr-Digest</c> field value, throwing on failure.
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <returns>The parsed field.</returns>
+    /// <exception cref="HttpDigestException">The value is not a well-formed digest field.</exception>
+    public static HttpDigestField Parse(ReadOnlySpan<char> input)
+    {
+        if (!TryParse(input, out HttpDigestField field, out string? error))
+        {
+            throw new HttpDigestException(error ?? "Malformed digest field.");
+        }
+        return field;
+    }
+
+    #endregion
+
+    #region Compute
+
+    /// <summary>
+    /// Computes a digest field over <paramref name="content"/> for a single algorithm.
+    /// </summary>
+    /// <param name="content">The content to hash (the message content for <c>Content-Digest</c>).</param>
+    /// <param name="algorithm">The algorithm to compute with; must be supported.</param>
+    /// <returns>A field carrying the single computed digest.</returns>
+    /// <exception cref="ArgumentException"><paramref name="algorithm"/> is not supported for computation.</exception>
+    public static HttpDigestField ForContent(ReadOnlySpan<byte> content, HttpDigestAlgorithm algorithm)
+    {
+        if (!algorithm.IsSupported)
+        {
+            throw new ArgumentException(
+                $"The digest algorithm '{algorithm}' cannot be used to generate a digest (RFC 9530 §5).", nameof(algorithm));
+        }
+
+        var entry = new HttpDigestEntry(algorithm, ComputeHash(algorithm, content));
+        return FromEntries(new[] { entry });
+    }
+
+    /// <summary>
+    /// Computes a digest field over <paramref name="content"/> for one or more algorithms, in the
+    /// given order.
+    /// </summary>
+    /// <param name="content">The content to hash.</param>
+    /// <param name="algorithms">The algorithms to compute with; each must be supported.</param>
+    /// <returns>A field carrying a digest per algorithm.</returns>
+    /// <exception cref="ArgumentException"><paramref name="algorithms"/> is empty or contains an unsupported algorithm.</exception>
+    public static HttpDigestField ForContent(ReadOnlySpan<byte> content, params HttpDigestAlgorithm[] algorithms)
+    {
+        ArgumentNullException.ThrowIfNull(algorithms);
+        if (algorithms.Length == 0)
+        {
+            throw new ArgumentException("At least one algorithm is required.", nameof(algorithms));
+        }
+
+        var entries = new HttpDigestEntry[algorithms.Length];
+        for (int i = 0; i < algorithms.Length; i++)
+        {
+            HttpDigestAlgorithm algorithm = algorithms[i];
+            if (!algorithm.IsSupported)
+            {
+                throw new ArgumentException(
+                    $"The digest algorithm '{algorithm}' cannot be used to generate a digest (RFC 9530 §5).", nameof(algorithms));
+            }
+            entries[i] = new HttpDigestEntry(algorithm, ComputeHash(algorithm, content));
+        }
+
+        return FromEntries(entries);
+    }
+
+    /// <summary>
+    /// Computes a digest field over a stream for one or more algorithms, reading the stream once
+    /// and feeding every algorithm's incremental hash in parallel.
+    /// </summary>
+    /// <param name="content">The forward-only content stream to hash.</param>
+    /// <param name="algorithms">The algorithms to compute with; each must be supported.</param>
+    /// <param name="cancellationToken">A token to cancel the read.</param>
+    /// <returns>A field carrying a digest per algorithm.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="algorithms"/> is empty or contains an unsupported algorithm.</exception>
+    public static async ValueTask<HttpDigestField> ForContentAsync(
+        Stream content,
+        HttpDigestAlgorithm[] algorithms,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(algorithms);
+        if (algorithms.Length == 0)
+        {
+            throw new ArgumentException("At least one algorithm is required.", nameof(algorithms));
+        }
+
+        using var digester = new HttpContentDigester(algorithms);
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = await content.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            digester.Append(buffer.AsSpan(0, read));
+        }
+        return digester.ToField();
+    }
+
+    internal static HttpDigestField FromEntries(HttpDigestEntry[] entries)
+    {
+        var members = new KeyValuePair<string, StructuredFieldMember>[entries.Length];
+        for (int i = 0; i < entries.Length; i++)
+        {
+            HttpDigestEntry entry = entries[i];
+            StructuredFieldBareItem bytes = StructuredFieldBareItem.FromByteSequence(entry.Digest.Span);
+            members[i] = new KeyValuePair<string, StructuredFieldMember>(
+                entry.Algorithm.Key!,
+                StructuredFieldMember.FromItem(new StructuredFieldItem(bytes)));
+        }
+        return new HttpDigestField(new StructuredFieldDictionary(members), entries);
+    }
+
+    internal static byte[] ComputeHash(HttpDigestAlgorithm algorithm, ReadOnlySpan<byte> content)
+    {
+        using IncrementalHash hash = algorithm.CreateIncrementalHash();
+        hash.AppendData(content);
+        return hash.GetHashAndReset();
+    }
+
+    #endregion
+
+    #region Verify
+
+    /// <summary>
+    /// Verifies <paramref name="content"/> against every supported digest the field carries.
+    /// </summary>
+    /// <param name="content">The content to hash and compare.</param>
+    /// <returns>
+    /// <see cref="HttpDigestVerificationResult.Matched"/> if all supported digests match,
+    /// <see cref="HttpDigestVerificationResult.Mismatched"/> if any supported digest differs, or
+    /// <see cref="HttpDigestVerificationResult.NoSupportedAlgorithm"/> if the field carried nothing
+    /// this library can verify with.
+    /// </returns>
+    public HttpDigestVerificationResult VerifyContent(ReadOnlySpan<byte> content)
+    {
+        if (_entries is null)
+        {
+            return HttpDigestVerificationResult.NoSupportedAlgorithm;
+        }
+
+        bool anySupported = false;
+        Span<byte> computed = stackalloc byte[64]; // large enough for SHA-512
+        foreach (HttpDigestEntry entry in _entries)
+        {
+            if (!entry.Algorithm.IsSupported)
+            {
+                continue;
+            }
+            anySupported = true;
+
+            using IncrementalHash hash = entry.Algorithm.CreateIncrementalHash();
+            hash.AppendData(content);
+            int written = hash.GetHashAndReset(computed);
+
+            // FixedTimeEquals is length-checked, so a truncated or oversized digest value is a
+            // mismatch rather than an exception.
+            if (!CryptographicOperations.FixedTimeEquals(computed[..written], entry.Digest.Span))
+            {
+                return HttpDigestVerificationResult.Mismatched;
+            }
+        }
+
+        return anySupported
+            ? HttpDigestVerificationResult.Matched
+            : HttpDigestVerificationResult.NoSupportedAlgorithm;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Serializes the field to its RFC 9651 &#167; 4.1.2 canonical dictionary form
+    /// (<c>algorithm=:base64:</c>, comma-separated). Round-trips every member preserved on parse,
+    /// including deprecated and unregistered algorithms.
+    /// </summary>
+    /// <returns>The canonical field value, or the empty string for the default instance.</returns>
+    public string Serialize() => _dictionary.Serialize();
+
+    /// <inheritdoc />
+    public override string ToString() => Serialize();
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestFields.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestFields.cs
@@ -1,0 +1,23 @@
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Entry points for the RFC 9530 digest-fields feature package: the server-side
+/// <c>Content-Digest</c> verifier the composition root installs on its listener.
+/// </summary>
+public static class HttpDigestFields
+{
+    /// <summary>
+    /// Creates the stateless <see cref="IHttpRequestInterceptor"/> that verifies an inbound
+    /// <c>Content-Digest</c> against the request body and rejects a mismatch (or a malformed field)
+    /// with <c>400 Bad Request</c> before the request is dispatched.
+    /// </summary>
+    /// <remarks>
+    /// Register it <em>before</em> any content-decoding interceptor, because <c>Content-Digest</c>
+    /// is taken over the message content as received. A request with no <c>Content-Digest</c>, or
+    /// one offering only deprecated/unregistered algorithms, is passed through unverified.
+    /// </remarks>
+    /// <returns>The content-digest verification interceptor.</returns>
+    public static IHttpRequestInterceptor CreateContentDigestVerifier() => new HttpContentDigestInterceptor();
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestVerificationResult.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestVerificationResult.cs
@@ -1,0 +1,26 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The outcome of verifying content against the algorithms carried by an
+/// <see cref="HttpDigestField"/>.
+/// </summary>
+public enum HttpDigestVerificationResult
+{
+    /// <summary>
+    /// The field carried no algorithm this library can verify with — either it was empty or every
+    /// entry used a deprecated/unregistered algorithm. Per RFC 9530 a recipient that cannot verify
+    /// treats the digest as absent rather than as a failure.
+    /// </summary>
+    NoSupportedAlgorithm = 0,
+
+    /// <summary>
+    /// Every supported digest the field carried matched the computed digest of the content.
+    /// </summary>
+    Matched,
+
+    /// <summary>
+    /// At least one supported digest the field carried did not match the computed digest of the
+    /// content. The content must be treated as corrupt or tampered.
+    /// </summary>
+    Mismatched,
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpWantDigestField.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpWantDigestField.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The parsed value of an RFC 9530 <c>Want-Content-Digest</c> or <c>Want-Repr-Digest</c> field: an
+/// ordered map from <see cref="HttpDigestAlgorithm"/> to the integer preference the peer expressed
+/// for it. Both fields share the identical RFC 9651 Structured Field Dictionary syntax
+/// (<c>algorithm=preference</c>), so one value model serves both.
+/// </summary>
+/// <remarks>
+/// The primary consumer is response generation: a server that received <c>Want-Content-Digest</c>
+/// calls <see cref="TrySelectPreferred"/> to pick the supported algorithm the client most prefers,
+/// then stamps <c>Content-Digest</c> with it. Deprecated and unregistered algorithms are preserved
+/// on parse but are never selected, because this library cannot compute them.
+/// </remarks>
+public readonly struct HttpWantDigestField
+{
+    private readonly StructuredFieldDictionary _dictionary;
+    private readonly HttpWantDigestPreference[]? _preferences;
+
+    private HttpWantDigestField(StructuredFieldDictionary dictionary, HttpWantDigestPreference[] preferences)
+    {
+        _dictionary = dictionary;
+        _preferences = preferences;
+    }
+
+    /// <summary>
+    /// Gets the recognized preferences carried by the field, in field order. Members whose
+    /// algorithm key is not in the registry are preserved for round-tripping but not surfaced here.
+    /// </summary>
+    public IReadOnlyList<HttpWantDigestPreference> Preferences => _preferences ?? Array.Empty<HttpWantDigestPreference>();
+
+    #region Parse
+
+    /// <summary>
+    /// Parses a <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c> field value.
+    /// </summary>
+    /// <param name="value">The header field value; repeated field lines are combined by comma per RFC 9651 &#167; 4.2.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(HttpHeaderValue value, out HttpWantDigestField field)
+        => TryParse(value.Value.AsSpan(), out field, out _);
+
+    /// <summary>
+    /// Parses a <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c> field value.
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out HttpWantDigestField field)
+        => TryParse(input, out field, out _);
+
+    /// <summary>
+    /// Parses a <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c> field value. On failure,
+    /// <paramref name="error"/> carries a human-readable explanation (malformed dictionary syntax,
+    /// a member that is not an Integer, or an empty field).
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <param name="field">When this method returns <see langword="true"/>, the parsed field.</param>
+    /// <param name="error">When this method returns <see langword="false"/>, the reason parsing failed.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out HttpWantDigestField field, out string? error)
+    {
+        field = default;
+
+        if (!StructuredFieldDictionary.TryParse(input, out StructuredFieldDictionary dictionary, out error))
+        {
+            return false;
+        }
+
+        if (dictionary.Count == 0)
+        {
+            error = "A want-digest field must carry at least one algorithm preference.";
+            return false;
+        }
+
+        var preferences = new List<HttpWantDigestPreference>(dictionary.Count);
+        foreach (KeyValuePair<string, StructuredFieldMember> member in dictionary)
+        {
+            StructuredFieldMember value = member.Value;
+            if (value.IsInnerList || value.Item.Value.Type != StructuredFieldType.Integer)
+            {
+                error = $"The want-digest field member '{member.Key}' must be an Integer preference (RFC 9530 §4).";
+                return false;
+            }
+
+            if (HttpDigestAlgorithm.TryParse(member.Key, out HttpDigestAlgorithm algorithm))
+            {
+                preferences.Add(new HttpWantDigestPreference(algorithm, value.Item.Value.AsInteger()));
+            }
+        }
+
+        field = new HttpWantDigestField(dictionary, preferences.ToArray());
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c> field value, throwing on failure.
+    /// </summary>
+    /// <param name="input">The field value to parse.</param>
+    /// <returns>The parsed field.</returns>
+    /// <exception cref="HttpDigestException">The value is not a well-formed want-digest field.</exception>
+    public static HttpWantDigestField Parse(ReadOnlySpan<char> input)
+    {
+        if (!TryParse(input, out HttpWantDigestField field, out string? error))
+        {
+            throw new HttpDigestException(error ?? "Malformed want-digest field.");
+        }
+        return field;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Builds a want-digest field from an explicit set of preferences (for a server or client that
+    /// wants to emit <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c>).
+    /// </summary>
+    /// <param name="preferences">The preferences, in the order they should appear.</param>
+    /// <returns>The want-digest field.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="preferences"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="preferences"/> is empty or references an unregistered algorithm.</exception>
+    public static HttpWantDigestField Create(params HttpWantDigestPreference[] preferences)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        if (preferences.Length == 0)
+        {
+            throw new ArgumentException("At least one preference is required.", nameof(preferences));
+        }
+
+        var members = new KeyValuePair<string, StructuredFieldMember>[preferences.Length];
+        for (int i = 0; i < preferences.Length; i++)
+        {
+            HttpWantDigestPreference preference = preferences[i];
+            if (!preference.Algorithm.IsRegistered)
+            {
+                throw new ArgumentException("A want-digest preference must reference a registered algorithm.", nameof(preferences));
+            }
+            StructuredFieldBareItem integer = StructuredFieldBareItem.FromInteger(preference.Preference);
+            members[i] = new KeyValuePair<string, StructuredFieldMember>(
+                preference.Algorithm.Key!,
+                StructuredFieldMember.FromItem(new StructuredFieldItem(integer)));
+        }
+
+        return new HttpWantDigestField(new StructuredFieldDictionary(members), (HttpWantDigestPreference[])preferences.Clone());
+    }
+
+    /// <summary>
+    /// Selects the supported algorithm the peer most prefers — the acceptable
+    /// (<see cref="HttpWantDigestPreference.IsAcceptable"/>) preference with the highest value,
+    /// breaking ties toward the stronger algorithm. Deprecated and unregistered algorithms are
+    /// never selected.
+    /// </summary>
+    /// <param name="algorithm">When this method returns <see langword="true"/>, the selected algorithm.</param>
+    /// <returns><see langword="true"/> if a supported, acceptable algorithm was found; otherwise <see langword="false"/>.</returns>
+    public bool TrySelectPreferred(out HttpDigestAlgorithm algorithm)
+    {
+        algorithm = default;
+        if (_preferences is null)
+        {
+            return false;
+        }
+
+        long bestPreference = 0;
+        int bestStrength = -1;
+        bool found = false;
+        foreach (HttpWantDigestPreference preference in _preferences)
+        {
+            if (!preference.Algorithm.IsSupported || !preference.IsAcceptable)
+            {
+                continue;
+            }
+
+            int strength = preference.Algorithm.HashLengthInBytes;
+            if (!found
+                || preference.Preference > bestPreference
+                || (preference.Preference == bestPreference && strength > bestStrength))
+            {
+                found = true;
+                bestPreference = preference.Preference;
+                bestStrength = strength;
+                algorithm = preference.Algorithm;
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Serializes the field to its RFC 9651 &#167; 4.1.2 canonical dictionary form
+    /// (<c>algorithm=preference</c>, comma-separated).
+    /// </summary>
+    /// <returns>The canonical field value, or the empty string for the default instance.</returns>
+    public string Serialize() => _dictionary.Serialize();
+
+    /// <inheritdoc />
+    public override string ToString() => Serialize();
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpWantDigestPreference.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpWantDigestPreference.cs
@@ -1,0 +1,30 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single preference from an RFC 9530 <c>Want-Content-Digest</c> / <c>Want-Repr-Digest</c>
+/// field: an <see cref="HttpDigestAlgorithm"/> paired with the integer preference the peer
+/// expressed for it. A preference of <c>0</c> (or below) means the algorithm is not acceptable;
+/// higher values indicate greater preference (RFC 9530 &#167; 4).
+/// </summary>
+public readonly struct HttpWantDigestPreference
+{
+    /// <summary>
+    /// Initializes a new <see cref="HttpWantDigestPreference"/>.
+    /// </summary>
+    /// <param name="algorithm">The algorithm the preference applies to.</param>
+    /// <param name="preference">The integer preference (0 = not acceptable, higher = more preferred).</param>
+    public HttpWantDigestPreference(HttpDigestAlgorithm algorithm, long preference)
+    {
+        Algorithm = algorithm;
+        Preference = preference;
+    }
+
+    /// <summary>Gets the algorithm the preference applies to.</summary>
+    public HttpDigestAlgorithm Algorithm { get; }
+
+    /// <summary>Gets the integer preference; 0 or below means the algorithm is not acceptable.</summary>
+    public long Preference { get; }
+
+    /// <summary>Gets a value indicating whether the peer finds this algorithm acceptable (<see cref="Preference"/> &gt; 0).</summary>
+    public bool IsAcceptable => Preference > 0;
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpContentDigestInterceptor.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpContentDigestInterceptor.cs
@@ -1,0 +1,68 @@
+using System.IO;
+
+namespace Assimalign.Cohesion.Http.Internal;
+
+/// <summary>
+/// A request-parse interceptor that verifies an inbound <c>Content-Digest</c> against the request
+/// body and rejects a mismatch with <c>400 Bad Request</c>. Opt-in: the composition root installs
+/// it via <see cref="HttpDigestFields.CreateContentDigestVerifier"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stateless — one instance serves every connection and request on the listener. It hooks
+/// <c>OnRequestBody</c>: by the time that hook runs the transport has materialized the request
+/// body, so the verifier reads it in full (to hash it), compares against every supported digest the
+/// field carries, and returns a replay stream so the application still observes the body. A
+/// mismatch, or a malformed <c>Content-Digest</c> field, throws
+/// <see cref="HttpRequestRejectedException"/> before dispatch, which the transport answers with the
+/// carried status and then closes the connection.
+/// </para>
+/// <para>
+/// Verification is over the message content <em>as received</em> (RFC 9530 <c>Content-Digest</c>
+/// semantics), so this interceptor must run before any content-decoding interceptor. A request
+/// carrying no <c>Content-Digest</c>, or only deprecated/unknown algorithms, passes through
+/// untouched.
+/// </para>
+/// </remarks>
+internal sealed class HttpContentDigestInterceptor : IHttpRequestInterceptor
+{
+    /// <inheritdoc />
+    public Stream OnRequestBody(HttpRequestInterceptorContext context, Stream body)
+    {
+        if (!context.Headers.TryGetValue(HttpHeaderKey.ContentDigest, out HttpHeaderValue raw) || raw.IsEmpty)
+        {
+            return body;
+        }
+
+        if (!HttpDigestField.TryParse(raw, out HttpDigestField field))
+        {
+            // Fail closed: an operator-installed verifier treats a malformed Content-Digest as a
+            // client error rather than silently ignoring it (RFC 9530 §2 permits either).
+            throw new HttpRequestRejectedException(HttpStatusCode.BadRequest, "The Content-Digest field is malformed.");
+        }
+
+        if (!field.HasSupportedAlgorithm)
+        {
+            // Only deprecated/unregistered algorithms were offered — nothing this library verifies.
+            return body;
+        }
+
+        byte[] content = ReadToEnd(body);
+        if (field.VerifyContent(content) == HttpDigestVerificationResult.Mismatched)
+        {
+            throw new HttpRequestRejectedException(
+                HttpStatusCode.BadRequest, "The request body does not match its Content-Digest.");
+        }
+
+        return new HttpDigestReplayStream(content, body);
+    }
+
+    private static byte[] ReadToEnd(Stream body)
+    {
+        // Read from the current position so a body another interceptor already partially consumed
+        // is not double-counted; the verifier is registered first, so it observes the pristine body.
+        using var buffer = new MemoryStream();
+        body.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpDigestReplayStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpDigestReplayStream.cs
@@ -1,0 +1,28 @@
+using System.IO;
+
+namespace Assimalign.Cohesion.Http.Internal;
+
+/// <summary>
+/// A read-only, seekable replay of a request body that the digest verifier fully consumed to hash
+/// it. Reads serve the buffered bytes; disposal also disposes the original wrapped body so the
+/// interceptor honors the seam's "a wrapper owns the stream it wraps" contract.
+/// </summary>
+internal sealed class HttpDigestReplayStream : MemoryStream
+{
+    private readonly Stream _original;
+
+    public HttpDigestReplayStream(byte[] content, Stream original)
+        : base(content, writable: false)
+    {
+        _original = original;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _original.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/Assimalign.Cohesion.Http.DigestFields.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/Assimalign.Cohesion.Http.DigestFields.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>disable</ImplicitUsings>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.DigestFields" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigestInterceptorTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigestInterceptorTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Text;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpContentDigestInterceptorTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A matching Content-Digest passes and replays the body")]
+    public void OnRequestBody_Match_ReplaysBody()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("payload that matches its digest");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpRequestInterceptorContext context = CreateContext(digest);
+        IHttpRequestInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+
+        Stream result = verifier.OnRequestBody(context, new MemoryStream(content));
+
+        using var read = new MemoryStream();
+        result.CopyTo(read);
+        read.ToArray().ShouldBe(content);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A mismatched Content-Digest is rejected with 400")]
+    public void OnRequestBody_Mismatch_Rejects400()
+    {
+        byte[] declared = Encoding.UTF8.GetBytes("the original payload");
+        byte[] actual = Encoding.UTF8.GetBytes("the tampered payload");
+        string digest = HttpDigestField.ForContent(declared, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpRequestInterceptorContext context = CreateContext(digest);
+        IHttpRequestInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+
+        HttpRequestRejectedException ex = Should.Throw<HttpRequestRejectedException>(
+            () => verifier.OnRequestBody(context, new MemoryStream(actual)));
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A malformed Content-Digest is rejected with 400")]
+    public void OnRequestBody_Malformed_Rejects400()
+    {
+        HttpRequestInterceptorContext context = CreateContext("sha-256=12345");
+        IHttpRequestInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+
+        HttpRequestRejectedException ex = Should.Throw<HttpRequestRejectedException>(
+            () => verifier.OnRequestBody(context, new MemoryStream(new byte[] { 1, 2, 3 })));
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: No Content-Digest passes through unchanged")]
+    public void OnRequestBody_NoDigest_PassesThrough()
+    {
+        HttpRequestInterceptorContext context = CreateContext(contentDigest: null);
+        IHttpRequestInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+        using var body = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        Stream result = verifier.OnRequestBody(context, body);
+
+        result.ShouldBeSameAs(body);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A deprecated-only Content-Digest passes through unverified")]
+    public void OnRequestBody_DeprecatedOnly_PassesThrough()
+    {
+        HttpRequestInterceptorContext context = CreateContext("md5=:1B2M2Y8AsgTpgAmY7PhCfg==:");
+        IHttpRequestInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+        using var body = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        Stream result = verifier.OnRequestBody(context, body);
+
+        result.ShouldBeSameAs(body);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: Disposing the replay stream disposes the original body")]
+    public void OnRequestBody_ReplayDisposal_DisposesOriginal()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("owned body");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpRequestInterceptorContext context = CreateContext(digest);
+        var original = new TrackingStream(content);
+
+        Stream result = HttpDigestFields.CreateContentDigestVerifier().OnRequestBody(context, original);
+        result.Dispose();
+
+        original.IsDisposed.ShouldBeTrue();
+    }
+
+    private static HttpRequestInterceptorContext CreateContext(string? contentDigest)
+    {
+        var headers = new HttpHeaderCollection();
+        if (contentDigest is not null)
+        {
+            headers.Add(HttpHeaderKey.ContentDigest, contentDigest);
+        }
+
+        return new HttpRequestInterceptorContext
+        {
+            Version = HttpVersion.Http11,
+            Method = HttpMethod.Post,
+            Path = new HttpPath("/upload"),
+            Scheme = HttpScheme.Http,
+            Host = new HttpHost("api.test"),
+            Headers = headers.AsReadOnly(),
+            Features = new HttpFeatureCollection(),
+            ConnectionInfo = HttpConnectionInfo.Empty,
+            MaxRequestBodySize = null,
+        };
+    }
+
+    private sealed class TrackingStream : MemoryStream
+    {
+        public TrackingStream(byte[] content) : base(content, writable: false)
+        {
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigesterTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigesterTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpContentDigesterTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Digester: Incremental appends equal a one-shot digest")]
+    public void Append_InChunks_EqualsOneShot()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("the quick brown fox jumps over the lazy dog");
+
+        using var digester = new HttpContentDigester(HttpDigestAlgorithm.Sha256, HttpDigestAlgorithm.Sha512);
+        digester.Append(content.AsSpan(0, 10));
+        digester.Append(content.AsSpan(10, 20));
+        digester.Append(content.AsSpan(30));
+        HttpDigestField incremental = digester.ToField();
+
+        HttpDigestField oneShot = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256, HttpDigestAlgorithm.Sha512);
+        incremental.Serialize().ShouldBe(oneShot.Serialize());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Digester: ToField can be called and still allow further appends")]
+    public void ToField_DoesNotReset()
+    {
+        byte[] first = Encoding.UTF8.GetBytes("abc");
+        byte[] second = Encoding.UTF8.GetBytes("def");
+
+        using var digester = new HttpContentDigester(HttpDigestAlgorithm.Sha256);
+        digester.Append(first);
+        HttpDigestField afterFirst = digester.ToField();
+        digester.Append(second);
+        HttpDigestField afterBoth = digester.ToField();
+
+        afterFirst.Serialize().ShouldBe(HttpDigestField.ForContent(first, HttpDigestAlgorithm.Sha256).Serialize());
+        afterBoth.Serialize().ShouldBe(HttpDigestField.ForContent(Encoding.UTF8.GetBytes("abcdef"), HttpDigestAlgorithm.Sha256).Serialize());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Digester: Rejects an unsupported algorithm")]
+    public void Constructor_UnsupportedAlgorithm_Throws()
+    {
+        Should.Throw<ArgumentException>(() => new HttpContentDigester(HttpDigestAlgorithm.Sha256, HttpDigestAlgorithm.Md5));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Digester: Use after dispose throws")]
+    public void Append_AfterDispose_Throws()
+    {
+        var digester = new HttpContentDigester(HttpDigestAlgorithm.Sha256);
+        digester.Dispose();
+
+        Should.Throw<ObjectDisposedException>(() => digester.Append(new byte[] { 1 }));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Digester: ForContentAsync over a stream equals the buffered digest")]
+    public async Task ForContentAsync_Stream_EqualsBuffered()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("streamed representation data");
+        using var stream = new MemoryStream(content);
+
+        HttpDigestField streamed = await HttpDigestField.ForContentAsync(
+            stream, new[] { HttpDigestAlgorithm.Sha256 });
+
+        streamed.Serialize().ShouldBe(HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize());
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestAlgorithmTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestAlgorithmTests.cs
@@ -1,0 +1,65 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpDigestAlgorithmTests
+{
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Algorithm: Active algorithms are supported")]
+    [InlineData("sha-256", 32)]
+    [InlineData("sha-512", 64)]
+    public void TryParse_ActiveAlgorithm_IsSupported(string key, int hashLength)
+    {
+        HttpDigestAlgorithm.TryParse(key, out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+
+        algorithm.IsRegistered.ShouldBeTrue();
+        algorithm.IsSupported.ShouldBeTrue();
+        algorithm.Key.ShouldBe(key);
+        algorithm.HashLengthInBytes.ShouldBe(hashLength);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Algorithm: Deprecated entries are recognized but not supported")]
+    [InlineData("md5")]
+    [InlineData("sha")]
+    [InlineData("unixsum")]
+    [InlineData("unixcksum")]
+    public void TryParse_DeprecatedAlgorithm_IsRecognizedButUnsupported(string key)
+    {
+        HttpDigestAlgorithm.TryParse(key, out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+
+        algorithm.IsRegistered.ShouldBeTrue();
+        algorithm.IsSupported.ShouldBeFalse();
+        algorithm.HashLengthInBytes.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Algorithm: Unregistered key is rejected")]
+    public void TryParse_UnregisteredKey_ReturnsFalse()
+    {
+        HttpDigestAlgorithm.TryParse("crc32c", out HttpDigestAlgorithm algorithm).ShouldBeFalse();
+
+        algorithm.IsRegistered.ShouldBeFalse();
+        algorithm.IsSupported.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Algorithm: Key match is case-insensitive and canonicalizes")]
+    public void TryParse_MixedCase_CanonicalizesToRegistryKey()
+    {
+        HttpDigestAlgorithm.TryParse("SHA-256", out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+
+        algorithm.Key.ShouldBe("sha-256");
+        algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Algorithm: Default value is unregistered and unsupported")]
+    public void Default_IsUnregistered()
+    {
+        HttpDigestAlgorithm algorithm = default;
+
+        algorithm.IsRegistered.ShouldBeFalse();
+        algorithm.IsSupported.ShouldBeFalse();
+        algorithm.Key.ShouldBeNull();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestFieldTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestFieldTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpDigestFieldTests
+{
+    // Known-answer vector: base64(SHA-256("")) — a widely published constant.
+    private const string EmptySha256Base64 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: Parses a single sha-256 entry and round-trips")]
+    public void TryParse_SingleSha256_RoundTrips()
+    {
+        string value = $"sha-256=:{EmptySha256Base64}:";
+
+        HttpDigestField.TryParse(value, out HttpDigestField field).ShouldBeTrue();
+
+        field.Entries.Count.ShouldBe(1);
+        field.Entries[0].Algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+        field.HasSupportedAlgorithm.ShouldBeTrue();
+        field.Serialize().ShouldBe(value);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: Preserves all entries of a multi-algorithm value")]
+    public void TryParse_MultiAlgorithm_PreservesAllEntries()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("hello world");
+        string sha256 = Convert.ToBase64String(SHA256.HashData(content));
+        string sha512 = Convert.ToBase64String(SHA512.HashData(content));
+        string value = $"sha-256=:{sha256}:, sha-512=:{sha512}:";
+
+        HttpDigestField.TryParse(value, out HttpDigestField field).ShouldBeTrue();
+
+        field.Entries.Count.ShouldBe(2);
+        field.Entries[0].Algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+        field.Entries[1].Algorithm.ShouldBe(HttpDigestAlgorithm.Sha512);
+        field.Serialize().ShouldBe(value);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: Recognizes a deprecated algorithm but reports no supported algorithm")]
+    public void TryParse_DeprecatedOnly_RecognizedButUnsupported()
+    {
+        // md5 is recognized on parse but never usable for verification (RFC 9530 §5).
+        HttpDigestField.TryParse("md5=:1B2M2Y8AsgTpgAmY7PhCfg==:", out HttpDigestField field).ShouldBeTrue();
+
+        field.Entries.Count.ShouldBe(1);
+        field.Entries[0].Algorithm.ShouldBe(HttpDigestAlgorithm.Md5);
+        field.Entries[0].Algorithm.IsSupported.ShouldBeFalse();
+        field.HasSupportedAlgorithm.ShouldBeFalse();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Field: Malformed values are rejected with a diagnostic")]
+    [InlineData("sha-256=:not valid base64!:")] // bad base64
+    [InlineData("sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=")] // missing colons (not a byte sequence)
+    [InlineData("sha-256=12345")] // wrong item type (integer, not byte sequence)
+    [InlineData("")] // empty
+    [InlineData("sha-256")] // bare key, no value
+    public void TryParse_Malformed_ReturnsFalseWithError(string value)
+    {
+        HttpDigestField.TryParse(value, out HttpDigestField field, out string? error).ShouldBeFalse();
+
+        field.Entries.Count.ShouldBe(0);
+        error.ShouldNotBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: Parse throws HttpDigestException on malformed input")]
+    public void Parse_Malformed_Throws()
+    {
+        Should.Throw<HttpDigestException>(() => HttpDigestField.Parse("sha-256=12345"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: ForContent computes the correct sha-256 digest and wire form")]
+    public void ForContent_Sha256_MatchesBclAndWireFormat()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("hello world");
+        byte[] expected = SHA256.HashData(content);
+
+        HttpDigestField field = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256);
+
+        field.TryGetDigest(HttpDigestAlgorithm.Sha256, out ReadOnlyMemory<byte> digest).ShouldBeTrue();
+        digest.ToArray().ShouldBe(expected);
+        field.Serialize().ShouldBe($"sha-256=:{Convert.ToBase64String(expected)}:");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Field: ForContent rejects an unsupported algorithm")]
+    public void ForContent_UnsupportedAlgorithm_Throws()
+    {
+        Should.Throw<ArgumentException>(() => HttpDigestField.ForContent(new byte[] { 1 }, HttpDigestAlgorithm.Md5));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verify: Matching content verifies")]
+    public void VerifyContent_Match_ReturnsMatched()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("the quick brown fox");
+        HttpDigestField field = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256, HttpDigestAlgorithm.Sha512);
+
+        field.VerifyContent(content).ShouldBe(HttpDigestVerificationResult.Matched);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verify: Tampered content mismatches")]
+    public void VerifyContent_Tampered_ReturnsMismatched()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("the quick brown fox");
+        HttpDigestField field = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256);
+
+        byte[] tampered = Encoding.UTF8.GetBytes("the quick brown FOX");
+        field.VerifyContent(tampered).ShouldBe(HttpDigestVerificationResult.Mismatched);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verify: Known sha-256 vector over empty content matches")]
+    public void VerifyContent_KnownEmptyVector_Matches()
+    {
+        HttpDigestField field = HttpDigestField.Parse($"sha-256=:{EmptySha256Base64}:");
+
+        field.VerifyContent(ReadOnlySpan<byte>.Empty).ShouldBe(HttpDigestVerificationResult.Matched);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verify: A deprecated-only field cannot be verified")]
+    public void VerifyContent_DeprecatedOnly_ReturnsNoSupportedAlgorithm()
+    {
+        HttpDigestField.TryParse("md5=:1B2M2Y8AsgTpgAmY7PhCfg==:", out HttpDigestField field).ShouldBeTrue();
+
+        field.VerifyContent(ReadOnlySpan<byte>.Empty).ShouldBe(HttpDigestVerificationResult.NoSupportedAlgorithm);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verify: A wrong-length digest mismatches instead of throwing")]
+    public void VerifyContent_WrongLengthDigest_ReturnsMismatched()
+    {
+        // A syntactically valid but too-short sha-256 digest must be treated as a mismatch.
+        HttpDigestField.TryParse("sha-256=:AAAA:", out HttpDigestField field).ShouldBeTrue();
+
+        field.VerifyContent(ReadOnlySpan<byte>.Empty).ShouldBe(HttpDigestVerificationResult.Mismatched);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestHeaderRulesTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpDigestHeaderRulesTests.cs
@@ -1,0 +1,37 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpDigestHeaderRulesTests
+{
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Keys: Header keys emit their exact RFC 9530 field names")]
+    [InlineData("Content-Digest")]
+    [InlineData("Repr-Digest")]
+    [InlineData("Want-Content-Digest")]
+    [InlineData("Want-Repr-Digest")]
+    public void HeaderKeys_MatchRfcFieldNames(string expected)
+    {
+        HttpHeaderKey key = expected switch
+        {
+            "Content-Digest" => HttpHeaderKey.ContentDigest,
+            "Repr-Digest" => HttpHeaderKey.ReprDigest,
+            "Want-Content-Digest" => HttpHeaderKey.WantContentDigest,
+            _ => HttpHeaderKey.WantReprDigest,
+        };
+
+        key.Value.ShouldBe(expected);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Trailers: Digest fields are allowed in the trailer section")]
+    public void DigestFields_AreNotProhibitedInTrailers()
+    {
+        // RFC 9530 §2.1 permits Content-Digest / Repr-Digest as trailers so a streamed body can be
+        // hashed as it is written; HttpFieldRules must not classify them as trailer-prohibited.
+        HttpFieldRules.IsProhibitedInTrailers(HttpHeaderKey.ContentDigest).ShouldBeFalse();
+        HttpFieldRules.IsProhibitedInTrailers(HttpHeaderKey.ReprDigest).ShouldBeFalse();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpWantDigestFieldTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpWantDigestFieldTests.cs
@@ -1,0 +1,80 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.DigestFields.Tests;
+
+using Assimalign.Cohesion.Http;
+
+public class HttpWantDigestFieldTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Parses integer preferences and round-trips")]
+    public void TryParse_IntegerPreferences_RoundTrips()
+    {
+        string value = "sha-256=3, sha-512=10";
+
+        HttpWantDigestField.TryParse(value, out HttpWantDigestField field).ShouldBeTrue();
+
+        field.Preferences.Count.ShouldBe(2);
+        field.Preferences[0].Algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+        field.Preferences[0].Preference.ShouldBe(3);
+        field.Preferences[1].Preference.ShouldBe(10);
+        field.Serialize().ShouldBe(value);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Selects the highest-preference supported algorithm")]
+    public void TrySelectPreferred_HighestPreference_Wins()
+    {
+        HttpWantDigestField.TryParse("sha-256=3, sha-512=10", out HttpWantDigestField field).ShouldBeTrue();
+
+        field.TrySelectPreferred(out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+        algorithm.ShouldBe(HttpDigestAlgorithm.Sha512);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Breaks a preference tie toward the stronger algorithm")]
+    public void TrySelectPreferred_Tie_PrefersStronger()
+    {
+        HttpWantDigestField.TryParse("sha-256=5, sha-512=5", out HttpWantDigestField field).ShouldBeTrue();
+
+        field.TrySelectPreferred(out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+        algorithm.ShouldBe(HttpDigestAlgorithm.Sha512);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Skips unacceptable (0) and deprecated algorithms")]
+    public void TrySelectPreferred_SkipsUnacceptableAndDeprecated()
+    {
+        // sha-512 not acceptable (0); md5 deprecated (unsupported); only sha-256 is selectable.
+        HttpWantDigestField.TryParse("sha-512=0, md5=9, sha-256=1", out HttpWantDigestField field).ShouldBeTrue();
+
+        field.TrySelectPreferred(out HttpDigestAlgorithm algorithm).ShouldBeTrue();
+        algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Returns false when no supported algorithm is acceptable")]
+    public void TrySelectPreferred_NoneAcceptable_ReturnsFalse()
+    {
+        HttpWantDigestField.TryParse("sha-256=0, md5=9", out HttpWantDigestField field).ShouldBeTrue();
+
+        field.TrySelectPreferred(out _).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Create builds a serializable preference field")]
+    public void Create_BuildsSerializableField()
+    {
+        HttpWantDigestField field = HttpWantDigestField.Create(
+            new HttpWantDigestPreference(HttpDigestAlgorithm.Sha512, 10),
+            new HttpWantDigestPreference(HttpDigestAlgorithm.Sha256, 3));
+
+        field.Serialize().ShouldBe("sha-512=10, sha-256=3");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Want: Malformed preference values are rejected")]
+    [InlineData("sha-256=:AAAA:")] // byte sequence, not an integer
+    [InlineData("sha-256")] // bare key (boolean), not an integer
+    [InlineData("")] // empty
+    public void TryParse_Malformed_ReturnsFalse(string value)
+    {
+        HttpWantDigestField.TryParse(value, out HttpWantDigestField _, out string? error).ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.slnx
+++ b/libraries/Http/Assimalign.Cohesion.Http.slnx
@@ -79,6 +79,18 @@
 	<Folder Name="/Http/Assimalign.Cohesion.Http.Cookies/tests/">
 		<Project Path="Assimalign.Cohesion.Http.Cookies/tests/Assimalign.Cohesion.Http.Cookies.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.DigestFields/">
+		<File Path="Assimalign.Cohesion.Http.DigestFields/README.md" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.DigestFields/docs/">
+		<File Path="Assimalign.Cohesion.Http.DigestFields/docs/DESIGN.md" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.DigestFields/src/">
+		<Project Path="Assimalign.Cohesion.Http.DigestFields/src/Assimalign.Cohesion.Http.DigestFields.csproj" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.DigestFields/tests/">
+		<Project Path="Assimalign.Cohesion.Http.DigestFields/tests/Assimalign.Cohesion.Http.DigestFields.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Http/Assimalign.Cohesion.Http.ExtendedConnect/" />
 	<Folder Name="/Http/Assimalign.Cohesion.Http.ExtendedConnect/src/">
 		<Project Path="Assimalign.Cohesion.Http.ExtendedConnect/src/Assimalign.Cohesion.Http.ExtendedConnect.csproj" />

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
@@ -108,6 +108,15 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
     /// <summary>Gets the <c>Connection</c> HTTP header name.</summary>
     public static HttpHeaderKey Connection {get;}= new( "Connection");
 
+    /// <summary>Gets the <c>Content-Digest</c> HTTP header name (RFC 9530 &#167; 2).</summary>
+    /// <remarks>
+    /// Carries the integrity digest of the actual message content (the selected representation
+    /// after content codings) as an RFC 9651 Structured Field Dictionary of
+    /// <c>algorithm=:base64-digest:</c> entries. Modeled by <c>HttpDigestField</c> in
+    /// <c>Assimalign.Cohesion.Http.DigestFields</c>.
+    /// </remarks>
+    public static HttpHeaderKey ContentDigest {get;}= new( "Content-Digest");
+
     /// <summary>Gets the <c>Content-Disposition</c> HTTP header name.</summary>
     public static HttpHeaderKey ContentDisposition {get;}= new( "Content-Disposition");
 
@@ -240,6 +249,15 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
     /// <summary>Gets the <c>Referer</c> HTTP header name.</summary>
     public static HttpHeaderKey Referer {get;}= new( "Referer");
 
+    /// <summary>Gets the <c>Repr-Digest</c> HTTP header name (RFC 9530 &#167; 3).</summary>
+    /// <remarks>
+    /// Carries the integrity digest of the representation data (independent of content codings and
+    /// range selection) as an RFC 9651 Structured Field Dictionary. Shares the value model with
+    /// <see cref="ContentDigest"/> (<c>HttpDigestField</c>); full representation-data verification
+    /// depends on content-coding layers not yet present, so this key is modeled but not enforced.
+    /// </remarks>
+    public static HttpHeaderKey ReprDigest {get;}= new( "Repr-Digest");
+
     /// <summary>Gets the <c>Retry-After</c> HTTP header name.</summary>
     public static HttpHeaderKey RetryAfter {get;}= new( "Retry-After");
 
@@ -315,6 +333,23 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
 
     /// <summary>Gets the <c>Via</c> HTTP header name.</summary>
     public static HttpHeaderKey Via {get;}= new( "Via");
+
+    /// <summary>Gets the <c>Want-Content-Digest</c> HTTP header name (RFC 9530 &#167; 4).</summary>
+    /// <remarks>
+    /// A request/response preference asking the peer to include <see cref="ContentDigest"/> using
+    /// the listed algorithms, expressed as an RFC 9651 Structured Field Dictionary of
+    /// <c>algorithm=preference</c> integer entries (0 = not acceptable, higher = more preferred).
+    /// Modeled by <c>HttpWantDigestField</c> in <c>Assimalign.Cohesion.Http.DigestFields</c>.
+    /// </remarks>
+    public static HttpHeaderKey WantContentDigest {get;}= new( "Want-Content-Digest");
+
+    /// <summary>Gets the <c>Want-Repr-Digest</c> HTTP header name (RFC 9530 &#167; 4).</summary>
+    /// <remarks>
+    /// A request/response preference asking the peer to include <see cref="ReprDigest"/> using the
+    /// listed algorithms, expressed as an RFC 9651 Structured Field Dictionary of integer
+    /// preferences. Shares the value model with <see cref="WantContentDigest"/>.
+    /// </remarks>
+    public static HttpHeaderKey WantReprDigest {get;}= new( "Want-Repr-Digest");
 
     /// <summary>Gets the <c>Warning</c> HTTP header name.</summary>
     public static HttpHeaderKey Warning {get;}= new( "Warning");


### PR DESCRIPTION
## Work items resolved by this PR
Closes #756

<!-- creep: 0 of 0 items were discovered out-of-scope -->

## Summary

Implements RFC 9530 integrity **Digest Fields** for the HTTP area (feature `L01.01.11.29`,
Stage 2 / Lane B). Adds `Content-Digest`, `Repr-Digest`, `Want-Content-Digest`, and
`Want-Repr-Digest` as RFC 9651 Structured Field Dictionaries with `sha-256` / `sha-512`, built on
the merged #747 structured-fields toolkit, plus a parse-time verification path hung on the merged
#818 `IHttpRequestInterceptor` seam.

Lands as a new feature package **`libraries/Http/Assimalign.Cohesion.Http.DigestFields`** (mirrors
the `Http.Cookies` / `Http.RequestLimits` sub-library pattern — references core only). The one core
change is the four well-known header keys; per the core `docs/DESIGN.md` "Per-field parsers"
non-goal, all value parsing lives in the consumer package.

## What's included

- **Core** — 4 `HttpHeaderKey` constants (`Content-Digest`, `Repr-Digest`, `Want-Content-Digest`,
  `Want-Repr-Digest`) with exact RFC 9530 field names + XML docs.
- **`HttpDigestField` / `HttpWantDigestField`** — span-based `TryParse`/`Serialize` value models
  over `StructuredFieldDictionary`. One model serves both members of each pair. Multi-algorithm
  values preserve every entry; malformed input (bad base64, missing colons, wrong item type, empty)
  is rejected with a diagnosable `out string? error`, never silently ignored.
- **`HttpDigestAlgorithm`** — `sha-256` / `sha-512` supported for compute + verify; `md5`, `sha`,
  `unixsum`, `unixcksum` recognized on parse but never used (RFC 9530 §5). Hashing is BCL
  `IncrementalHash` only — no reflection, AOT-safe.
- **Server-side verification** — `HttpDigestFields.CreateContentDigestVerifier()` returns a
  stateless `IHttpRequestInterceptor` that verifies an inbound `Content-Digest` against the request
  body (constant-time compare) and rejects a mismatch, or a malformed field, with a **deterministic
  `400`** before dispatch. On HTTP/1.1 the transport materializes the body before the body hook and
  catches `HttpRequestRejectedException` on the parse path, so the rejection is answered pre-dispatch
  and the body is replayed to the app on success.
- **Response stamping** — `IHttpResponse.SetContentDigest(...)` honors the request's
  `Want-Content-Digest` preference ordering (`HttpWantDigestField.TrySelectPreferred`);
  `HttpContentDigester` is the incremental "hash as you write" primitive for the trailer-borne
  streamed case (digest fields stay trailer-eligible — `HttpFieldRules.IsProhibitedInTrailers` does
  not list them, guarded by a test).

## Design notes / scope (see `docs/DESIGN.md`)

- **`Content-Digest` is end-to-end; `Repr-Digest` is modeled** (key + value model + compute) but not
  enforced, pending content-coding layers — a drop-in on the same value model when they land.
- **Verifier is h1-only at runtime** (matches `Http.RequestLimits`); h2/h3 hook wiring is tracked
  follow-up (#819).
- **Trailer emission** into a streaming response rides on the streaming write path (#769); this PR
  provides the incremental primitive and the trailer-eligibility guarantee.
- The verifier is **opt-in** (RFC 9530 digest verification is not a blanket default like body-size
  limits), so it is not auto-installed in `Web.Hosting`; a composition root registers it explicitly.

## Testing

- 50 co-located xUnit + Shouldly tests (`Cohesion Test [Http.DigestFields] - …`), all green:
  algorithm registry, parse/serialize round-trips, multi-algorithm preservation, malformed
  rejection, known SHA-256 vector, compute vs BCL cross-check, incremental digester, Want-*
  selection, and the interceptor **match + mismatch + malformed + passthrough** paths.
- Core `Assimalign.Cohesion.Http` suite unaffected (496 passed) after the additive header-key change.
- Verified `IsAotCompatible=true`, no `Microsoft.Extensions.*`, no reflection, file-scoped
  namespaces, `extension(...)` members, `CohesionProjectReference`.

Blockers confirmed merged before starting: #747 (SFV toolkit, PR #804) and #818 (request-parse
interceptor seam, PR #811).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
