### PR TITLE
[L01.01.11.40] RFC 9110 range-request + If-Range primitives

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -672,3 +672,119 @@ on `HttpResponseInterceptorContext.Headers`.
 ### AOT posture
 
 Interface dispatch over a snapshotted interceptor array; no reflection, no codegen.
+
+## Range requests and the `If-Range` precondition (RFC 9110 §14 / §13.1.5)
+
+Range requests are the layer the caching/validator section above explicitly
+deferred: it owns `ETag`, `HttpEntityTag`, `HttpEntityTagCondition`, `HttpDate`,
+and the four-step §13.2.2 precondition evaluator (`HttpConditionalRequest`); this
+section adds byte-range parsing, `Content-Range`, the `If-Range` value object,
+`206`/`416` selection, and the §13.2.2 **step-5** range-application decision that
+*reuses* those primitives rather than re-deriving them. `Web.StaticFiles` (#777)
+and output caching (#795) consume this layer.
+
+### The type map, and what is reused vs. new
+
+| Concern | Type(s) | Owner |
+|---|---|---|
+| Entity-tag, `If-Match`/`If-None-Match` value, HTTP-date, §13.2.2 steps 1–4 | `HttpEntityTag`, `HttpEntityTagCondition`, `HttpDate`, `HttpConditionalRequest`, `HttpPreconditionOutcome` | caching/validator section (#755) |
+| `Range` request header | `HttpRange` (one spec), `HttpRangeHeader` (the set) — RFC 9110 §14.1.1 | this section |
+| `Content-Range` response header | `HttpContentRange` — §14.4 | this section |
+| `If-Range` (entity-tag or date) + its step-5 decision | `HttpIfRange` (+ `Matches`) — §13.1.5 | this section |
+| `206`/`416` selection | `HttpRangeSelector` → `HttpRangeSelection` / `HttpRangeSlice` / `HttpRangeSelectionStatus` — §14.2 | this section |
+
+The range value objects are `readonly struct`s with span `TryParse`/`Parse`/
+`ToString`, and `HttpRangeSelector` is a `static` class — the same "value objects
++ static protocol transforms, not interfaces" rationale documented in the
+media-type and caching sections. No new ETag or condition type is introduced:
+`HttpIfRange`'s entity-tag form is an `HttpEntityTag`, and its `Matches` reuses
+`HttpEntityTag.StrongEquals`.
+
+### Parsing is strict, and "invalid" ≠ "unsatisfiable"
+
+A `Range` header yields one of three downstream outcomes, and separating them is
+deliberate:
+
+1. **Unparseable / unknown unit → ignore the range, serve `200`.**
+   `HttpRangeHeader.TryParse` returns `false` for a non-`bytes` unit or any
+   syntactically invalid range-set (one bad member fails the *whole* set) — the
+   RFC 9110 §14.2 "a server MAY ignore a Range it can't or won't honor." The
+   selector is never called.
+2. **Valid but wholly out of range → `416`.** A parsed `bytes` set where no spec
+   overlaps the representation is *unsatisfiable* — a different response (`416`
+   with `Content-Range: bytes */N`), not an ignore.
+3. **Valid, ≥1 overlapping → `206`.**
+
+Collapsing (1) and (2) — e.g. `416` for a malformed header — is a common and
+wrong implementation; keeping strict parse (`false`) separate from unsatisfiable
+selection (`Unsatisfiable`) is what makes the three-way outcome representable.
+
+### Range selection: 206 / 416 / Full, order preserved, DoS-guarded
+
+`HttpRangeSelector.Select(range, completeLength, maxRanges)` resolves each spec
+via `HttpRange.TryResolve` (§14.1.2: open-ended and suffix ranges clamp to the
+content; a `first-pos` at/after the end, an empty `-0` suffix, or a zero-length
+representation are unsatisfiable) and returns `HttpRangeSelection`:
+
+- **`Partial`** — one `HttpRangeSlice` per satisfiable spec, in client order, each
+  carrying the `Content-Range` a `206` (single or `multipart/byteranges`)
+  advertises. Ranges are **not coalesced or reordered** — the RFC permits
+  coalescing but does not require it; preserving client order keeps the primitive
+  predictable, and a consumer can coalesce the returned slices.
+- **`Unsatisfiable`** — carries `UnsatisfiedContentRange` = `bytes */N`.
+- **`Full`** — the escape hatch for a range set larger than `maxRanges`
+  (default 16). RFC 9110 §14.2 blesses ignoring "egregious" range requests; a huge
+  set of tiny overlapping ranges is the classic amplification vector, so the count
+  cap degrades to a plain `200`. It is a policy knob, surfaced as a parameter.
+
+### `If-Range` is step 5, and composes with the shared evaluator
+
+`HttpConditionalRequest.Evaluate` (the caching/validator section) resolves
+§13.2.2 steps 1–4 and returns `Proceed` / `NotModified` / `PreconditionFailed`.
+It deliberately stops there: `If-Range` is range-specific. `HttpIfRange.Matches`
+is step 5, and the two compose into the full "typed decision" the range feature
+needs:
+
+```
+outcome = HttpConditionalRequest.Evaluate(context)      // steps 1–4 → 304 / 412 / proceed
+if outcome != Proceed              → send 304 / 412
+else if a Range header is present:
+    applyRange = ifRange is null  ||  ifRange.Matches(currentETag, currentLastModified)   // step 5
+    if applyRange   → HttpRangeSelector.Select(...)     → 206 / 416 / (Full → 200)
+    else            → 200 full          // validator stale: give the client the whole thing
+else                               → 200 full
+```
+
+Two correctness details:
+
+- **`If-Range` is always strong.** The entity-tag form uses
+  `HttpEntityTag.StrongEquals` (a weak or absent current tag never applies the
+  range); the date form applies the range only when the representation has not
+  been modified after the client's date (`Last-Modified ≤ If-Range date`, the
+  Kestrel rule). A mismatch *ignores* the range (full `200`) — `If-Range` is
+  "give me the whole thing if my copy is stale", never a `412`.
+- **One-second granularity.** `HttpIfRange.Matches` truncates the representation's
+  `Last-Modified` to whole seconds before the date comparison, because an
+  HTTP-date carries only whole seconds; a sub-second write therefore does not read
+  as "modified".
+
+### AOT posture (range/If-Range)
+
+Structs, spans, `long.TryParse`, and reuse of `HttpDate`/`HttpEntityTag` — no
+reflection, no runtime codegen, no dynamic dispatch. Trim-safe by construction
+(`IsAotCompatible=true`).
+
+### Non-goals (this layer)
+
+- **No `multipart/byteranges` rendering.** The selector returns slices and their
+  `Content-Range`s; composing the multipart body (boundaries, part headers) is a
+  response-writer concern (#769 streaming path / `Web.StaticFiles` #777).
+- **No range coalescing** and **no `Accept-Ranges` emission** — server response
+  concerns, not value-object ones.
+- **No re-derived validator types.** ETag, the condition list, HTTP-date, and the
+  step-1–4 evaluator belong to the caching/validator section; this layer reuses
+  them.
+- **No header-collection integration.** As with the media-type and caching
+  primitives, reading the `Range` / `If-Range` / conditional fields off an
+  `IHttpRequest` and populating `HttpConditionalRequestContext` is the consuming
+  middleware's job.

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Exceptions/HttpErrorCode.cs
@@ -72,4 +72,20 @@ public enum HttpErrorCode
     /// Application execution failed while processing the request.
     /// </summary>
     ExecutionError,
+
+    /// <summary>
+    /// A <c>Range</c> header value (RFC 9110 &#167; 14.1.1) could not be parsed — an
+    /// unrecognized range unit or a malformed range set.
+    /// </summary>
+    InvalidRange,
+
+    /// <summary>
+    /// A <c>Content-Range</c> header value (RFC 9110 &#167; 14.4) could not be parsed.
+    /// </summary>
+    InvalidContentRange,
+
+    /// <summary>
+    /// An <c>If-Range</c> conditional-request header (RFC 9110 &#167; 13.1.5) could not be parsed.
+    /// </summary>
+    InvalidConditional,
 }

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpContentRange.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpContentRange.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed <c>Content-Range</c> response header (RFC 9110 &#167; 14.4). It appears in one of three
+/// shapes: a satisfied range with a known complete length (<c>bytes 0-499/1234</c>), a satisfied
+/// range whose complete length is unknown (<c>bytes 0-499/*</c>), or an unsatisfied range that
+/// reports only the complete length (<c>bytes */1234</c>) — the form a <c>416 Range Not
+/// Satisfiable</c> response carries.
+/// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpContentRange : IEquatable<HttpContentRange>
+{
+    private HttpContentRange(string unit, long? from, long? to, long? length)
+    {
+        Unit = unit;
+        From = from;
+        To = to;
+        Length = length;
+    }
+
+    /// <summary>Gets the range unit; <see cref="HttpRangeHeader.BytesUnit"/> for any parsed instance.</summary>
+    public string Unit { get; }
+
+    /// <summary>Gets the first byte position of the represented range, or <see langword="null"/> for the unsatisfied (<c>*/N</c>) form.</summary>
+    public long? From { get; }
+
+    /// <summary>Gets the last byte position (inclusive) of the represented range, or <see langword="null"/> for the unsatisfied form.</summary>
+    public long? To { get; }
+
+    /// <summary>Gets the total length of the representation, or <see langword="null"/> when it is unknown (the <c>/*</c> form).</summary>
+    public long? Length { get; }
+
+    /// <summary>Gets a value indicating whether this is the unsatisfied (<c>bytes */N</c>) form.</summary>
+    public bool IsUnsatisfied => !From.HasValue;
+
+    /// <summary>Gets a value indicating whether the complete representation length is known.</summary>
+    public bool HasCompleteLength => Length.HasValue;
+
+    /// <summary>Gets a value indicating whether this instance was default-constructed.</summary>
+    public bool IsEmpty => Unit is null;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>
+    /// Creates a satisfied <c>Content-Range</c> for the byte slice <paramref name="from"/>..<paramref name="to"/>.
+    /// </summary>
+    /// <param name="from">The first byte position (zero-based).</param>
+    /// <param name="to">The last byte position (inclusive).</param>
+    /// <param name="completeLength">The total representation length, or <see langword="null"/> when unknown (emits <c>/*</c>).</param>
+    /// <returns>The satisfied content-range.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="from"/> is negative, <paramref name="to"/> is less than <paramref name="from"/>, or <paramref name="completeLength"/> is not greater than <paramref name="to"/>.</exception>
+    public static HttpContentRange Satisfied(long from, long to, long? completeLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(from);
+        ArgumentOutOfRangeException.ThrowIfLessThan(to, from);
+        if (completeLength is long length)
+        {
+            // RFC 9110 § 14.4: last-pos must be strictly less than complete-length.
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(length, to);
+        }
+        return new HttpContentRange(HttpRangeHeader.BytesUnit, from, to, completeLength);
+    }
+
+    /// <summary>
+    /// Creates an unsatisfied <c>Content-Range</c> (<c>bytes */N</c>) reporting the complete length —
+    /// the form that accompanies a <c>416</c> response.
+    /// </summary>
+    /// <param name="completeLength">The total representation length.</param>
+    /// <returns>The unsatisfied content-range.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="completeLength"/> is negative.</exception>
+    public static HttpContentRange Unsatisfied(long completeLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(completeLength);
+        return new HttpContentRange(HttpRangeHeader.BytesUnit, null, null, completeLength);
+    }
+
+    /// <summary>
+    /// Parses a <c>Content-Range</c> header value (RFC 9110 &#167; 14.4).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <returns>The parsed <see cref="HttpContentRange"/>.</returns>
+    /// <exception cref="HttpException">The value is not a well-formed content-range.</exception>
+    public static HttpContentRange Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpContentRange result))
+        {
+            throw new HttpInvalidContentRangeException($"The value is not a valid content-range: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a <c>Content-Range</c> header value (RFC 9110 &#167; 14.4).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed content-range.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed byte content-range.</returns>
+    public static bool TryParse(string? value, out HttpContentRange result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse a <c>Content-Range</c> header value (RFC 9110 &#167; 14.4). Only the
+    /// <c>bytes</c> unit is interpreted.
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed content-range.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed byte content-range.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpContentRange result)
+    {
+        result = default;
+
+        ReadOnlySpan<char> trimmed = HttpFieldSyntax.TrimOws(value);
+        int space = trimmed.IndexOf(' ');
+        if (space <= 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> unitSpan = trimmed[..space];
+        if (!unitSpan.Equals(HttpRangeHeader.BytesUnit, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> body = HttpFieldSyntax.TrimOws(trimmed[(space + 1)..]);
+        int slash = body.IndexOf('/');
+        if (slash <= 0 || slash >= body.Length - 1)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> rangePart = body[..slash];
+        ReadOnlySpan<char> lengthPart = body[(slash + 1)..];
+
+        long? completeLength;
+        if (lengthPart.Length == 1 && lengthPart[0] == '*')
+        {
+            completeLength = null;
+        }
+        else if (TryParseDigits(lengthPart, out long parsedLength))
+        {
+            completeLength = parsedLength;
+        }
+        else
+        {
+            return false;
+        }
+
+        // unsatisfied-range = "*" "/" complete-length
+        if (rangePart.Length == 1 && rangePart[0] == '*')
+        {
+            if (completeLength is null)
+            {
+                // "*/*" is not a valid Content-Range.
+                return false;
+            }
+            result = new HttpContentRange(HttpRangeHeader.BytesUnit, null, null, completeLength);
+            return true;
+        }
+
+        // incl-range = first-pos "-" last-pos
+        int dash = rangePart.IndexOf('-');
+        if (dash <= 0)
+        {
+            return false;
+        }
+        if (!TryParseDigits(rangePart[..dash], out long from) || !TryParseDigits(rangePart[(dash + 1)..], out long to))
+        {
+            return false;
+        }
+        if (to < from || (completeLength is long len && to >= len))
+        {
+            return false;
+        }
+
+        result = new HttpContentRange(HttpRangeHeader.BytesUnit, from, to, completeLength);
+        return true;
+    }
+
+    private static bool TryParseDigits(ReadOnlySpan<char> value, out long result)
+        => long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+
+    /// <inheritdoc />
+    public bool Equals(HttpContentRange other)
+        => From == other.From && To == other.To && Length == other.Length
+        && string.Equals(Unit, other.Unit, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpContentRange other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(From, To, Length, Unit is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(Unit));
+
+    /// <summary>
+    /// Renders the header in wire form (<c>bytes 0-499/1234</c>, <c>bytes 0-499/*</c>, or <c>bytes */1234</c>).
+    /// </summary>
+    /// <returns>The header value text, or an empty string for a default-constructed instance.</returns>
+    public override string ToString()
+    {
+        if (IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        string length = Length.HasValue ? Length.Value.ToString(CultureInfo.InvariantCulture) : "*";
+        if (IsUnsatisfied)
+        {
+            return $"{Unit} */{length}";
+        }
+        string from = From!.Value.ToString(CultureInfo.InvariantCulture);
+        string to = To!.Value.ToString(CultureInfo.InvariantCulture);
+        return $"{Unit} {from}-{to}/{length}";
+    }
+
+    /// <summary>Determines whether two content-ranges are equal.</summary>
+    public static bool operator ==(HttpContentRange left, HttpContentRange right) => left.Equals(right);
+
+    /// <summary>Determines whether two content-ranges are not equal.</summary>
+    public static bool operator !=(HttpContentRange left, HttpContentRange right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpIfRange.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpIfRange.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Diagnostics;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed <c>If-Range</c> conditional request header (RFC 9110 &#167; 13.1.5). Its value is
+/// <em>either</em> an entity-tag <em>or</em> an HTTP-date; the two are distinguished on the wire by
+/// whether the value begins with a double quote or <c>W/</c> (entity-tag) versus a date.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>If-Range</c> lets a client that already holds part of a representation ask for the remaining
+/// bytes only if the representation is unchanged, and otherwise receive the whole thing. The
+/// validator it carries is always evaluated with <em>strong</em> semantics via
+/// <see cref="Matches(HttpEntityTag?, DateTimeOffset?)"/>: an entity-tag is compared with
+/// <see cref="HttpEntityTag.StrongEquals(HttpEntityTag)"/> (so a weak tag never matches), and a date
+/// applies the range only when the representation has not been modified after the client's date.
+/// </para>
+/// <para>
+/// This is RFC 9110 &#167; 13.2.2 step 5 (the range-application decision). It composes with steps
+/// 1&#8211;4 (<c>If-Match</c> / <c>If-None-Match</c> / <c>If-*-Since</c>), which are resolved by
+/// <see cref="HttpConditionalRequest.Evaluate(in HttpConditionalRequestContext)"/>: a caller runs
+/// that first, and only when it returns <see cref="HttpPreconditionOutcome.Proceed"/> for a request
+/// carrying a <c>Range</c> does <see cref="Matches(HttpEntityTag?, DateTimeOffset?)"/> decide whether
+/// to honor the range (<c>206</c>) or ignore it and serve the full representation (<c>200</c>).
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpIfRange : IEquatable<HttpIfRange>
+{
+    private HttpIfRange(HttpEntityTag? entityTag, DateTimeOffset? date)
+    {
+        EntityTag = entityTag;
+        Date = date;
+    }
+
+    /// <summary>Gets the entity-tag validator, or <see langword="null"/> when the header carries a date.</summary>
+    public HttpEntityTag? EntityTag { get; }
+
+    /// <summary>Gets the HTTP-date validator, or <see langword="null"/> when the header carries an entity-tag.</summary>
+    public DateTimeOffset? Date { get; }
+
+    /// <summary>Gets a value indicating whether the validator is an entity-tag (rather than a date).</summary>
+    public bool IsEntityTag => EntityTag.HasValue;
+
+    /// <summary>Gets a value indicating whether this instance was default-constructed (holds no validator).</summary>
+    public bool IsEmpty => !EntityTag.HasValue && !Date.HasValue;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>Creates an <c>If-Range</c> that carries an entity-tag validator.</summary>
+    /// <param name="entityTag">The entity-tag to compare against the current representation.</param>
+    /// <returns>The <c>If-Range</c> value.</returns>
+    public static HttpIfRange FromEntityTag(HttpEntityTag entityTag) => new(entityTag, null);
+
+    /// <summary>Creates an <c>If-Range</c> that carries an HTTP-date validator.</summary>
+    /// <param name="date">The date to compare against the current representation's <c>Last-Modified</c>.</param>
+    /// <returns>The <c>If-Range</c> value.</returns>
+    public static HttpIfRange FromDate(DateTimeOffset date) => new(null, date);
+
+    /// <summary>
+    /// Evaluates this <c>If-Range</c> validator against the target representation's current validators
+    /// (RFC 9110 &#167; 13.1.5) — the RFC 9110 &#167; 13.2.2 step-5 decision of whether a present
+    /// <c>Range</c> should be honored. The entity-tag form uses strong comparison (a weak or absent
+    /// current tag never matches); the date form applies the range only when the representation has
+    /// not been modified after the client's date, compared at one-second (HTTP-date) granularity.
+    /// </summary>
+    /// <param name="currentETag">The target representation's current entity-tag, or <see langword="null"/> when it has none.</param>
+    /// <param name="currentLastModified">The target representation's current last-modification date, or <see langword="null"/> when unknown.</param>
+    /// <returns>
+    /// <see langword="true"/> when the range should be applied (serve <c>206</c>); <see langword="false"/>
+    /// when the validator no longer matches and the full representation should be served (<c>200</c>).
+    /// </returns>
+    public bool Matches(HttpEntityTag? currentETag, DateTimeOffset? currentLastModified)
+    {
+        if (EntityTag is HttpEntityTag ifRangeTag)
+        {
+            // Strong comparison: a weak or missing current validator never applies the range.
+            return currentETag is HttpEntityTag etag && ifRangeTag.StrongEquals(etag);
+        }
+        if (Date is DateTimeOffset ifRangeDate)
+        {
+            // Apply the range only if the representation has not been modified after the client's date.
+            return currentLastModified is DateTimeOffset lastModified
+                && TruncateToSeconds(lastModified) <= ifRangeDate;
+        }
+        return false;
+    }
+
+    // HTTP-date carries one-second resolution; drop any sub-second component before comparing.
+    private static DateTimeOffset TruncateToSeconds(DateTimeOffset value)
+    {
+        DateTime utc = value.UtcDateTime;
+        return new DateTimeOffset(utc.Ticks - (utc.Ticks % TimeSpan.TicksPerSecond), TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// Parses an <c>If-Range</c> header value (RFC 9110 &#167; 13.1.5).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <returns>The parsed <see cref="HttpIfRange"/>.</returns>
+    /// <exception cref="HttpException">The value is neither a valid entity-tag nor a valid HTTP-date.</exception>
+    public static HttpIfRange Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpIfRange result))
+        {
+            throw new HttpInvalidConditionalException($"The value is not a valid If-Range header: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse an <c>If-Range</c> header value (RFC 9110 &#167; 13.1.5).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed value.</param>
+    /// <returns><see langword="true"/> when the value is a valid entity-tag or HTTP-date.</returns>
+    public static bool TryParse(string? value, out HttpIfRange result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse an <c>If-Range</c> header value (RFC 9110 &#167; 13.1.5).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed value.</param>
+    /// <returns><see langword="true"/> when the value is a valid entity-tag or HTTP-date.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpIfRange result)
+    {
+        result = default;
+
+        ReadOnlySpan<char> trimmed = HttpFieldSyntax.TrimOws(value);
+        if (trimmed.IsEmpty)
+        {
+            return false;
+        }
+
+        // RFC 9110 § 13.1.5: an entity-tag is distinguished from a date by a leading DQUOTE or "W/".
+        bool looksLikeEntityTag = trimmed[0] == '"'
+            || (trimmed.Length >= 2 && trimmed[0] == 'W' && trimmed[1] == '/');
+
+        if (looksLikeEntityTag)
+        {
+            if (HttpEntityTag.TryParse(trimmed, out HttpEntityTag entityTag))
+            {
+                result = new HttpIfRange(entityTag, null);
+                return true;
+            }
+            return false;
+        }
+
+        if (HttpDate.TryParse(trimmed, out DateTimeOffset date))
+        {
+            result = new HttpIfRange(null, date);
+            return true;
+        }
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(HttpIfRange other)
+        => Nullable.Equals(EntityTag, other.EntityTag) && Nullable.Equals(Date, other.Date);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpIfRange other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(EntityTag, Date);
+
+    /// <summary>
+    /// Renders the header in wire form — the entity-tag's quoted form, or the date as an IMF-fixdate.
+    /// </summary>
+    /// <returns>The header value text, or an empty string for a default-constructed instance.</returns>
+    public override string ToString()
+    {
+        if (EntityTag is HttpEntityTag tag)
+        {
+            return tag.ToString();
+        }
+        if (Date is DateTimeOffset date)
+        {
+            return HttpDate.Format(date);
+        }
+        return string.Empty;
+    }
+
+    /// <summary>Determines whether two <c>If-Range</c> values are equal.</summary>
+    public static bool operator ==(HttpIfRange left, HttpIfRange right) => left.Equals(right);
+
+    /// <summary>Determines whether two <c>If-Range</c> values are not equal.</summary>
+    public static bool operator !=(HttpIfRange left, HttpIfRange right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRange.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRange.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single byte <c>range-spec</c> within a <c>Range</c> header (RFC 9110 &#167; 14.1.1). One of
+/// three shapes: a closed <c>int-range</c> (<c>first-last</c>), an open-ended <c>int-range</c>
+/// (<c>first-</c>, "from <c>first</c> to the end"), or a <c>suffix-range</c> (<c>-length</c>,
+/// "the final <c>length</c> bytes").
+/// </summary>
+/// <remarks>
+/// The positions are recorded exactly as the client stated them, independent of any content length.
+/// <see cref="TryResolve(long, out long, out long)"/> applies RFC 9110 &#167; 14.1.2 to turn a spec
+/// into a concrete <c>(offset, length)</c> slice against a known representation length, reporting
+/// whether the spec is satisfiable.
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpRange : IEquatable<HttpRange>
+{
+    private HttpRange(long? from, long? to, long? suffixLength)
+    {
+        From = from;
+        To = to;
+        SuffixLength = suffixLength;
+    }
+
+    /// <summary>
+    /// Gets the first byte position of an <c>int-range</c>, or <see langword="null"/> when this is a
+    /// <c>suffix-range</c>.
+    /// </summary>
+    public long? From { get; }
+
+    /// <summary>
+    /// Gets the last byte position (inclusive) of a closed <c>int-range</c>, or <see langword="null"/>
+    /// for an open-ended <c>int-range</c> or a <c>suffix-range</c>.
+    /// </summary>
+    public long? To { get; }
+
+    /// <summary>
+    /// Gets the trailing byte count of a <c>suffix-range</c>, or <see langword="null"/> for an
+    /// <c>int-range</c>.
+    /// </summary>
+    public long? SuffixLength { get; }
+
+    /// <summary>Gets a value indicating whether this is a <c>suffix-range</c> (<c>-length</c>).</summary>
+    public bool IsSuffix => SuffixLength.HasValue;
+
+    /// <summary>Gets a value indicating whether this is an open-ended <c>int-range</c> (<c>first-</c>).</summary>
+    public bool IsOpenEnded => From.HasValue && !To.HasValue;
+
+    /// <summary>Gets a value indicating whether this instance was default-constructed (holds no range).</summary>
+    public bool IsEmpty => !From.HasValue && !SuffixLength.HasValue;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>
+    /// Creates a closed <c>int-range</c> spanning <paramref name="from"/> to <paramref name="to"/> inclusive.
+    /// </summary>
+    /// <param name="from">The first byte position (zero-based).</param>
+    /// <param name="to">The last byte position (inclusive).</param>
+    /// <returns>The range spec.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="from"/> is negative or greater than <paramref name="to"/>.</exception>
+    public static HttpRange FromTo(long from, long to)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(from);
+        ArgumentOutOfRangeException.ThrowIfLessThan(to, from);
+        return new HttpRange(from, to, null);
+    }
+
+    /// <summary>
+    /// Creates an open-ended <c>int-range</c> from <paramref name="from"/> to the end of the representation.
+    /// </summary>
+    /// <param name="from">The first byte position (zero-based).</param>
+    /// <returns>The range spec.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="from"/> is negative.</exception>
+    public static HttpRange StartingAt(long from)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(from);
+        return new HttpRange(from, null, null);
+    }
+
+    /// <summary>
+    /// Creates a <c>suffix-range</c> selecting the final <paramref name="length"/> bytes of the representation.
+    /// </summary>
+    /// <param name="length">The number of trailing bytes to select.</param>
+    /// <returns>The range spec.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+    public static HttpRange Suffix(long length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        return new HttpRange(null, null, length);
+    }
+
+    /// <summary>
+    /// Resolves this spec against a representation of <paramref name="completeLength"/> bytes,
+    /// applying RFC 9110 &#167; 14.1.2 (open-ended and suffix ranges are clamped to the content;
+    /// a <c>first-pos</c> at or beyond the end, or an empty suffix, is unsatisfiable).
+    /// </summary>
+    /// <param name="completeLength">The total length, in bytes, of the selected representation.</param>
+    /// <param name="offset">When this method returns <see langword="true"/>, the zero-based offset of the first selected byte.</param>
+    /// <param name="length">When this method returns <see langword="true"/>, the number of selected bytes (always &#8805; 1).</param>
+    /// <returns><see langword="true"/> when the spec is satisfiable against <paramref name="completeLength"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="completeLength"/> is negative.</exception>
+    public bool TryResolve(long completeLength, out long offset, out long length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(completeLength);
+        offset = 0;
+        length = 0;
+
+        if (IsEmpty || completeLength == 0)
+        {
+            return false;
+        }
+
+        if (IsSuffix)
+        {
+            long suffix = SuffixLength!.Value;
+            if (suffix == 0)
+            {
+                // "-0" selects the final zero bytes: an empty, unsatisfiable range.
+                return false;
+            }
+            long take = Math.Min(suffix, completeLength);
+            offset = completeLength - take;
+            length = take;
+            return true;
+        }
+
+        long first = From!.Value;
+        if (first >= completeLength)
+        {
+            // The range starts at or beyond the end of the representation → unsatisfiable.
+            return false;
+        }
+
+        long last = To ?? completeLength - 1;
+        if (last >= completeLength)
+        {
+            last = completeLength - 1;
+        }
+
+        offset = first;
+        length = last - first + 1;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a single byte <c>range-spec</c> (RFC 9110 &#167; 14.1.1), for example
+    /// <c>0-499</c>, <c>500-</c>, or <c>-500</c>.
+    /// </summary>
+    /// <param name="value">The range-spec text (surrounding whitespace is tolerated).</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed range spec.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed byte range-spec.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpRange result)
+    {
+        result = default;
+
+        ReadOnlySpan<char> spec = HttpFieldSyntax.TrimOws(value);
+        if (spec.IsEmpty)
+        {
+            return false;
+        }
+
+        if (spec[0] == '-')
+        {
+            // suffix-range = "-" suffix-length
+            if (!TryParseDigits(spec[1..], out long suffixLength))
+            {
+                return false;
+            }
+            result = new HttpRange(null, null, suffixLength);
+            return true;
+        }
+
+        // int-range = first-pos "-" [ last-pos ]
+        int dash = spec.IndexOf('-');
+        if (dash <= 0)
+        {
+            return false;
+        }
+
+        if (!TryParseDigits(spec[..dash], out long first))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> lastSpan = spec[(dash + 1)..];
+        if (lastSpan.IsEmpty)
+        {
+            result = new HttpRange(first, null, null);
+            return true;
+        }
+
+        if (!TryParseDigits(lastSpan, out long last) || last < first)
+        {
+            return false;
+        }
+
+        result = new HttpRange(first, last, null);
+        return true;
+    }
+
+    private static bool TryParseDigits(ReadOnlySpan<char> value, out long result)
+        => long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+
+    /// <inheritdoc />
+    public bool Equals(HttpRange other) => From == other.From && To == other.To && SuffixLength == other.SuffixLength;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpRange other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(From, To, SuffixLength);
+
+    /// <summary>
+    /// Renders the range-spec in wire form (<c>0-499</c>, <c>500-</c>, or <c>-500</c>) without the
+    /// range unit.
+    /// </summary>
+    /// <returns>The range-spec text, or an empty string for a default-constructed instance.</returns>
+    public override string ToString()
+    {
+        if (IsEmpty)
+        {
+            return string.Empty;
+        }
+        if (IsSuffix)
+        {
+            return $"-{SuffixLength!.Value.ToString(CultureInfo.InvariantCulture)}";
+        }
+        string first = From!.Value.ToString(CultureInfo.InvariantCulture);
+        return To.HasValue ? $"{first}-{To.Value.ToString(CultureInfo.InvariantCulture)}" : $"{first}-";
+    }
+
+    /// <summary>Determines whether two range specs are equal.</summary>
+    public static bool operator ==(HttpRange left, HttpRange right) => left.Equals(right);
+
+    /// <summary>Determines whether two range specs are not equal.</summary>
+    public static bool operator !=(HttpRange left, HttpRange right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeHeader.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeHeader.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A parsed <c>Range</c> request header (RFC 9110 &#167; 14.2): a range unit followed by a
+/// non-empty, ordered set of <see cref="HttpRange"/> specs. Only the <c>bytes</c> unit is
+/// interpreted — a header naming any other (or an unrecognized) unit fails to parse, which is the
+/// signal for a server to ignore the range and serve the full representation (RFC 9110 &#167; 14.2).
+/// </summary>
+/// <remarks>
+/// Parsing is deliberately strict: a syntactically invalid range-set fails as a whole rather than
+/// silently dropping the malformed members, so a caller that gets a parsed header can trust every
+/// spec in it. Whether the set produces a <c>206</c> or a <c>416</c> is a separate decision made by
+/// <see cref="HttpRangeSelector"/> against a known content length.
+/// </remarks>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpRangeHeader
+{
+    /// <summary>The <c>bytes</c> range unit — the only unit defined for HTTP range requests.</summary>
+    public const string BytesUnit = "bytes";
+
+    private readonly HttpRange[]? ranges;
+
+    private HttpRangeHeader(string unit, HttpRange[] ranges)
+    {
+        Unit = unit;
+        this.ranges = ranges;
+    }
+
+    /// <summary>Gets the range unit; <see cref="BytesUnit"/> for any successfully parsed header.</summary>
+    public string Unit { get; }
+
+    /// <summary>Gets the ordered set of range specs. Never empty for a parsed header.</summary>
+    public IReadOnlyList<HttpRange> Ranges
+        => ranges ?? (IReadOnlyList<HttpRange>)Array.Empty<HttpRange>();
+
+    /// <summary>Gets the number of range specs.</summary>
+    public int Count => ranges?.Length ?? 0;
+
+    /// <summary>Gets a value indicating whether this instance was default-constructed (holds no ranges).</summary>
+    public bool IsEmpty => ranges is null;
+
+    private string DebuggerDisplay => IsEmpty ? "<empty>" : ToString();
+
+    /// <summary>
+    /// Parses a <c>Range</c> header value (RFC 9110 &#167; 14.1.1), for example <c>bytes=0-499,-500</c>.
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <returns>The parsed <see cref="HttpRangeHeader"/>.</returns>
+    /// <exception cref="HttpException">The value is not a well-formed byte-range header.</exception>
+    public static HttpRangeHeader Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out HttpRangeHeader result))
+        {
+            throw new HttpInvalidRangeException($"The value is not a valid byte-range header: '{value.ToString()}'.");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a <c>Range</c> header value (RFC 9110 &#167; 14.1.1).
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed header.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed byte-range header.</returns>
+    public static bool TryParse(string? value, out HttpRangeHeader result)
+        => TryParse(value.AsSpan(), out result);
+
+    /// <summary>
+    /// Attempts to parse a <c>Range</c> header value (RFC 9110 &#167; 14.1.1). Returns
+    /// <see langword="false"/> for an unrecognized range unit or any syntactically invalid range-set —
+    /// both cases the caller should treat as "no usable range" and serve the full representation.
+    /// </summary>
+    /// <param name="value">The header value text.</param>
+    /// <param name="result">When this method returns <see langword="true"/>, the parsed header.</param>
+    /// <returns><see langword="true"/> when the value is a well-formed byte-range header.</returns>
+    public static bool TryParse(ReadOnlySpan<char> value, out HttpRangeHeader result)
+    {
+        result = default;
+
+        ReadOnlySpan<char> trimmed = HttpFieldSyntax.TrimOws(value);
+        int equals = trimmed.IndexOf('=');
+        if (equals <= 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> unitSpan = HttpFieldSyntax.TrimOws(trimmed[..equals]);
+        // Range units are case-insensitive tokens (RFC 9110 § 14.1); only "bytes" is interpreted here.
+        if (!unitSpan.Equals(BytesUnit, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> setSpan = trimmed[(equals + 1)..];
+        List<HttpRange>? list = null;
+        while (!setSpan.IsEmpty)
+        {
+            int comma = setSpan.IndexOf(',');
+            ReadOnlySpan<char> segment = comma < 0 ? setSpan : setSpan[..comma];
+            setSpan = comma < 0 ? ReadOnlySpan<char>.Empty : setSpan[(comma + 1)..];
+
+            ReadOnlySpan<char> spec = HttpFieldSyntax.TrimOws(segment);
+            if (spec.IsEmpty)
+            {
+                // The list rule (1#) permits and skips empty elements.
+                continue;
+            }
+
+            if (!HttpRange.TryParse(spec, out HttpRange range))
+            {
+                // Any malformed member invalidates the whole set (strict parse → caller ignores range).
+                return false;
+            }
+            (list ??= new List<HttpRange>()).Add(range);
+        }
+
+        if (list is null || list.Count == 0)
+        {
+            return false;
+        }
+
+        result = new HttpRangeHeader(BytesUnit, list.ToArray());
+        return true;
+    }
+
+    /// <summary>
+    /// Renders the header in wire form (e.g. <c>bytes=0-499,-500</c>).
+    /// </summary>
+    /// <returns>The header value text, or an empty string for a default-constructed instance.</returns>
+    public override string ToString()
+    {
+        if (IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(Unit.Length + 1 + ranges!.Length * 8);
+        builder.Append(Unit).Append('=');
+        for (int i = 0; i < ranges.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+            builder.Append(ranges[i].ToString());
+        }
+        return builder.ToString();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelection.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The typed result of <see cref="HttpRangeSelector.Select(in HttpRangeHeader, long, int)"/>: the
+/// response disposition for a range request (RFC 9110 &#167; 14.2) together with the data needed to
+/// build that response — the selected <see cref="Slices"/> for a <c>206</c>, or the
+/// <see cref="UnsatisfiedContentRange"/> for a <c>416</c>.
+/// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpRangeSelection
+{
+    private readonly HttpRangeSlice[]? slices;
+
+    private HttpRangeSelection(HttpRangeSelectionStatus status, HttpRangeSlice[]? slices, HttpContentRange unsatisfiedContentRange, long completeLength)
+    {
+        Status = status;
+        this.slices = slices;
+        UnsatisfiedContentRange = unsatisfiedContentRange;
+        CompleteLength = completeLength;
+    }
+
+    /// <summary>Gets the response disposition for the range request.</summary>
+    public HttpRangeSelectionStatus Status { get; }
+
+    /// <summary>Gets the total length of the representation the selection was computed against.</summary>
+    public long CompleteLength { get; }
+
+    /// <summary>
+    /// Gets the selected slices when <see cref="Status"/> is
+    /// <see cref="HttpRangeSelectionStatus.Partial"/> (in request order); empty otherwise.
+    /// </summary>
+    public IReadOnlyList<HttpRangeSlice> Slices
+        => slices ?? (IReadOnlyList<HttpRangeSlice>)Array.Empty<HttpRangeSlice>();
+
+    /// <summary>
+    /// Gets the <c>bytes */N</c> content-range to send with a <c>416</c> when <see cref="Status"/> is
+    /// <see cref="HttpRangeSelectionStatus.Unsatisfiable"/>; a default value otherwise.
+    /// </summary>
+    public HttpContentRange UnsatisfiedContentRange { get; }
+
+    /// <summary>Gets a value indicating whether the selection is a single satisfiable slice.</summary>
+    public bool IsSingleSlice => Status == HttpRangeSelectionStatus.Partial && slices is { Length: 1 };
+
+    private string DebuggerDisplay => Status switch
+    {
+        HttpRangeSelectionStatus.Partial => $"Partial ({slices?.Length ?? 0} slice(s))",
+        HttpRangeSelectionStatus.Unsatisfiable => $"Unsatisfiable ({UnsatisfiedContentRange})",
+        _ => "Full",
+    };
+
+    internal static HttpRangeSelection Full(long completeLength)
+        => new(HttpRangeSelectionStatus.Full, null, default, completeLength);
+
+    internal static HttpRangeSelection Partial(HttpRangeSlice[] slices, long completeLength)
+        => new(HttpRangeSelectionStatus.Partial, slices, default, completeLength);
+
+    internal static HttpRangeSelection Unsatisfiable(long completeLength)
+        => new(HttpRangeSelectionStatus.Unsatisfiable, null, HttpContentRange.Unsatisfied(completeLength), completeLength);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelectionStatus.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelectionStatus.cs
@@ -1,0 +1,28 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The outcome of applying a <c>Range</c> header to a representation (RFC 9110 &#167; 14.2), and the
+/// response status it maps to.
+/// </summary>
+public enum HttpRangeSelectionStatus
+{
+    /// <summary>
+    /// The range was ignored and the entire representation should be served with <c>200 OK</c>.
+    /// A server chooses this when a range request is present but not worth honoring — for example a
+    /// range set larger than the configured limit (a denial-of-service guard permitted by
+    /// RFC 9110 &#167; 14.2).
+    /// </summary>
+    Full = 0,
+
+    /// <summary>
+    /// At least one range is satisfiable; serve <c>206 Partial Content</c> using the selected
+    /// <see cref="HttpRangeSelection.Slices"/>.
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// No range is satisfiable; serve <c>416 Range Not Satisfiable</c> with the
+    /// <see cref="HttpRangeSelection.UnsatisfiedContentRange"/> (<c>bytes */N</c>).
+    /// </summary>
+    Unsatisfiable,
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelector.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSelector.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Applies a parsed <c>Range</c> header to a representation of known length per RFC 9110
+/// &#167; 14.2, deciding between a <c>206 Partial Content</c> response (returning the concrete byte
+/// slices) and a <c>416 Range Not Satisfiable</c> response (returning the <c>bytes */N</c>
+/// content-range). This is the selection step only; whether a present range should be honored at all
+/// is a precondition/<c>If-Range</c> decision made by <see cref="HttpPreconditionEvaluator"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ranges are resolved in the order the client listed them and are <em>not</em> coalesced or
+/// reordered (RFC 9110 &#167; 14.2 permits coalescing but does not require it; preserving client
+/// order keeps the primitive predictable). A range set larger than <paramref name="maxRanges"/> is
+/// treated as not worth honoring and yields <see cref="HttpRangeSelectionStatus.Full"/> — the
+/// denial-of-service mitigation the RFC explicitly allows for "egregious" range requests.
+/// </para>
+/// </remarks>
+public static class HttpRangeSelector
+{
+    /// <summary>
+    /// The default upper bound on the number of ranges honored in a single request before the whole
+    /// range set is ignored in favor of a full <c>200</c> response.
+    /// </summary>
+    public const int DefaultMaxRanges = 16;
+
+    /// <summary>
+    /// Selects the response for <paramref name="range"/> against a representation of
+    /// <paramref name="completeLength"/> bytes (RFC 9110 &#167; 14.2).
+    /// </summary>
+    /// <param name="range">The parsed <c>Range</c> header.</param>
+    /// <param name="completeLength">The total length, in bytes, of the selected representation.</param>
+    /// <param name="maxRanges">The maximum number of ranges to honor before serving the full representation instead; defaults to <see cref="DefaultMaxRanges"/>.</param>
+    /// <returns>
+    /// A <see cref="HttpRangeSelection"/> describing whether to serve <c>200</c> (full), <c>206</c>
+    /// (partial, with slices), or <c>416</c> (unsatisfiable, with a <c>bytes */N</c> content-range).
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="completeLength"/> is negative or <paramref name="maxRanges"/> is less than one.</exception>
+    public static HttpRangeSelection Select(in HttpRangeHeader range, long completeLength, int maxRanges = DefaultMaxRanges)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(completeLength);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxRanges, 1);
+
+        // A parsed-but-empty header (or one carrying no usable unit) means "no range" → serve full.
+        if (range.IsEmpty || range.Count == 0)
+        {
+            return HttpRangeSelection.Full(completeLength);
+        }
+
+        // Denial-of-service guard: an egregiously large range set is ignored (RFC 9110 § 14.2).
+        if (range.Count > maxRanges)
+        {
+            return HttpRangeSelection.Full(completeLength);
+        }
+
+        IReadOnlyList<HttpRange> ranges = range.Ranges;
+        List<HttpRangeSlice>? slices = null;
+        for (int i = 0; i < ranges.Count; i++)
+        {
+            if (ranges[i].TryResolve(completeLength, out long offset, out long length))
+            {
+                (slices ??= new List<HttpRangeSlice>(ranges.Count)).Add(new HttpRangeSlice(offset, length, completeLength));
+            }
+        }
+
+        // RFC 9110 § 14.2: if none of the ranges overlap the representation, the request is
+        // unsatisfiable → 416 with "bytes */complete-length".
+        if (slices is null)
+        {
+            return HttpRangeSelection.Unsatisfiable(completeLength);
+        }
+
+        return HttpRangeSelection.Partial(slices.ToArray(), completeLength);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSlice.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpRangeSlice.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single concrete byte slice selected from a representation by <see cref="HttpRangeSelector"/> —
+/// a zero-based <see cref="Offset"/>/<see cref="Length"/> pair together with the
+/// <see cref="HttpContentRange"/> a <c>206</c> response advertises for it (in a multipart
+/// <c>206</c> this is the part's <c>Content-Range</c> header).
+/// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct HttpRangeSlice : IEquatable<HttpRangeSlice>
+{
+    /// <summary>
+    /// Initializes a slice covering <paramref name="length"/> bytes at <paramref name="offset"/>
+    /// within a representation of <paramref name="completeLength"/> bytes.
+    /// </summary>
+    /// <param name="offset">The zero-based offset of the first selected byte.</param>
+    /// <param name="length">The number of selected bytes (must be at least one).</param>
+    /// <param name="completeLength">The total representation length.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="offset"/> is negative, <paramref name="length"/> is less than one, or the slice extends past <paramref name="completeLength"/>.</exception>
+    public HttpRangeSlice(long offset, long length, long completeLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfLessThan(length, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset + length, completeLength);
+
+        Offset = offset;
+        Length = length;
+        ContentRange = HttpContentRange.Satisfied(offset, offset + length - 1, completeLength);
+    }
+
+    /// <summary>Gets the zero-based offset of the first selected byte.</summary>
+    public long Offset { get; }
+
+    /// <summary>Gets the number of selected bytes.</summary>
+    public long Length { get; }
+
+    /// <summary>Gets the last selected byte position (inclusive).</summary>
+    public long EndInclusive => Offset + Length - 1;
+
+    /// <summary>Gets the <c>Content-Range</c> this slice advertises in a <c>206</c> response.</summary>
+    public HttpContentRange ContentRange { get; }
+
+    private string DebuggerDisplay => $"{Offset}..{EndInclusive} ({Length} bytes)";
+
+    /// <inheritdoc />
+    public bool Equals(HttpRangeSlice other) => Offset == other.Offset && Length == other.Length;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpRangeSlice other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(Offset, Length);
+
+    /// <summary>Determines whether two slices cover the same bytes.</summary>
+    public static bool operator ==(HttpRangeSlice left, HttpRangeSlice right) => left.Equals(right);
+
+    /// <summary>Determines whether two slices cover different bytes.</summary>
+    public static bool operator !=(HttpRangeSlice left, HttpRangeSlice right) => !left.Equals(right);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidConditionalException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidConditionalException.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+internal sealed class HttpInvalidConditionalException : HttpException
+{
+    public HttpInvalidConditionalException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidConditional;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidContentRangeException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidContentRangeException.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+internal sealed class HttpInvalidContentRangeException : HttpException
+{
+    public HttpInvalidContentRangeException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidContentRange;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidRangeException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Internal/Exceptions/HttpInvalidRangeException.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+internal sealed class HttpInvalidRangeException : HttpException
+{
+    public HttpInvalidRangeException(string message)
+        : base(message)
+    {
+        Code = HttpErrorCode.InvalidRange;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/Conditional/HttpRangePreconditionCompositionTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/Conditional/HttpRangePreconditionCompositionTests.cs
@@ -1,0 +1,132 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// End-to-end RFC 9110 &#167; 13.2.2 composition tests: the range/precondition primitives layer the
+/// <c>If-Range</c> range-application decision (step 5, <see cref="HttpIfRange.Matches"/>) and range
+/// selection (<see cref="HttpRangeSelector"/>) on top of the shared conditional-request evaluator
+/// (steps 1&#8211;4, <see cref="HttpConditionalRequest.Evaluate"/>). These tests exercise the full
+/// consumer flow — the typed decision of proceed / <c>304</c> / <c>412</c> / <c>206</c> / <c>416</c> /
+/// ignore-range — through that composition.
+/// </summary>
+public class HttpRangePreconditionCompositionTests
+{
+    private static readonly DateTimeOffset LastModified = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly HttpEntityTag CurrentTag = HttpEntityTag.Strong("v1");
+    private const long ContentLength = 1000;
+
+    private enum ResponseKind
+    {
+        Ok200,
+        Partial206,
+        NotModified304,
+        PreconditionFailed412,
+        RangeNotSatisfiable416,
+    }
+
+    /// <summary>
+    /// The canonical consumer composition: evaluate steps 1&#8211;4, then (only on proceed) apply the
+    /// <c>If-Range</c> step-5 decision and range selection.
+    /// </summary>
+    private static ResponseKind Decide(
+        HttpMethod method,
+        HttpEntityTagCondition? ifMatch = null,
+        HttpEntityTagCondition? ifNoneMatch = null,
+        DateTimeOffset? ifModifiedSince = null,
+        DateTimeOffset? ifUnmodifiedSince = null,
+        HttpRangeHeader? range = null,
+        HttpIfRange? ifRange = null)
+    {
+        HttpPreconditionOutcome outcome = HttpConditionalRequest.Evaluate(new HttpConditionalRequestContext
+        {
+            Method = method,
+            ETag = CurrentTag,
+            LastModified = LastModified,
+            IfMatch = ifMatch,
+            IfNoneMatch = ifNoneMatch,
+            IfModifiedSince = ifModifiedSince,
+            IfUnmodifiedSince = ifUnmodifiedSince,
+        });
+
+        switch (outcome)
+        {
+            case HttpPreconditionOutcome.NotModified:
+                return ResponseKind.NotModified304;
+            case HttpPreconditionOutcome.PreconditionFailed:
+                return ResponseKind.PreconditionFailed412;
+        }
+
+        if (range is not HttpRangeHeader rangeHeader)
+        {
+            return ResponseKind.Ok200;
+        }
+
+        // Step 5: honor the range only when there is no If-Range or its validator still matches.
+        bool applyRange = ifRange is not HttpIfRange gate || gate.Matches(CurrentTag, LastModified);
+        if (!applyRange)
+        {
+            return ResponseKind.Ok200;
+        }
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(rangeHeader, ContentLength);
+        return selection.Status switch
+        {
+            HttpRangeSelectionStatus.Partial => ResponseKind.Partial206,
+            HttpRangeSelectionStatus.Unsatisfiable => ResponseKind.RangeNotSatisfiable416,
+            _ => ResponseKind.Ok200,
+        };
+    }
+
+    [Fact]
+    public void Get_IfNoneMatchMatches_ShouldBe304_BeforeAnyRange()
+    {
+        Decide(HttpMethod.Get, ifNoneMatch: HttpEntityTagCondition.Parse("\"v1\""), range: HttpRangeHeader.Parse("bytes=0-99"))
+            .ShouldBe(ResponseKind.NotModified304);
+    }
+
+    [Fact]
+    public void Put_IfMatchFails_ShouldBe412()
+    {
+        Decide(HttpMethod.Put, ifMatch: HttpEntityTagCondition.Parse("\"v2\""))
+            .ShouldBe(ResponseKind.PreconditionFailed412);
+    }
+
+    [Fact]
+    public void Get_RangeNoIfRangeSatisfiable_ShouldBe206()
+    {
+        Decide(HttpMethod.Get, range: HttpRangeHeader.Parse("bytes=0-99"))
+            .ShouldBe(ResponseKind.Partial206);
+    }
+
+    [Fact]
+    public void Get_RangeUnsatisfiable_ShouldBe416()
+    {
+        Decide(HttpMethod.Get, range: HttpRangeHeader.Parse("bytes=5000-6000"))
+            .ShouldBe(ResponseKind.RangeNotSatisfiable416);
+    }
+
+    [Fact]
+    public void Get_IfRangeMatches_ShouldApplyRange206()
+    {
+        Decide(HttpMethod.Get, range: HttpRangeHeader.Parse("bytes=0-99"), ifRange: HttpIfRange.FromEntityTag(HttpEntityTag.Strong("v1")))
+            .ShouldBe(ResponseKind.Partial206);
+    }
+
+    [Fact]
+    public void Get_IfRangeMismatch_ShouldIgnoreRangeAndServe200()
+    {
+        Decide(HttpMethod.Get, range: HttpRangeHeader.Parse("bytes=0-99"), ifRange: HttpIfRange.FromEntityTag(HttpEntityTag.Strong("stale")))
+            .ShouldBe(ResponseKind.Ok200);
+    }
+
+    [Fact]
+    public void Get_NoConditionsNoRange_ShouldBe200()
+    {
+        Decide(HttpMethod.Get).ShouldBe(ResponseKind.Ok200);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/Conditional/HttpRangeSelectorTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/Conditional/HttpRangeSelectorTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 9110 &#167; 14.2 compliance tests for <see cref="HttpRangeSelector"/>: satisfiable ranges
+/// produce <c>206</c> slices with correct <c>Content-Range</c> values, wholly-unsatisfiable requests
+/// produce <c>416</c> with <c>bytes */N</c>, and an oversized range set is ignored in favor of a full
+/// <c>200</c>.
+/// </summary>
+public class HttpRangeSelectorTests
+{
+    [Fact]
+    public void Select_SingleSatisfiableRange_ShouldReturnOneSlice()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=0-499");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Partial);
+        selection.IsSingleSlice.ShouldBeTrue();
+        selection.Slices[0].Offset.ShouldBe(0);
+        selection.Slices[0].Length.ShouldBe(500);
+        selection.Slices[0].ContentRange.ToString().ShouldBe("bytes 0-499/1000");
+    }
+
+    [Fact]
+    public void Select_SuffixRange_ShouldReturnTrailingSlice()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=-200");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Partial);
+        selection.Slices[0].Offset.ShouldBe(800);
+        selection.Slices[0].Length.ShouldBe(200);
+        selection.Slices[0].ContentRange.ToString().ShouldBe("bytes 800-999/1000");
+    }
+
+    [Fact]
+    public void Select_MultipleSatisfiableRanges_ShouldReturnSlicesInOrder()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=0-99,500-599,-100");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Partial);
+        selection.Slices.Count.ShouldBe(3);
+        selection.Slices[0].ContentRange.ToString().ShouldBe("bytes 0-99/1000");
+        selection.Slices[1].ContentRange.ToString().ShouldBe("bytes 500-599/1000");
+        selection.Slices[2].ContentRange.ToString().ShouldBe("bytes 900-999/1000");
+    }
+
+    [Fact]
+    public void Select_MixedSatisfiability_ShouldKeepOnlySatisfiableRanges()
+    {
+        // The second range starts past the end and is dropped; the first survives.
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=0-99,2000-2999");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Partial);
+        selection.Slices.Count.ShouldBe(1);
+        selection.Slices[0].Offset.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Select_AllUnsatisfiable_ShouldReturn416WithStarForm()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=2000-2999");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Unsatisfiable);
+        selection.UnsatisfiedContentRange.ToString().ShouldBe("bytes */1000");
+    }
+
+    [Fact]
+    public void Select_ZeroSuffixAgainstContent_ShouldBeUnsatisfiable()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=-0");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Unsatisfiable);
+        selection.UnsatisfiedContentRange.ToString().ShouldBe("bytes */1000");
+    }
+
+    [Fact]
+    public void Select_EmptyRepresentation_ShouldBeUnsatisfiable()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=0-0");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 0);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Unsatisfiable);
+        selection.UnsatisfiedContentRange.ToString().ShouldBe("bytes */0");
+    }
+
+    [Fact]
+    public void Select_TooManyRanges_ShouldFallBackToFull()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=0-0,1-1,2-2,3-3");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000, maxRanges: 3);
+
+        selection.Status.ShouldBe(HttpRangeSelectionStatus.Full);
+        selection.Slices.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Select_OpenEndedRange_ShouldSpanToEnd()
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse("bytes=990-");
+
+        HttpRangeSelection selection = HttpRangeSelector.Select(header, 1000);
+
+        selection.Slices[0].Offset.ShouldBe(990);
+        selection.Slices[0].Length.ShouldBe(10);
+        selection.Slices[0].ContentRange.ToString().ShouldBe("bytes 990-999/1000");
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpContentRangeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpContentRangeTests.cs
@@ -1,0 +1,87 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 9110 &#167; 14.4 compliance tests for <see cref="HttpContentRange"/>: the satisfied form (with
+/// a known or unknown complete length) and the unsatisfied <c>bytes */N</c> form that accompanies a
+/// <c>416</c> response.
+/// </summary>
+public class HttpContentRangeTests
+{
+    [Fact]
+    public void TryParse_SatisfiedWithLength_ShouldCaptureAllParts()
+    {
+        HttpContentRange.TryParse("bytes 0-499/1234", out HttpContentRange range).ShouldBeTrue();
+
+        range.IsUnsatisfied.ShouldBeFalse();
+        range.From.ShouldBe(0);
+        range.To.ShouldBe(499);
+        range.Length.ShouldBe(1234);
+        range.HasCompleteLength.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_SatisfiedUnknownLength_ShouldHaveNullLength()
+    {
+        HttpContentRange.TryParse("bytes 0-499/*", out HttpContentRange range).ShouldBeTrue();
+
+        range.From.ShouldBe(0);
+        range.To.ShouldBe(499);
+        range.Length.ShouldBeNull();
+        range.HasCompleteLength.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_Unsatisfied_ShouldExposeCompleteLengthOnly()
+    {
+        HttpContentRange.TryParse("bytes */1234", out HttpContentRange range).ShouldBeTrue();
+
+        range.IsUnsatisfied.ShouldBeTrue();
+        range.From.ShouldBeNull();
+        range.To.ShouldBeNull();
+        range.Length.ShouldBe(1234);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("bytes")]
+    [InlineData("bytes 0-499")]      // missing "/length"
+    [InlineData("bytes */*")]        // unsatisfied form requires a length
+    [InlineData("bytes 499-0/1234")] // last < first
+    [InlineData("bytes 0-1234/1000")]// last must be < complete-length
+    [InlineData("items 0-1/2")]      // unknown unit
+    [InlineData("bytes 0-/10")]      // missing last-pos
+    public void TryParse_Malformed_ShouldFail(string raw)
+    {
+        HttpContentRange.TryParse(raw, out HttpContentRange range).ShouldBeFalse();
+        range.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Satisfied_LastPosNotLessThanCompleteLength_ShouldThrow()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => HttpContentRange.Satisfied(0, 1000, 1000));
+    }
+
+    [Theory]
+    [InlineData("bytes 0-499/1234")]
+    [InlineData("bytes 0-499/*")]
+    [InlineData("bytes */1234")]
+    public void ToString_ShouldRoundTrip(string raw)
+    {
+        HttpContentRange range = HttpContentRange.Parse(raw);
+
+        range.ToString().ShouldBe(raw);
+    }
+
+    [Fact]
+    public void Unsatisfied_Factory_ShouldRenderStarForm()
+    {
+        HttpContentRange.Unsatisfied(1234).ToString().ShouldBe("bytes */1234");
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpIfRangeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpIfRangeTests.cs
@@ -1,0 +1,156 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 9110 &#167; 13.1.5 compliance tests for <see cref="HttpIfRange"/>: distinguishing the
+/// entity-tag form from the HTTP-date form and round-tripping each.
+/// </summary>
+public class HttpIfRangeTests
+{
+    [Fact]
+    public void TryParse_EntityTag_ShouldCaptureTag()
+    {
+        HttpIfRange.TryParse("\"xyzzy\"", out HttpIfRange ifRange).ShouldBeTrue();
+
+        ifRange.IsEntityTag.ShouldBeTrue();
+        ifRange.EntityTag!.Value.Tag.ShouldBe("xyzzy");
+        ifRange.Date.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryParse_WeakEntityTag_ShouldCaptureWeakness()
+    {
+        HttpIfRange.TryParse("W/\"xyzzy\"", out HttpIfRange ifRange).ShouldBeTrue();
+
+        ifRange.IsEntityTag.ShouldBeTrue();
+        ifRange.EntityTag!.Value.IsWeak.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_HttpDate_ShouldCaptureDate()
+    {
+        HttpIfRange.TryParse("Sun, 06 Nov 1994 08:49:37 GMT", out HttpIfRange ifRange).ShouldBeTrue();
+
+        ifRange.IsEntityTag.ShouldBeFalse();
+        ifRange.Date.ShouldBe(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero));
+    }
+
+    [Theory]
+    // RFC 9110 § 5.6.7: recipients MUST accept all three HTTP-date formats. All three encode the
+    // same instant (a Wednesday, so the RFC 850 / asctime forms also exercise the "Wed" vs "W/"
+    // entity-tag disambiguation).
+    [InlineData("Wed, 01 Jan 2020 00:00:00 GMT")]     // IMF-fixdate
+    [InlineData("Wednesday, 01-Jan-20 00:00:00 GMT")] // obsolete RFC 850
+    [InlineData("Wed Jan  1 00:00:00 2020")]          // asctime (space-padded day)
+    public void TryParse_AllThreeDateFormats_ShouldParseToSameInstant(string raw)
+    {
+        HttpIfRange.TryParse(raw, out HttpIfRange ifRange).ShouldBeTrue();
+
+        ifRange.IsEntityTag.ShouldBeFalse();
+        ifRange.Date.ShouldBe(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-date")]
+    [InlineData("\"unterminated")]
+    public void TryParse_Malformed_ShouldFail(string raw)
+    {
+        HttpIfRange.TryParse(raw, out HttpIfRange ifRange).ShouldBeFalse();
+        ifRange.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ToString_EntityTag_ShouldRoundTrip()
+    {
+        HttpIfRange.Parse("W/\"abc\"").ToString().ShouldBe("W/\"abc\"");
+    }
+
+    [Fact]
+    public void ToString_Date_ShouldEmitImfFixdate()
+    {
+        HttpIfRange ifRange = HttpIfRange.FromDate(new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero));
+
+        ifRange.ToString().ShouldBe("Sun, 06 Nov 1994 08:49:37 GMT");
+    }
+
+    // ============================================================================
+    // Matches (RFC 9110 § 13.1.5 / § 13.2.2 step 5) — the range-application decision
+    // ============================================================================
+
+    private static readonly DateTimeOffset LastModified = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Matches_EntityTagStrongMatch_ShouldApplyRange()
+    {
+        HttpIfRange ifRange = HttpIfRange.FromEntityTag(HttpEntityTag.Strong("v1"));
+
+        ifRange.Matches(HttpEntityTag.Strong("v1"), LastModified).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_EntityTagMismatch_ShouldIgnoreRange()
+    {
+        HttpIfRange ifRange = HttpIfRange.FromEntityTag(HttpEntityTag.Strong("v1"));
+
+        ifRange.Matches(HttpEntityTag.Strong("v2"), LastModified).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_WeakCurrentTag_ShouldIgnoreRange()
+    {
+        // If-Range uses strong comparison, so a weak current validator never applies the range.
+        HttpIfRange ifRange = HttpIfRange.FromEntityTag(HttpEntityTag.Strong("v1"));
+
+        ifRange.Matches(HttpEntityTag.Weak("v1"), LastModified).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_EntityTagButNoCurrentTag_ShouldIgnoreRange()
+    {
+        HttpIfRange ifRange = HttpIfRange.FromEntityTag(HttpEntityTag.Strong("v1"));
+
+        ifRange.Matches(currentETag: null, LastModified).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_DateEqualsLastModified_ShouldApplyRange()
+    {
+        HttpIfRange.FromDate(LastModified).Matches(null, LastModified).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_DateOlderThanLastModified_ShouldIgnoreRange()
+    {
+        // Representation was modified after the client's date → serve the full 200.
+        HttpIfRange ifRange = HttpIfRange.FromDate(new DateTimeOffset(2019, 6, 1, 0, 0, 0, TimeSpan.Zero));
+
+        ifRange.Matches(null, LastModified).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_DateNewerThanLastModified_ShouldApplyRange()
+    {
+        HttpIfRange ifRange = HttpIfRange.FromDate(new DateTimeOffset(2020, 6, 1, 0, 0, 0, TimeSpan.Zero));
+
+        ifRange.Matches(null, LastModified).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_SubSecondLastModification_ShouldStillApplyRange()
+    {
+        // A sub-second bump does not count as modified at HTTP-date (one-second) granularity.
+        HttpIfRange.FromDate(LastModified).Matches(null, LastModified.AddMilliseconds(500)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_DateFormButNoLastModified_ShouldIgnoreRange()
+    {
+        HttpIfRange.FromDate(LastModified).Matches(HttpEntityTag.Strong("v1"), currentLastModified: null).ShouldBeFalse();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpRangeTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/ValueObjects/HttpRangeTests.cs
@@ -1,0 +1,189 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+/// <summary>
+/// RFC 9110 &#167; 14.1.1 / &#167; 14.1.2 compliance tests for <see cref="HttpRange"/> and
+/// <see cref="HttpRangeHeader"/>: int-range, open-ended, and suffix-range parsing; multiple ranges;
+/// strict rejection of malformed sets and unknown units; and single-range resolution against a
+/// known content length.
+/// </summary>
+public class HttpRangeTests
+{
+    // ============================================================================
+    // Single range-spec parsing
+    // ============================================================================
+
+    [Fact]
+    public void TryParse_ClosedIntRange_ShouldCaptureBounds()
+    {
+        HttpRange.TryParse("0-499", out HttpRange range).ShouldBeTrue();
+
+        range.From.ShouldBe(0);
+        range.To.ShouldBe(499);
+        range.IsSuffix.ShouldBeFalse();
+        range.IsOpenEnded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_OpenEndedIntRange_ShouldHaveNoEnd()
+    {
+        HttpRange.TryParse("500-", out HttpRange range).ShouldBeTrue();
+
+        range.From.ShouldBe(500);
+        range.To.ShouldBeNull();
+        range.IsOpenEnded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_SuffixRange_ShouldCaptureLength()
+    {
+        HttpRange.TryParse("-500", out HttpRange range).ShouldBeTrue();
+
+        range.IsSuffix.ShouldBeTrue();
+        range.SuffixLength.ShouldBe(500);
+        range.From.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-")]
+    [InlineData("abc")]
+    [InlineData("10-abc")]
+    [InlineData("abc-10")]
+    [InlineData("499-0")]     // last < first
+    [InlineData("1-2-3")]     // extra dash
+    [InlineData("- 5")]       // internal space
+    public void TryParse_Malformed_ShouldFail(string raw)
+    {
+        HttpRange.TryParse(raw, out HttpRange range).ShouldBeFalse();
+        range.IsEmpty.ShouldBeTrue();
+    }
+
+    // ============================================================================
+    // Resolution against content length (RFC 9110 § 14.1.2)
+    // ============================================================================
+
+    [Fact]
+    public void TryResolve_ClosedRangeWithinContent_ShouldReturnExactSlice()
+    {
+        HttpRange.FromTo(0, 499).TryResolve(1000, out long offset, out long length).ShouldBeTrue();
+
+        offset.ShouldBe(0);
+        length.ShouldBe(500);
+    }
+
+    [Fact]
+    public void TryResolve_ClosedRangePastEnd_ShouldClampToContent()
+    {
+        // bytes=500-1000 against a 1000-byte body clamps the last position to 999.
+        HttpRange.FromTo(500, 1000).TryResolve(1000, out long offset, out long length).ShouldBeTrue();
+
+        offset.ShouldBe(500);
+        length.ShouldBe(500);
+    }
+
+    [Fact]
+    public void TryResolve_OpenEnded_ShouldSpanToEnd()
+    {
+        HttpRange.StartingAt(900).TryResolve(1000, out long offset, out long length).ShouldBeTrue();
+
+        offset.ShouldBe(900);
+        length.ShouldBe(100);
+    }
+
+    [Fact]
+    public void TryResolve_SuffixLongerThanContent_ShouldReturnWholeBody()
+    {
+        HttpRange.Suffix(5000).TryResolve(1000, out long offset, out long length).ShouldBeTrue();
+
+        offset.ShouldBe(0);
+        length.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void TryResolve_Suffix_ShouldReturnTrailingBytes()
+    {
+        HttpRange.Suffix(200).TryResolve(1000, out long offset, out long length).ShouldBeTrue();
+
+        offset.ShouldBe(800);
+        length.ShouldBe(200);
+    }
+
+    [Fact]
+    public void TryResolve_FirstPosAtOrBeyondEnd_ShouldBeUnsatisfiable()
+    {
+        HttpRange.StartingAt(1000).TryResolve(1000, out _, out _).ShouldBeFalse();
+        HttpRange.FromTo(1500, 2000).TryResolve(1000, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_ZeroSuffix_ShouldBeUnsatisfiable()
+    {
+        HttpRange.Suffix(0).TryResolve(1000, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_EmptyContent_ShouldBeUnsatisfiable()
+    {
+        HttpRange.FromTo(0, 10).TryResolve(0, out _, out _).ShouldBeFalse();
+        HttpRange.Suffix(10).TryResolve(0, out _, out _).ShouldBeFalse();
+    }
+
+    // ============================================================================
+    // Full Range header parsing
+    // ============================================================================
+
+    [Fact]
+    public void TryParse_MultipleRanges_ShouldPreserveOrder()
+    {
+        HttpRangeHeader.TryParse("bytes=0-499, 500-999 , -500", out HttpRangeHeader header).ShouldBeTrue();
+
+        header.Unit.ShouldBe("bytes");
+        header.Count.ShouldBe(3);
+        header.Ranges[0].ShouldBe(HttpRange.FromTo(0, 499));
+        header.Ranges[1].ShouldBe(HttpRange.FromTo(500, 999));
+        header.Ranges[2].ShouldBe(HttpRange.Suffix(500));
+    }
+
+    [Fact]
+    public void TryParse_EmptyListElements_ShouldBeSkipped()
+    {
+        HttpRangeHeader.TryParse("bytes=0-0,,1-1", out HttpRangeHeader header).ShouldBeTrue();
+
+        header.Count.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("bytes=")]
+    [InlineData("bytes")]
+    [InlineData("bytes=abc")]
+    [InlineData("bytes=0-499,bad")]   // one malformed member invalidates the whole set
+    [InlineData("items=0-499")]       // unknown unit
+    [InlineData("=0-499")]
+    public void TryParse_MalformedOrUnknownUnit_ShouldFail(string raw)
+    {
+        HttpRangeHeader.TryParse(raw, out HttpRangeHeader header).ShouldBeFalse();
+        header.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_UnitIsCaseInsensitive()
+    {
+        HttpRangeHeader.TryParse("BYTES=0-1", out HttpRangeHeader header).ShouldBeTrue();
+        header.Count.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData("bytes=0-499,-500")]
+    [InlineData("bytes=500-")]
+    public void ToString_ShouldRoundTrip(string raw)
+    {
+        HttpRangeHeader header = HttpRangeHeader.Parse(raw);
+
+        header.ToString().ShouldBe(raw);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the typed **byte-range** and **`If-Range`** primitives for `libraries/Http/Assimalign.Cohesion.Http`, turning the `Range` / `Content-Range` / `If-Range` field names into RFC 9110-correct response decisions (`206` / `416`, and the range-application decision). Stage 1 · Lane B, unblocked per `docs/HTTP_WEB_PROGRAM_PLAN.md` §4. Consumed by `Web.StaticFiles` (#777) and output caching (#795).

> **Built on #755 (now merged).** The issue required coordinating validator/ETag types with #755 (caching primitives) "so they are shared, not duplicated." #755 (PR #839, now on `main`) lands `HttpEntityTag`, `HttpEntityTagCondition`, `HttpDate`, and the §13.2.2 steps-1–4 precondition evaluator (`HttpConditionalRequest`), and its DESIGN.md explicitly cedes range requests + `If-Range` to this issue. This PR **reuses those types rather than re-defining them** and has been rebased onto `main` — its diff is only the range layer below (no duplicated validator types).

## What this adds (on top of #755)

Value objects (`readonly struct`, span `TryParse`/`Parse`/`ToString`, mirroring `HttpMediaType`):

| Type | Field | RFC |
|---|---|---|
| `HttpRange` / `HttpRangeHeader` | `Range` — int-range, open-ended, suffix, multiple + §14.1.2 resolution | §14.1.1 |
| `HttpContentRange` | `Content-Range` — satisfied + unsatisfied `bytes */N` | §14.4 |
| `HttpIfRange` (+ `Matches`) | `If-Range` — entity-tag **or** HTTP-date, and the §13.2.2 **step-5** decision | §13.1.5 |

Evaluator (pure `static`, matching `HttpContentNegotiation` / #755's helpers):

- `HttpRangeSelector.Select(range, completeLength, maxRanges)` → `HttpRangeSelection`: satisfiable ranges → **206** `HttpRangeSlice`s (offset/length + a `Content-Range` each, in client order); wholly-unsatisfiable → **416** with `bytes */N`; an oversized range set → **`Full`** (200) — the DoS guard RFC 9110 §14.2 blesses. (§14.2)

`HttpErrorCode` gains `InvalidRange` / `InvalidContentRange` / `InvalidConditional` (+ internal exceptions).

## How the §13.2.2 "typed decision" composes

#755 owns steps 1–4; this PR is step 5. Together they give the full proceed / `304` / `412` / `206` / `416` / ignore-range decision (exercised end-to-end by `HttpRangePreconditionCompositionTests`):

```
outcome = HttpConditionalRequest.Evaluate(context)      // #755: steps 1–4 → 304 / 412 / proceed
if outcome != Proceed              → send 304 / 412
else if a Range is present:
    applyRange = ifRange is null || ifRange.Matches(currentETag, currentLastModified)   // step 5 (this PR)
    if applyRange   → HttpRangeSelector.Select(...)     → 206 / 416 / (Full → 200)
    else            → 200 full          // If-Range validator stale → serve the whole thing
else                               → 200 full
```

`If-Range` is always **strong** (entity-tag form uses `HttpEntityTag.StrongEquals`; date form applies only when `Last-Modified ≤ If-Range date`, compared at one-second granularity), and a mismatch *ignores* the range (full `200`) rather than failing — never a `412`.

## Tests

New Shouldly tests co-located under `tests/` (**687 total green**, incl. #755's suite, 0 warnings): multi-range, suffix-range, open-ended, invalid/unknown-unit rejection, `206`/`416`/`Full` selection, `If-Range` strong entity-tag + date semantics (incl. sub-second truncation), and the end-to-end precondition+range composition. All AOT/trim-safe, no reflection.

## AGENTS.md / notes

File-scoped namespaces; `CohesionProjectReference` only (no new packages, no `Microsoft.Extensions.*`); `IsAotCompatible=true`; XML docs on all public APIs; area-scoped internal exceptions (`HttpException` root); `docs/DESIGN.md` gains a range/`If-Range` section documenting the layering on #755. Range value objects are structs and `HttpRangeSelector` is a `static` class — matching the `HttpMediaType` / `HttpContentNegotiation` / #755 shape (interface-first governs stateful services; these are pure protocol transforms), as documented in DESIGN.md. No edits to `HTTP_WEB_PROGRAM_PLAN.md` — the orchestrator reconciles the Progress Log.

Closes #792
