### PR TITLE
[L01.01.11.36] Streaming response write path (h1/h2/h3) + Server-Sent Events primitives

### DIFF
--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -851,6 +851,23 @@
 	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ExtendedConnect/tests/">
 		<Project Path="libraries/Http/Assimalign.Cohesion.Http.ExtendedConnect/tests/Assimalign.Cohesion.Http.ExtendedConnect.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.Streaming/" />
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/">
+		<Project Path="libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Assimalign.Cohesion.Http.Streaming.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/">
+		<Project Path="libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/Assimalign.Cohesion.Http.Streaming.Tests.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/" />
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/">
+		<Project Path="libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Assimalign.Cohesion.Http.ServerSentEvents.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/">
+		<Project Path="libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/Assimalign.Cohesion.Http.ServerSentEvents.Tests.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/">
+		<Project Path="libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ProtocolUpgrade/" />
 	<Folder Name="/cohesion/libraries/Http/Assimalign.Cohesion.Http.ProtocolUpgrade/src/">
 		<Project Path="libraries/Http/Assimalign.Cohesion.Http.ProtocolUpgrade/src/Assimalign.Cohesion.Http.ProtocolUpgrade.csproj" />

--- a/libraries/Assimalign.Cohesion.Libraries.slnx
+++ b/libraries/Assimalign.Cohesion.Libraries.slnx
@@ -624,6 +624,23 @@
 	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.ExtendedConnect/tests/">
 		<Project Path="Http/Assimalign.Cohesion.Http.ExtendedConnect/tests/Assimalign.Cohesion.Http.ExtendedConnect.Tests.csproj" />
 	</Folder>
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.Streaming/" />
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/">
+		<Project Path="Http/Assimalign.Cohesion.Http.Streaming/src/Assimalign.Cohesion.Http.Streaming.csproj" />
+	</Folder>
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/">
+		<Project Path="Http/Assimalign.Cohesion.Http.Streaming/tests/Assimalign.Cohesion.Http.Streaming.Tests.csproj" />
+	</Folder>
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/" />
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/">
+		<Project Path="Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Assimalign.Cohesion.Http.ServerSentEvents.csproj" />
+	</Folder>
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/">
+		<Project Path="Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/Assimalign.Cohesion.Http.ServerSentEvents.Tests.csproj" />
+	</Folder>
+	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/">
+		<Project Path="Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse.csproj" />
+	</Folder>
 	<Folder Name="/libraries/Http/Assimalign.Cohesion.Http.Forms/">
 		<File Path="Http/Assimalign.Cohesion.Http.Forms/README.md" />
 	</Folder>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -278,6 +278,111 @@ gone, replaced by the listener's declared `ConnectionCapabilities`:
   handshake runs), surfaced through a typed seam rather than through
   HTTP-transport plumbing.
 
+## Response streaming: raw body sink behind the response-interceptor seam
+
+### What it is
+
+The baseline response path buffers a whole response and serializes it once
+(`SendAsync` reads `Response.Body` and writes it in a single HEADERS+DATA
+sequence). That cannot express Server-Sent Events, long-lived progress feeds, or
+memory-efficient large responses, because the peer sees nothing until the handler
+returns. The streaming write path adds the ability to start a response and write it
+incrementally — but **it is deliberately not wired into the transport as a
+streaming feature.** Instead the transport exposes a generic seam and a raw body
+sink; the streaming/SSE capability is a feature package that plugs in.
+
+This keeps the transport free of any streaming or SSE dependency: the streaming
+API, its state machine, and the SSE wire format all live in feature packages
+(`Assimalign.Cohesion.Http.Streaming`, `Assimalign.Cohesion.Http.ServerSentEvents`)
+that this library never references.
+
+### The two moving parts
+
+- **`HttpResponseBodyStream`** — the transport's raw response body sink, a write-only
+  `System.IO.Stream`. Its abstract base owns the response-lifecycle state machine
+  (commit-the-head-once on the first write/flush, idempotent completion) and forwards
+  the framing to per-protocol subclasses: `Http1ResponseBodyStream` (chunked transfer
+  coding), `Http2ResponseBodyStream` / `Http3ResponseBodyStream` (`DATA` frames). This
+  is where the header-commit timing and the wire framing live.
+- **`IHttpResponseInterceptor`** (core Http) + `HttpConnectionListenerOptions.ResponseInterceptors`
+  — the symmetric counterpart to the request-interceptor seam. At context setup, when
+  any response interceptor is registered, the transport creates the per-protocol sink,
+  builds a `HttpResponseInterceptorContext` exposing it as `ResponseBody`, and runs the
+  interceptors. A feature package's interceptor wraps the sink in a typed feature and
+  installs it on `context.Features`; the transport neither knows nor cares what feature.
+
+Response interceptors are snapshotted on the `HttpConnectionListener` (like request
+interceptors) and threaded to all three protocol connections. **Zero response
+interceptors is a true fast path**: no sink is created and the buffered response
+path runs exactly as before.
+
+### The `SendAsync` inversion
+
+The connection loop still calls `connectionContext.SendAsync(context)` after the
+handler returns. Each transport's `SendAsync` branches at the top: if a response
+feature wrote to the raw sink (`ResponseBodySink is { HasStarted: true }`),
+`SendAsync` **finalizes** the sink — emitting the terminating zero-length chunk
+(HTTP/1.1) or the empty `END_STREAM` DATA frame (HTTP/2) — instead of writing a
+second buffered response. If the sink was never written (or none exists), the
+buffered path runs unchanged. The wire terminator is thus emitted by the transport
+when it finalizes the exchange, not by the feature.
+
+### Per-protocol framing
+
+- **HTTP/1.1 — chunked transfer coding (RFC 9112 §7.1).** When the handler left
+  `Content-Length` unset (the streaming case), `Http1ResponseBodyStream` adds
+  `Transfer-Encoding: chunked` and wraps every write in a chunk; the finalize emits
+  the terminating zero-length chunk. Chunked framing is self-delimiting, so the
+  connection stays keep-alive. A HEAD response commits the head but writes no body.
+  `Http1MessageWriter.WriteHeadAsync` is shared by the buffered and streaming paths.
+- **HTTP/2 — incremental DATA frames (RFC 9113).** The HEADERS block is written
+  **without** a synthesized `Content-Length` (the body is delimited by
+  `END_STREAM`); each write emits one or more DATA frames split on the peer's
+  `MAX_FRAME_SIZE`, each flushed through the transport; finalize emits an empty DATA
+  frame carrying `END_STREAM`.
+- **HTTP/3 — incremental DATA frames (RFC 9114).** Same shape over the QUIC request
+  stream (a HEADERS frame with no `Content-Length`, then DATA frames). The body is
+  delimited by the QUIC stream end, so finalize only flushes.
+
+### Backpressure (flow control)
+
+- **HTTP/2** multiplexes over one TCP stream and tracks flow-control windows in
+  software, so send-side backpressure is enforced here. `WriteStreamingDataAsync`
+  calls `AcquireSendWindowAsync`, which consumes credit from **both** the
+  connection-level and stream-level send windows (RFC 9113 §5.2) and, when both are
+  exhausted, parks on a `TaskCompletionSource` signal until an inbound
+  `WINDOW_UPDATE` (or a `SETTINGS_INITIAL_WINDOW_SIZE` increase) replenishes credit.
+  Window reads/writes are serialized under a dedicated `_sendFlowLock`;
+  `ProcessWindowUpdateFrame` replenishes under the same lock and signals parked
+  writers. A writer never holds the flow lock across an `await`, and signal
+  completions run asynchronously so a parked writer never resumes inline under the
+  lock.
+- **HTTP/3** rides QUIC, whose per-stream flow control is applied by the transport on
+  the underlying `Stream.WriteAsync`, so no software window accounting is needed here.
+
+Because a streaming response is written on the application thread while the receive
+loop keeps pumping frames (so window replenishment can arrive), the HTTP/2 path is
+careful about shared state: all outbound frame writes go through the existing
+`_writeLock`, all send-window access goes through `_sendFlowLock`, and the streaming
+completion does **not** remove the stream from `_streams` (a concurrent `Remove`
+would race the receive loop's reads). The fully-closed stream is reaped at
+connection teardown instead.
+
+### AOT posture
+
+No reflection, no runtime code generation. Chunk framing is byte arithmetic; the
+HTTP/2 flow controller is lock + `TaskCompletionSource` signaling.
+
+### Non-goals
+
+- **Data-rate (minimum-throughput) limits** on the streamed body — deferred with the
+  other data-rate limits.
+- **HEAD-body suppression on HTTP/2 / HTTP/3.** Only the HTTP/1.1 path suppresses the
+  body for HEAD; the h2/h3 buffered paths never did, and the sink matches their
+  existing behavior.
+- **A streaming/SSE dependency in this library.** By design — the feature packages
+  own it; this transport only exposes the sink and the interceptor seam.
+
 ## Receive-loop failure isolation
 
 Each protocol's receive loop (`Http1ConnectionContext.ReceiveAsync`,

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/examples/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/examples/README.md
@@ -26,3 +26,4 @@ dotnet run --project .\examples\Assimalign.Cohesion.Http.Connections.Examples.Ht
 - The HTTP/3 example uses QUIC and requires a QUIC-capable platform and runtime.
 - If the HTTP/3 sample fails during the QUIC/TLS handshake, verify local QUIC support and certificate handling on the host machine before debugging the HTTP/3 frame layer.
 - All examples are single-request samples intended to demonstrate real end-to-end protocol flow on localhost.
+- The incremental **response-streaming** write path these transports expose (chunked / DATA-frame streaming) is demonstrated end-to-end by the Server-Sent Events sample under `libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples`, which composes this transport with the SSE feature package.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListener.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListener.cs
@@ -31,6 +31,7 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
     private readonly List<IMultiplexedConnectionListener> _multiplexedListeners;
     private readonly HttpServerLimits _limits;
     private readonly IHttpRequestInterceptor[] _interceptors;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
     private readonly List<Task> _acceptLoops;
     private readonly Channel<HttpConnection> _acceptedConnections;
     private readonly CancellationTokenSource _disposeCancellationTokenSource;
@@ -59,6 +60,7 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
         // Snapshot: registrations after this point must not race the accept loops or observe a
         // half-mutated list; the empty snapshot keeps the parser's zero-interceptor fast path.
         _interceptors = [.. options.Interceptors];
+        _responseInterceptors = [.. options.ResponseInterceptors];
 
         HttpProtocol protocols = HttpProtocol.None;
 
@@ -244,8 +246,8 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
 
                 HttpConnection httpConnection = protocol switch
                 {
-                    HttpProtocol.Http11 => new Http1Connection(connection, isSecure, _limits, _interceptors),
-                    HttpProtocol.Http20 => new Http2Connection(connection, isSecure),
+                    HttpProtocol.Http11 => new Http1Connection(connection, isSecure, _limits, _interceptors, _responseInterceptors),
+                    HttpProtocol.Http20 => new Http2Connection(connection, isSecure, _responseInterceptors),
                     _ => throw new InvalidOperationException($"The configured HTTP protocol '{protocol}' does not map to a stream connection listener.")
                 };
 
@@ -287,7 +289,7 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
                     .AcceptAsync(_disposeCancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
-                HttpConnection httpConnection = CreateHttp3Connection(multiplexedConnection, isSecure);
+                HttpConnection httpConnection = CreateHttp3Connection(multiplexedConnection, isSecure, _responseInterceptors);
 
                 await _acceptedConnections.Writer.WriteAsync(httpConnection, _disposeCancellationTokenSource.Token).ConfigureAwait(false);
             }
@@ -315,14 +317,14 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
         }
     }
 
-    private static Http3Connection CreateHttp3Connection(IMultiplexedConnection connection, bool isSecure)
+    private static Http3Connection CreateHttp3Connection(IMultiplexedConnection connection, bool isSecure, IHttpResponseInterceptor[] responseInterceptors)
     {
         if (!IsHttp3SupportedPlatform())
         {
             throw new PlatformNotSupportedException("HTTP/3 transports require a QUIC-capable platform.");
         }
 
-        return new Http3Connection(connection, isSecure);
+        return new Http3Connection(connection, isSecure, responseInterceptors);
     }
 
     [SupportedOSPlatformGuard("windows")]

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListenerOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListenerOptions.cs
@@ -60,6 +60,28 @@ public sealed class HttpConnectionListenerOptions
     public IList<IHttpRequestInterceptor> Interceptors { get; } = new List<IHttpRequestInterceptor>();
 
     /// <summary>
+    /// Gets the ordered list of response interceptors invoked while each exchange's response
+    /// pipeline is being set up, before the application handler runs. See
+    /// <see cref="IHttpResponseInterceptor"/> for the hook contract.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the symmetric counterpart to <see cref="Interceptors"/>: response-side feature
+    /// packages (incremental streaming, Server-Sent Events, later compression) plug in here so the
+    /// transport can expose its raw response body sink to them without depending on the feature
+    /// package. The list is snapshotted when the <see cref="HttpConnectionListener"/> is constructed;
+    /// mutations after that point have no effect. A registered instance is shared across every
+    /// connection and request the listener serves, so implementations must be stateless and
+    /// thread-safe.
+    /// </para>
+    /// <para>
+    /// When the list is empty the transport takes the buffered fast path with no per-exchange
+    /// response-sink allocation at all.
+    /// </para>
+    /// </remarks>
+    public IList<IHttpResponseInterceptor> ResponseInterceptors { get; } = new List<IHttpResponseInterceptor>();
+
+    /// <summary>
     /// Gets or sets the maximum number of accepted HTTP connections that may be buffered
     /// before producers wait for <see cref="HttpConnectionListener.AcceptOrListenAsync(System.Threading.CancellationToken)"/>
     /// to dequeue them.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1Connection.cs
@@ -11,14 +11,16 @@ internal sealed class Http1Connection : HttpConnection
     private readonly IConnection _connection;
     private readonly HttpServerLimits _limits;
     private readonly IHttpRequestInterceptor[] _interceptors;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
     private Http1ConnectionContext? _openContext;
 
-    public Http1Connection(IConnection connection, bool isSecure, HttpServerLimits limits, IHttpRequestInterceptor[] interceptors)
+    public Http1Connection(IConnection connection, bool isSecure, HttpServerLimits limits, IHttpRequestInterceptor[] interceptors, IHttpResponseInterceptor[] responseInterceptors)
         : base(isSecure)
     {
         _connection = connection;
         _limits = limits;
         _interceptors = interceptors;
+        _responseInterceptors = responseInterceptors;
     }
 
     public override ConnectionId Id => _connection.Id;
@@ -36,7 +38,7 @@ internal sealed class Http1Connection : HttpConnection
     {
         // The wrapped connection is already live (connections are produced live by the
         // listener), so opening the HTTP context is a synchronous projection.
-        return _openContext ??= new Http1ConnectionContext(_connection, IsSecure, _limits, _interceptors);
+        return _openContext ??= new Http1ConnectionContext(_connection, IsSecure, _limits, _interceptors, _responseInterceptors);
     }
 
     public override ValueTask<HttpConnectionContext> OpenAsync(CancellationToken cancellationToken = default)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionContext.cs
@@ -14,12 +14,14 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
 {
     private readonly HttpServerLimits _limits;
     private readonly IHttpRequestInterceptor[] _interceptors;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
 
-    public Http1ConnectionContext(IConnection connection, bool isSecure, HttpServerLimits limits, IHttpRequestInterceptor[] interceptors)
+    public Http1ConnectionContext(IConnection connection, bool isSecure, HttpServerLimits limits, IHttpRequestInterceptor[] interceptors, IHttpResponseInterceptor[] responseInterceptors)
         : base(connection, isSecure)
     {
         _limits = limits;
         _interceptors = interceptors;
+        _responseInterceptors = responseInterceptors;
     }
 
     /// <summary>
@@ -50,6 +52,14 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
                 yield break;
             }
 
+            // Expose the raw chunked response body sink to registered response interceptors so a
+            // feature package (streaming / SSE) can wrap it and install a typed response feature —
+            // without this transport depending on that package. Zero interceptors → buffered fast path.
+            if (_responseInterceptors.Length > 0)
+            {
+                context.RunResponseInterceptors(_responseInterceptors, new Http1ResponseBodyStream(Stream, context));
+            }
+
             yield return context;
 
             if (!context.KeepAlive)
@@ -64,6 +74,14 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
         if (context is not Http1Context http1Context)
         {
             throw new InvalidOperationException("The supplied context does not belong to an HTTP/1.1 connection.");
+        }
+
+        // If a response feature streamed to the raw sink, the head and body are already on the
+        // wire; finalize (emit the terminating zero-length chunk) rather than writing a second,
+        // buffered response.
+        if (http1Context.ResponseBodySink is { HasStarted: true } sink)
+        {
+            return new ValueTask(sink.CompleteAsync(cancellationToken));
         }
 
         // NOTE: the suppress-response-on-upgrade behaviour previously gated by

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1MessageWriter.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1MessageWriter.cs
@@ -41,7 +41,32 @@ internal static class Http1MessageWriter
             headers[HttpHeaderKey.Connection] = "close";
         }
 
-        await WriteAsciiAsync(stream, $"HTTP/1.1 {context.Response.StatusCode}\r\n", cancellationToken).ConfigureAwait(false);
+        await WriteHeadAsync(stream, context.Response.StatusCode, headers, cancellationToken).ConfigureAwait(false);
+
+        if (context.Request.Method != HttpMethod.Head && bodyBytes.Length > 0)
+        {
+            await stream.WriteAsync(bodyBytes, 0, bodyBytes.Length, cancellationToken).ConfigureAwait(false);
+        }
+
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Writes the response head — the status line, every header field line (with
+    /// RFC 6265 one-line-per-cookie handling for <c>Set-Cookie</c>), and the blank
+    /// line terminating the header section — without a trailing flush and without
+    /// writing any body. Shared by the buffered response path and the incremental
+    /// streaming sink (<see cref="Http1ResponseBodyStream"/>) so both commit
+    /// headers identically.
+    /// </summary>
+    /// <param name="stream">The connection stream to write to.</param>
+    /// <param name="statusCode">The response status code.</param>
+    /// <param name="headers">The response headers to emit.</param>
+    /// <param name="cancellationToken">A token to cancel the write.</param>
+    /// <returns>A task that completes when the head bytes have been written to the stream buffer.</returns>
+    public static async ValueTask WriteHeadAsync(Stream stream, HttpStatusCode statusCode, HttpHeaderCollection headers, CancellationToken cancellationToken)
+    {
+        await WriteAsciiAsync(stream, $"HTTP/1.1 {statusCode}\r\n", cancellationToken).ConfigureAwait(false);
 
         foreach (System.Collections.Generic.KeyValuePair<HttpHeaderKey, HttpHeaderValue> header in headers)
         {
@@ -65,13 +90,6 @@ internal static class Http1MessageWriter
         }
 
         await WriteAsciiAsync(stream, "\r\n", cancellationToken).ConfigureAwait(false);
-
-        if (context.Request.Method != HttpMethod.Head && bodyBytes.Length > 0)
-        {
-            await stream.WriteAsync(bodyBytes, 0, bodyBytes.Length, cancellationToken).ConfigureAwait(false);
-        }
-
-        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static async ValueTask<byte[]> ReadBodyAsync(Stream body, CancellationToken cancellationToken)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ResponseBodyStream.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Connections.Internal.Http1;
+
+/// <summary>
+/// HTTP/1.1 raw response body sink. Commits the response head on first write/flush and frames
+/// incremental writes with chunked transfer coding (RFC 9112 §7.1) when the caller left
+/// <c>Content-Length</c> unset; otherwise the body streams with identity framing.
+/// </summary>
+/// <remarks>
+/// Chunked framing is self-delimiting, so the connection can stay keep-alive after a streamed
+/// response. The connection stream is owned by the connection, so this sink never disposes it — it
+/// only writes and flushes.
+/// </remarks>
+internal sealed class Http1ResponseBodyStream : HttpResponseBodyStream
+{
+    // RFC 9112 §7.1 — the terminating zero-length chunk plus the (empty) trailer section: "0" CRLF CRLF.
+    private static readonly byte[] LastChunk = Encoding.ASCII.GetBytes("0\r\n\r\n");
+    private static readonly byte[] Crlf = { (byte)'\r', (byte)'\n' };
+
+    private readonly Stream _stream;
+    private readonly Http1Context _context;
+    private bool _chunked;
+    private bool _suppressBody;
+
+    public Http1ResponseBodyStream(Stream stream, Http1Context context)
+    {
+        _stream = stream;
+        _context = context;
+    }
+
+    protected override async ValueTask CommitHeadersAsync(CancellationToken cancellationToken)
+    {
+        HttpHeaderCollection headers = _context.Response.Headers;
+
+        // RFC 9110 §9.3.2 — a HEAD response carries the same header section a GET would but never a
+        // body, so suppress every body write and the terminator.
+        _suppressBody = _context.Request.Method == HttpMethod.Head;
+
+        // Chunked transfer coding is selected when the caller did not commit to a Content-Length,
+        // which is the streaming case (length not known up front).
+        if (!headers.ContainsKey(HttpHeaderKey.ContentLength))
+        {
+            _chunked = true;
+            if (!headers.ContainsKey(HttpHeaderKey.TransferEncoding))
+            {
+                headers[HttpHeaderKey.TransferEncoding] = "chunked";
+            }
+        }
+
+        if (!_context.KeepAlive && !headers.ContainsKey(HttpHeaderKey.Connection))
+        {
+            headers[HttpHeaderKey.Connection] = "close";
+        }
+
+        await Http1MessageWriter.WriteHeadAsync(_stream, _context.Response.StatusCode, headers, cancellationToken).ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async ValueTask WriteFramedAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+    {
+        if (_suppressBody)
+        {
+            return;
+        }
+
+        if (_chunked)
+        {
+            byte[] prefix = Encoding.ASCII.GetBytes(
+                data.Length.ToString("x", CultureInfo.InvariantCulture) + "\r\n");
+            await _stream.WriteAsync(prefix, cancellationToken).ConfigureAwait(false);
+            await _stream.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+            await _stream.WriteAsync(Crlf, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await _stream.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    protected override ValueTask FlushFramedAsync(CancellationToken cancellationToken)
+        => new(_stream.FlushAsync(cancellationToken));
+
+    protected override async ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
+    {
+        if (_chunked && !_suppressBody)
+        {
+            await _stream.WriteAsync(LastChunk, cancellationToken).ConfigureAwait(false);
+        }
+
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/HPack/HPackEncoder.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/HPack/HPackEncoder.cs
@@ -17,6 +17,21 @@ internal static partial class HPackEncoder
             headers[HttpHeaderKey.ContentLength] = bodyLength.ToString(CultureInfo.InvariantCulture);
         }
 
+        return EncodeResponseHeaders(statusCode, headers);
+    }
+
+    /// <summary>
+    /// Encodes the response field section for an <em>incrementally streamed</em>
+    /// response: the <c>:status</c> pseudo-header followed by the supplied headers
+    /// verbatim, with <b>no</b> <c>Content-Length</c> synthesized. A streaming
+    /// response has no known body length up front — HTTP/2 delimits the body with
+    /// <c>END_STREAM</c> — so injecting a length here would be wrong.
+    /// </summary>
+    /// <param name="statusCode">The response status code.</param>
+    /// <param name="headers">The response headers to emit as-is.</param>
+    /// <returns>The HPACK-encoded field section.</returns>
+    public static byte[] EncodeResponseHeaders(HttpStatusCode statusCode, IHttpHeaderCollection headers)
+    {
         using MemoryStream buffer = new();
         WriteStatusHeader(buffer, (int)statusCode);
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Connection.cs
@@ -9,12 +9,14 @@ namespace Assimalign.Cohesion.Http.Connections.Internal.Http2;
 internal sealed class Http2Connection : HttpConnection
 {
     private readonly IConnection _connection;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
     private Http2ConnectionContext? _context;
 
-    public Http2Connection(IConnection connection, bool isSecure)
+    public Http2Connection(IConnection connection, bool isSecure, IHttpResponseInterceptor[] responseInterceptors)
         : base(isSecure)
     {
         _connection = connection;
+        _responseInterceptors = responseInterceptors;
     }
 
     public override ConnectionId Id => _connection.Id;
@@ -32,7 +34,7 @@ internal sealed class Http2Connection : HttpConnection
     {
         // The wrapped connection is already live (connections are produced live by the
         // listener), so opening the HTTP context is a synchronous projection.
-        return _context ??= new Http2ConnectionContext(_connection, IsSecure);
+        return _context ??= new Http2ConnectionContext(_connection, IsSecure, _responseInterceptors);
     }
 
     public override ValueTask<HttpConnectionContext> OpenAsync(CancellationToken cancellationToken = default)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
@@ -39,6 +39,14 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     // SETTINGS_INITIAL_WINDOW_SIZE.
     private Http2FlowControlWindow _connectionSendWindow = new(Http2ConnectionSettings.InitialInitialWindowSize);
     private Http2FlowControlWindow _connectionReceiveWindow = new(Http2ConnectionSettings.InitialInitialWindowSize);
+    // RFC 9113 §5.2 — outbound DATA must not exceed the peer's advertised
+    // connection/stream send windows. Streaming response writes consume from
+    // those windows on the application thread while the receive loop replenishes
+    // them from inbound WINDOW_UPDATE / SETTINGS frames, so both the consume and
+    // the replenish are serialized under this lock. `_sendWindowSignal` wakes a
+    // writer parked on an exhausted window as soon as credit arrives.
+    private readonly object _sendFlowLock = new();
+    private TaskCompletionSource _sendWindowSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int? _continuationStreamId;
     private bool _initialized;
     private bool _receivedClientSettings;
@@ -51,13 +59,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     // keep the field a plain int.
     private int _peerLastStreamId = -1;
 
-    public Http2ConnectionContext(IConnection connection, bool isSecure)
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
+
+    public Http2ConnectionContext(IConnection connection, bool isSecure, IHttpResponseInterceptor[] responseInterceptors)
         : base(connection, isSecure)
     {
         _headerDecoder = new HPackDecoder();
         _streams = new Dictionary<int, Http2Stream>();
         _localSettings = BuildLocalSettings();
         _remoteSettings = new Http2ConnectionSettings();
+        _responseInterceptors = responseInterceptors;
     }
 
     /// <summary>
@@ -126,6 +137,14 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
 
             if (processed.Context is not null)
             {
+                // Expose the raw DATA-frame response body sink to registered response interceptors
+                // so a feature package (streaming / SSE) can wrap it and install a typed response
+                // feature — without this transport depending on that package.
+                if (_responseInterceptors.Length > 0)
+                {
+                    processed.Context.RunResponseInterceptors(_responseInterceptors, new Http2ResponseBodyStream(this, processed.Context));
+                }
+
                 yield return processed.Context;
             }
         }
@@ -289,6 +308,15 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         if (http2Context.CancelRequested)
         {
             await EmitRstStreamAsync(http2Context.StreamId, Http2ErrorCode.Cancel, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // If a response feature streamed to the raw sink, the head and DATA frames are already on
+        // the wire; finalize the stream (empty DATA + END_STREAM) rather than re-sending a buffered
+        // response.
+        if (http2Context.ResponseBodySink is { HasStarted: true } sink)
+        {
+            await sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -498,12 +526,18 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         if (receivedFrame.Frame.StreamId == 0)
         {
             // Connection-level credit. Overflow → FLOW_CONTROL_ERROR
-            // connection-level (RFC 9113 §6.9.1).
-            if (!_connectionSendWindow.TryReplenish(increment))
+            // connection-level (RFC 9113 §6.9.1). Replenish under the flow lock
+            // and wake any parked streaming writer.
+            lock (_sendFlowLock)
             {
-                throw new Http2ConnectionException(
-                    Http2ErrorCode.FlowControlError,
-                    $"HTTP/2 connection-level send window would exceed {Http2FlowControlWindow.MaxValue} after WINDOW_UPDATE.");
+                if (!_connectionSendWindow.TryReplenish(increment))
+                {
+                    throw new Http2ConnectionException(
+                        Http2ErrorCode.FlowControlError,
+                        $"HTTP/2 connection-level send window would exceed {Http2FlowControlWindow.MaxValue} after WINDOW_UPDATE.");
+                }
+
+                SignalSendWindowReplenished();
             }
 
             return;
@@ -527,12 +561,66 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             return;
         }
 
-        if (!stream.SendWindow.TryReplenish(increment))
+        lock (_sendFlowLock)
         {
-            throw new Http2StreamException(
-                receivedFrame.Frame.StreamId,
-                Http2ErrorCode.FlowControlError,
-                $"HTTP/2 stream {receivedFrame.Frame.StreamId} send window would exceed {Http2FlowControlWindow.MaxValue} after WINDOW_UPDATE.");
+            if (!stream.SendWindow.TryReplenish(increment))
+            {
+                throw new Http2StreamException(
+                    receivedFrame.Frame.StreamId,
+                    Http2ErrorCode.FlowControlError,
+                    $"HTTP/2 stream {receivedFrame.Frame.StreamId} send window would exceed {Http2FlowControlWindow.MaxValue} after WINDOW_UPDATE.");
+            }
+
+            SignalSendWindowReplenished();
+        }
+    }
+
+    /// <summary>
+    /// Wakes every streaming writer parked on an exhausted send window by
+    /// completing the current signal and swapping in a fresh one. Must be called
+    /// while holding <see cref="_sendFlowLock"/>. Completion runs continuations
+    /// asynchronously so a parked writer never resumes inline under the lock.
+    /// </summary>
+    private void SignalSendWindowReplenished()
+    {
+        TaskCompletionSource prior = _sendWindowSignal;
+        _sendWindowSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        prior.TrySetResult();
+    }
+
+    /// <summary>
+    /// Reserves up to <paramref name="desired"/> octets of outbound DATA credit,
+    /// consuming from both the connection-level and stream-level send windows
+    /// (RFC 9113 §5.2). When both windows are exhausted the call parks until an
+    /// inbound WINDOW_UPDATE replenishes credit — this is the send-side
+    /// backpressure that keeps a streaming response from buffering unbounded ahead
+    /// of a slow reader.
+    /// </summary>
+    /// <param name="stream">The stream whose send window is charged.</param>
+    /// <param name="desired">The maximum number of octets the caller wants to send.</param>
+    /// <param name="cancellationToken">A token that abandons the wait (exchange abort / shutdown).</param>
+    /// <returns>The number of octets granted; always at least one.</returns>
+    private async ValueTask<int> AcquireSendWindowAsync(Http2Stream stream, int desired, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            Task signal;
+
+            lock (_sendFlowLock)
+            {
+                long available = Math.Min(_connectionSendWindow.Available, stream.SendWindow.Available);
+                if (available > 0)
+                {
+                    int grant = (int)Math.Min(desired, available);
+                    _connectionSendWindow.TryConsume(grant);
+                    stream.SendWindow.TryConsume(grant);
+                    return grant;
+                }
+
+                signal = _sendWindowSignal.Task;
+            }
+
+            await signal.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -680,13 +768,22 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             }
 
             int signedDelta = (int)delta;
-            foreach (Http2Stream existingStream in _streams.Values)
+            lock (_sendFlowLock)
             {
-                if (!existingStream.SendWindow.TryAdjustInitialWindow(signedDelta))
+                foreach (Http2Stream existingStream in _streams.Values)
                 {
-                    throw new Http2ConnectionException(
-                        Http2ErrorCode.FlowControlError,
-                        $"SETTINGS_INITIAL_WINDOW_SIZE change pushed stream {existingStream.StreamId} send window above {Http2FlowControlWindow.MaxValue}.");
+                    if (!existingStream.SendWindow.TryAdjustInitialWindow(signedDelta))
+                    {
+                        throw new Http2ConnectionException(
+                            Http2ErrorCode.FlowControlError,
+                            $"SETTINGS_INITIAL_WINDOW_SIZE change pushed stream {existingStream.StreamId} send window above {Http2FlowControlWindow.MaxValue}.");
+                    }
+                }
+
+                // A positive delta grants credit — wake any parked streaming writer.
+                if (signedDelta > 0)
+                {
+                    SignalSendWindowReplenished();
                 }
             }
         }
@@ -987,6 +1084,96 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
             await Http2FrameWriter.WriteAsync(Stream, frame, bodyBytes.AsMemory(offset, chunkLength), cancellationToken).ConfigureAwait(false);
             offset += chunkLength;
         }
+    }
+
+    /// <summary>
+    /// Commits the response head for an incrementally-streamed response: encodes
+    /// the field section with <b>no</b> synthesized <c>Content-Length</c> (the body
+    /// is delimited by <c>END_STREAM</c>) and writes the HEADERS block without the
+    /// <c>END_STREAM</c> flag so DATA frames can follow. Holds the connection write
+    /// lock for frame-sequence atomicity (RFC 9113 §4.1).
+    /// </summary>
+    internal async Task WriteStreamingHeadersAsync(Http2Context context, CancellationToken cancellationToken)
+    {
+        byte[] headerBlock = HPackEncoder.EncodeResponseHeaders(context.Response.StatusCode, context.Response.Headers);
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await WriteHeaderBlockAsync(context.StreamId, headerBlock, endStream: false, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Writes a chunk of streamed response body as one or more DATA frames,
+    /// splitting on the peer's MAX_FRAME_SIZE and awaiting send-window credit
+    /// (RFC 9113 §5.2) for each frame so a slow reader applies backpressure rather
+    /// than letting the server buffer unbounded. Each frame is flushed through to
+    /// the transport so the peer observes bytes before the response completes.
+    /// </summary>
+    internal async Task WriteStreamingDataAsync(Http2Context context, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+    {
+        int offset = 0;
+
+        while (offset < data.Length)
+        {
+            int maxChunk = Math.Min((int)_remoteSettings.MaxFrameSize, data.Length - offset);
+            int granted = await AcquireSendWindowAsync(context.Stream, maxChunk, cancellationToken).ConfigureAwait(false);
+            ReadOnlyMemory<byte> chunk = data.Slice(offset, granted);
+
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                Http2Frame frame = new();
+                frame.PrepareData(context.StreamId);
+                await Http2FrameWriter.WriteAsync(Stream, frame, chunk, cancellationToken).ConfigureAwait(false);
+                await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+
+            offset += granted;
+        }
+    }
+
+    /// <summary>
+    /// Finalizes a streamed response by emitting an empty DATA frame carrying
+    /// <c>END_STREAM</c> (RFC 9113 §5.1), then applies the local-half-close state
+    /// transition on the stream.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the buffered <see cref="SendAsync"/>, this does NOT eagerly remove
+    /// the stream from <c>_streams</c>: a streaming response is written on the
+    /// application thread, which can run concurrently with the receive loop (the
+    /// inverted-dispatch model streaming exists to enable), and that loop reads
+    /// <c>_streams</c> while processing inbound frames — a concurrent
+    /// <c>Remove</c> would race the dictionary. The fully-closed stream is reaped
+    /// when the connection is torn down instead.
+    /// </remarks>
+    internal async Task CompleteStreamingAsync(Http2Context context, CancellationToken cancellationToken)
+    {
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Http2Frame frame = new();
+            frame.PrepareData(context.StreamId);
+            frame.DataFlags |= Http2DataFrameFlags.EndStream;
+            await Http2FrameWriter.WriteAsync(Stream, frame, ReadOnlyMemory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+
+        context.Stream.SendEndStream();
     }
 
     private static async Task<byte[]> ReadBodyAsync(Stream body, CancellationToken cancellationToken)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ResponseBodyStream.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Connections.Internal.Http2;
+
+/// <summary>
+/// HTTP/2 raw response body sink. Commits the HEADERS block on first write/flush and emits the body
+/// as incremental <c>DATA</c> frames flushed through to the transport, honoring the peer's
+/// connection- and stream-level flow-control windows (RFC 9113 §5.2).
+/// </summary>
+/// <remarks>
+/// The sink holds no wire state of its own — it forwards to the owning
+/// <see cref="Http2ConnectionContext"/>, which owns the write lock, the HPACK encoder, and the
+/// send-window accounting. Each body write already flushes the underlying transport, so the flush
+/// hook is a no-op.
+/// </remarks>
+internal sealed class Http2ResponseBodyStream : HttpResponseBodyStream
+{
+    private readonly Http2ConnectionContext _connection;
+    private readonly Http2Context _context;
+
+    public Http2ResponseBodyStream(Http2ConnectionContext connection, Http2Context context)
+    {
+        _connection = connection;
+        _context = context;
+    }
+
+    protected override ValueTask CommitHeadersAsync(CancellationToken cancellationToken)
+        => new(_connection.WriteStreamingHeadersAsync(_context, cancellationToken));
+
+    protected override ValueTask WriteFramedAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+        => new(_connection.WriteStreamingDataAsync(_context, data, cancellationToken));
+
+    protected override ValueTask FlushFramedAsync(CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
+
+    protected override ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
+        => new(_connection.CompleteStreamingAsync(_context, cancellationToken));
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3Connection.cs
@@ -10,16 +10,18 @@ namespace Assimalign.Cohesion.Http.Connections.Internal.Http3;
 internal sealed class Http3Connection : HttpConnection
 {
     private readonly IMultiplexedConnection _connection;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
     private Http3ConnectionContext? _openContext;
 
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
     [SupportedOSPlatform("osx")]
-    public Http3Connection(IMultiplexedConnection connection, bool isSecure)
+    public Http3Connection(IMultiplexedConnection connection, bool isSecure, IHttpResponseInterceptor[] responseInterceptors)
         : base(isSecure)
     {
         _connection = connection;
+        _responseInterceptors = responseInterceptors;
     }
 
     public override ConnectionId Id => _connection.Id;
@@ -45,7 +47,7 @@ internal sealed class Http3Connection : HttpConnection
             throw new PlatformNotSupportedException("HTTP/3 transports require a QUIC-capable platform.");
         }
 
-        return _openContext = new Http3ConnectionContext(_connection, IsSecure);
+        return _openContext = new Http3ConnectionContext(_connection, IsSecure, _responseInterceptors);
     }
 
     public override ValueTask<HttpConnectionContext> OpenAsync(CancellationToken cancellationToken = default)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
@@ -25,15 +25,17 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
     private bool _controlStreamReceived;
     private bool _qpackEncoderStreamReceived;
     private bool _qpackDecoderStreamReceived;
+    private readonly IHttpResponseInterceptor[] _responseInterceptors;
 
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
     [SupportedOSPlatform("osx")]
-    public Http3ConnectionContext(IMultiplexedConnection connection, bool isSecure)
+    public Http3ConnectionContext(IMultiplexedConnection connection, bool isSecure, IHttpResponseInterceptor[] responseInterceptors)
     {
         _connection = connection;
         _isSecure = isSecure;
+        _responseInterceptors = responseInterceptors;
     }
 
     public override EndPoint? LocalEndPoint => _connection.LocalEndPoint;
@@ -632,6 +634,14 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
             throw new InvalidOperationException("The supplied context does not belong to an HTTP/3 connection.");
         }
 
+        // If a response feature streamed to the raw sink, the HEADERS and DATA frames are already on
+        // the wire; finalize instead of writing a buffered response.
+        if (http3Context.ResponseBodySink is { HasStarted: true } sink)
+        {
+            await sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         Stream stream = http3Context.StreamConnection.AsStream();
         byte[] bodyBytes = await ReadBodyAsync(http3Context.Response.Body, cancellationToken).ConfigureAwait(false);
         byte[] headerBlock = Http3HeaderCodec.EncodeResponseHeaders(http3Context, bodyBytes);
@@ -686,6 +696,14 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
         HttpConnectionInfo connectionInfo = new(streamConnection.LocalEndPoint, streamConnection.RemoteEndPoint);
 
         Http3Context context = new(request, response, connectionInfo, cancellationToken, streamConnection);
+
+        // Expose the raw DATA-frame response body sink (over the QUIC stream, whose flow control
+        // provides backpressure) to registered response interceptors so a feature package
+        // (streaming / SSE) can wrap it — without this transport depending on that package.
+        if (_responseInterceptors.Length > 0)
+        {
+            context.RunResponseInterceptors(_responseInterceptors, new Http3ResponseBodyStream(context));
+        }
 
         // Surface the :protocol pseudo-header (RFC 8441 / RFC 9220) generically
         // so a higher layer (Assimalign.Cohesion.Http.ExtendedConnect) can model

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3HeaderCodec.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3HeaderCodec.cs
@@ -181,6 +181,22 @@ internal static class Http3HeaderCodec
             headers[HttpHeaderKey.ContentLength] = bodyBytes.Length.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
+        return EncodeResponseHeaders(context);
+    }
+
+    /// <summary>
+    /// Encodes the response field section for an <em>incrementally streamed</em>
+    /// response: the <c>:status</c> pseudo-header followed by the response headers
+    /// verbatim, with <b>no</b> synthesized <c>Content-Length</c>. HTTP/3 delimits
+    /// the body with the stream end, so a length is neither known up front nor
+    /// required.
+    /// </summary>
+    /// <param name="context">The exchange whose response head is encoded.</param>
+    /// <returns>The QPACK-encoded field section.</returns>
+    public static byte[] EncodeResponseHeaders(Http3Context context)
+    {
+        HttpHeaderCollection headers = context.Response.Headers;
+
         List<(string Name, string Value)> fields =
         [
             (":status", ((int)context.Response.StatusCode).ToString(System.Globalization.CultureInfo.InvariantCulture)),

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections;
+using Assimalign.Cohesion.Http.Connections.Internal.Http3.Frames;
+
+namespace Assimalign.Cohesion.Http.Connections.Internal.Http3;
+
+/// <summary>
+/// HTTP/3 raw response body sink. Commits the HEADERS frame on first write/flush and emits the body
+/// as incremental <c>DATA</c> frames (RFC 9114 §7.2) flushed through to the QUIC request stream.
+/// </summary>
+/// <remarks>
+/// Backpressure is inherent: the QUIC transport applies per-stream flow control on the underlying
+/// <see cref="Stream"/> write, so a full window blocks the write until the peer grants more credit —
+/// no manual window accounting is needed here. The response body is delimited by the QUIC stream
+/// end, which the exchange's disposal signals; completion therefore only flushes.
+/// </remarks>
+internal sealed class Http3ResponseBodyStream : HttpResponseBodyStream
+{
+    private readonly Http3Context _context;
+    private readonly Stream _stream;
+
+    public Http3ResponseBodyStream(Http3Context context)
+    {
+        _context = context;
+        _stream = context.StreamConnection.AsStream();
+    }
+
+    protected override async ValueTask CommitHeadersAsync(CancellationToken cancellationToken)
+    {
+        byte[] headerBlock = Http3HeaderCodec.EncodeResponseHeaders(_context);
+        await WriteFrameAsync(Http3FrameType.Headers, headerBlock, cancellationToken).ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async ValueTask WriteFramedAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+    {
+        await WriteFrameAsync(Http3FrameType.Data, data, cancellationToken).ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override ValueTask FlushFramedAsync(CancellationToken cancellationToken)
+        => new(_stream.FlushAsync(cancellationToken));
+
+    protected override ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
+        => new(_stream.FlushAsync(cancellationToken));
+
+    private async ValueTask WriteFrameAsync(Http3FrameType frameType, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        // RFC 9114 §7.1 — frame = type (varint) + length (varint) + payload.
+        QuicVariableLengthInteger.Write(_stream, (long)frameType);
+        QuicVariableLengthInteger.Write(_stream, payload.Length);
+
+        if (!payload.IsEmpty)
+        {
+            await _stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpResponseBodyStream.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Connections.Internal;
+
+/// <summary>
+/// The transport's raw response body sink — a write-only <see cref="Stream"/> that owns the
+/// response-lifecycle state machine (commit-the-head-once on the first write/flush, idempotent
+/// completion) and forwards the wire-specific framing to a small set of <see langword="protected"/>
+/// hooks each protocol overrides. It is exposed to response features through
+/// <see cref="HttpResponseInterceptorContext.ResponseBody"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is where the streaming write path lives now: a feature package (for example
+/// <c>Assimalign.Cohesion.Http.Streaming</c>) wraps this stream to present a typed streaming API,
+/// but the framing (HTTP/1.1 chunked, HTTP/2 / HTTP/3 <c>DATA</c> frames, flow control) and the
+/// header-commit timing are the transport's concern and stay here. The header block is committed to
+/// the wire exactly once, when the first write or flush starts the response; after that the response
+/// status and headers are effectively locked because they are already on the wire.
+/// </para>
+/// <para>
+/// The stream is single-consumer (like any <see cref="Stream"/>): one exchange's response is written
+/// by one logical caller. Completion (the wire terminator — zero-length chunk / <c>END_STREAM</c>) is
+/// driven by the transport's send path via <see cref="CompleteAsync"/> when the exchange finishes.
+/// </para>
+/// </remarks>
+internal abstract class HttpResponseBodyStream : Stream
+{
+    private bool _started;
+    private bool _completed;
+
+    /// <summary>
+    /// Whether the response has started — the head has been (or is being) committed because at least
+    /// one write or flush has run. The transport's send path uses this to decide whether the exchange
+    /// streamed (finalize this sink) or took the buffered path.
+    /// </summary>
+    public bool HasStarted => _started;
+
+    /// <inheritdoc />
+    public override bool CanRead => false;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => !_completed;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompleted();
+        await EnsureStartedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!buffer.IsEmpty)
+        {
+            await WriteFramedAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count)
+        => WriteAsync(buffer.AsMemory(offset, count), CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        await EnsureStartedAsync(cancellationToken).ConfigureAwait(false);
+        await FlushFramedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override void Flush() => FlushAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <summary>
+    /// Finalizes the response body, emitting the transport's end-of-body marker. Called by the
+    /// transport's send path when the exchange completes. Starts the response first if it never
+    /// started (so an empty streamed response still emits a valid head + terminator). Idempotent.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the completion.</param>
+    /// <returns>A task that completes when the body has been finalized on the wire.</returns>
+    internal async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        await EnsureStartedAsync(cancellationToken).ConfigureAwait(false);
+        _completed = true;
+        await CompleteFramedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Commits the response status line and header block to the transport. Called once, on start.</summary>
+    protected abstract ValueTask CommitHeadersAsync(CancellationToken cancellationToken);
+
+    /// <summary>Frames and writes a non-empty chunk of body bytes, awaiting flow-control credit as needed.</summary>
+    protected abstract ValueTask WriteFramedAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken);
+
+    /// <summary>Pushes any buffered body bytes through to the transport so the peer can observe them.</summary>
+    protected abstract ValueTask FlushFramedAsync(CancellationToken cancellationToken);
+
+    /// <summary>Emits the transport's end-of-body marker (zero-length chunk / <c>END_STREAM</c>).</summary>
+    protected abstract ValueTask CompleteFramedAsync(CancellationToken cancellationToken);
+
+    private async ValueTask EnsureStartedAsync(CancellationToken cancellationToken)
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+        await CommitHeadersAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "The streaming response has already been completed; no further body bytes can be written.");
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/TransportHttpContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/TransportHttpContext.cs
@@ -59,6 +59,43 @@ internal abstract class TransportHttpContext : HttpContext
     public override CancellationToken RequestCancelled => _abortedSource.Token;
 
     /// <summary>
+    /// The transport's raw response body sink for this exchange, or
+    /// <see langword="null"/> when no response interceptors are registered (the buffered
+    /// fast path). When a response feature has written to it
+    /// (<see cref="HttpResponseBodyStream.HasStarted"/> is <see langword="true"/>) the
+    /// transport's buffered <c>SendAsync</c> finalizes the already-started response
+    /// instead of writing the buffered body again.
+    /// </summary>
+    internal HttpResponseBodyStream? ResponseBodySink { get; private set; }
+
+    /// <summary>
+    /// Runs the registered response interceptors, exposing the transport's raw response body
+    /// <paramref name="sink"/> so a feature package can wrap it and install a typed response
+    /// feature on <see cref="Features"/> — without the transport depending on that package.
+    /// The sink is retained so the transport's send path can finalize it if the exchange streamed.
+    /// </summary>
+    /// <param name="interceptors">The snapshotted response interceptors, in registration order.</param>
+    /// <param name="sink">The protocol-specific raw response body sink.</param>
+    internal void RunResponseInterceptors(IHttpResponseInterceptor[] interceptors, HttpResponseBodyStream sink)
+    {
+        ResponseBodySink = sink;
+
+        HttpResponseInterceptorContext interceptorContext = new()
+        {
+            Version = Version,
+            Headers = Response.Headers,
+            Features = Features,
+            ConnectionInfo = ConnectionInfo,
+            ResponseBody = sink,
+        };
+
+        foreach (IHttpResponseInterceptor interceptor in interceptors)
+        {
+            interceptor.OnResponse(interceptorContext);
+        }
+    }
+
+    /// <summary>
     /// Whether the application requested cancellation of this exchange via
     /// <see cref="Cancel"/>. Each transport's response path observes this and
     /// resets the single exchange (HTTP/2 <c>RST_STREAM</c>, HTTP/3 stream

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpContextFeatureLifecycleTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpContextFeatureLifecycleTests.cs
@@ -27,9 +27,9 @@ public class HttpContextFeatureLifecycleTests
     [Fact(DisplayName = "Cohesion Test [Http.Connections] - Features: Should expose an empty per-request feature collection by default")]
     public async Task Features_OnRequest_ShouldExposeEmptyCollection()
     {
-        // Arrange + Act — no request-parse interceptors are registered, so the transport takes
+        // Arrange + Act — no request- or response-interceptors are registered, so the transport takes
         // the zero-interceptor fast path and seeds nothing (features are attached by registered
-        // IHttpRequestInterceptor implementations or by middleware).
+        // IHttpRequestInterceptor / IHttpResponseInterceptor implementations or by middleware).
         IHttpContext httpContext = await ReceiveSingleContextAsync();
 
         // Assert — Features is non-null but empty.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpResponseStreamingTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpResponseStreamingTests.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Internal.Http2;
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+/// <summary>
+/// Exercises the transport's raw response body sink through the <see cref="IHttpResponseInterceptor"/>
+/// seam. Streaming is opt-in — the tests register the <c>Http.Streaming</c> feature's interceptor
+/// (a test-only reference; the transport library never depends on it) and drive
+/// <c>context.Response.Streaming</c>, proving each protocol frames incremental writes and lets a
+/// client observe bytes before the response completes.
+/// </summary>
+public class HttpResponseStreamingTests
+{
+    private static void EnableStreaming(HttpConnectionListenerOptions options)
+        => options.ResponseInterceptors.Add(HttpResponseStreaming.CreateInterceptor());
+
+    // ------------------------------------------------------------------ HTTP/1.1
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http1: Should stream chunked body and let the client observe bytes before completion")]
+    public async Task Http1_Streaming_ShouldChunkAndObserveBeforeComplete()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET /sse HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        EnableStreaming(options);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext context = await ReadSingleContextAsync(connectionContext);
+
+        context.Response.Headers[HttpHeaderKey.ContentType] = "text/event-stream";
+        IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+        // Write + flush the first chunk before the response is completed.
+        await streaming.WriteAsync(Encoding.UTF8.GetBytes("event-1"));
+        await streaming.FlushAsync();
+
+        string firstObservation = Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+
+        firstObservation.ShouldContain("HTTP/1.1 200 OK");
+        firstObservation.ShouldContain("Transfer-Encoding: chunked", Case.Insensitive);
+        firstObservation.ShouldNotContain("Content-Length");
+        firstObservation.ShouldContain("7\r\nevent-1\r\n");
+
+        // Completion (driven by the connection loop's SendAsync) writes the terminating chunk.
+        await connectionContext.SendAsync(context);
+        string completion = Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+        completion.ShouldContain("0\r\n\r\n");
+
+        await context.DisposeAsync();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http1: Should expose no streaming feature when the interceptor is not registered")]
+    public async Task Http1_WithoutInterceptor_ShouldNotExposeStreaming()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext context = await ReadSingleContextAsync(connectionContext);
+
+        // Streaming is opt-in: with no interceptor registered the feature is absent and the buffered
+        // response path is used.
+        context.Response.SupportsStreaming.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http1: A buffered response still works when the streaming interceptor is registered but unused")]
+    public async Task Http1_InterceptorRegisteredButUnused_ShouldWriteBufferedResponse()
+    {
+        // The streaming interceptor installs the feature and creates the raw sink, but a handler that
+        // ignores it (writing to the buffered Response.Body instead) must still get a normal
+        // Content-Length response — the sink was never written, so SendAsync takes the buffered path.
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            "GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        EnableStreaming(options);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext context = await ReadSingleContextAsync(connectionContext);
+
+        // Streaming is available, but the handler uses the buffered body.
+        context.Response.SupportsStreaming.ShouldBeTrue();
+        context.Response.Body = new System.IO.MemoryStream(Encoding.UTF8.GetBytes("buffered"));
+        await connectionContext.SendAsync(context);
+
+        string responseText = Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+        responseText.ShouldContain("HTTP/1.1 200 OK");
+        responseText.ShouldContain("Content-Length: 8");
+        responseText.ShouldNotContain("Transfer-Encoding: chunked");
+        responseText.ShouldContain("buffered");
+
+        await context.DisposeAsync();
+    }
+
+    // -------------------------------------------------------------------- HTTP/2
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http2: Should emit incremental DATA frames without a Content-Length")]
+    public async Task Http2_Streaming_ShouldEmitDataFramesBeforeComplete()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/sse", "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+        EnableStreaming(options);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext context = await ReadSingleContextAsync(connectionContext);
+
+        context.Response.Headers[HttpHeaderKey.ContentType] = "text/event-stream";
+        IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+        await streaming.WriteAsync(Encoding.UTF8.GetBytes("chunk-1"));
+        await streaming.FlushAsync();
+
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = await ReadFramesUntilAsync(
+            connection, fs => fs.Any(f => f.FrameType == 0 /* DATA */));
+
+        (long FrameType, byte[] Payload) headerFrame = frames.First(f => f.FrameType == 1);
+        Dictionary<string, string> headers = HttpProtocolPayloadFactory.DecodeLiteralHttp2Headers(headerFrame.Payload);
+        headers[":status"].ShouldBe("200");
+        headers.ContainsKey("content-length").ShouldBeFalse();
+
+        byte[] streamed = frames.Where(f => f.FrameType == 0).SelectMany(f => f.Payload).ToArray();
+        Encoding.UTF8.GetString(streamed).ShouldBe("chunk-1");
+
+        await connectionContext.SendAsync(context);
+        await context.DisposeAsync();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http2: Should honor the send window and resume after WINDOW_UPDATE")]
+    public async Task Http2_Streaming_ShouldRespectFlowControlBackpressure()
+    {
+        // Peer advertises a 4-octet initial stream window, so the first DATA frame can carry at most
+        // 4 octets; the writer then parks until a WINDOW_UPDATE grants more credit.
+        byte[] preface = Http2TestSettings.Preface();
+        byte[] settings = Http2TestSettings.RawFrame(
+            frameType: 0x4, flags: 0, streamId: 0,
+            payload: Http2TestSettings.SettingsPayload((Http2TestSettings.Parameter.InitialWindowSize, 4u)));
+        byte[] request = HttpProtocolPayloadFactory.CreateHttp2HeadersFrame(
+            1,
+            0x4 | 0x1, // END_HEADERS + END_STREAM
+            (":method", "GET"),
+            (":path", "/sse"),
+            (":scheme", "https"),
+            (":authority", "api.test"));
+        byte[] streamWindowUpdate = Http2TestSettings.RawFrame(0x8, 0, 1, WindowUpdateIncrement(1000));
+        byte[] connectionWindowUpdate = Http2TestSettings.RawFrame(0x8, 0, 0, WindowUpdateIncrement(1000));
+
+        TestConnection connection = new(Combine(preface, settings, request, streamWindowUpdate, connectionWindowUpdate));
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+        EnableStreaming(options);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        await using IAsyncEnumerator<IHttpContext> enumerator = connectionContext.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext context = enumerator.Current;
+        IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+        // Drive the write on a background task: it commits headers, emits the window-limited first
+        // DATA frame (4 octets), then parks awaiting credit.
+        Task writeTask = Task.Run(async () =>
+        {
+            await streaming.WriteAsync(Encoding.ASCII.GetBytes("0123456789"));
+            await streaming.CompleteAsync();
+        });
+
+        // Observe the pre-credit output: exactly the 4 octets the window allowed.
+        IReadOnlyList<(long FrameType, byte[] Payload)> preFrames = await ReadFramesUntilAsync(
+            connection, fs => fs.Any(f => f.FrameType == 0 /* DATA */));
+        byte[] preData = preFrames.Where(f => f.FrameType == 0).SelectMany(f => f.Payload).ToArray();
+        Encoding.ASCII.GetString(preData).ShouldBe("0123");
+
+        // Pump the receive loop so the preloaded WINDOW_UPDATE frames are processed, which unblocks
+        // the parked writer; the loop then hits end-of-stream.
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+        await writeTask;
+
+        // The remainder is delivered once credit is granted.
+        IReadOnlyList<(long FrameType, byte[] Payload)> postFrames =
+            HttpProtocolPayloadFactory.ParseHttp2Frames(await connection.ReadOutputAsync());
+        byte[] postData = postFrames.Where(f => f.FrameType == 0).SelectMany(f => f.Payload).ToArray();
+        Encoding.ASCII.GetString(postData).ShouldBe("456789");
+    }
+
+    // -------------------------------------------------------------------- HTTP/3
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Streaming/Http3: Should emit incremental DATA frames without a Content-Length")]
+    public async Task Http3_Streaming_ShouldEmitDataFramesBeforeComplete()
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp3Request("GET", "/sse", "https", "a");
+        TestConnection stream = new(payload);
+        TestMultiplexedConnection connection = new(stream);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp3(new TestMultiplexedConnectionListener(connection));
+        EnableStreaming(options);
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext connectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext context = await ReadSingleContextAsync(connectionContext);
+
+        context.Response.Headers[HttpHeaderKey.ContentType] = "text/event-stream";
+        IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+        await streaming.WriteAsync(Encoding.UTF8.GetBytes("chunk-1"));
+        await streaming.FlushAsync();
+
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = await ReadHttp3FramesUntilAsync(
+            stream, fs => fs.Any(f => f.FrameType == 0 /* DATA */));
+
+        (long FrameType, byte[] Payload) headerFrame = frames.First(f => f.FrameType == 1);
+        Dictionary<string, string> headers = HttpProtocolPayloadFactory.DecodeLiteralHttp3Headers(headerFrame.Payload);
+        headers[":status"].ShouldBe("200");
+        headers.ContainsKey("content-length").ShouldBeFalse();
+
+        byte[] streamed = frames.Where(f => f.FrameType == 0).SelectMany(f => f.Payload).ToArray();
+        Encoding.UTF8.GetString(streamed).ShouldBe("chunk-1");
+
+        await connectionContext.SendAsync(context);
+        await context.DisposeAsync();
+    }
+
+    // ------------------------------------------------------------------- Helpers
+
+    private static byte[] WindowUpdateIncrement(int increment) =>
+    [
+        (byte)((increment >> 24) & 0x7F),
+        (byte)((increment >> 16) & 0xFF),
+        (byte)((increment >> 8) & 0xFF),
+        (byte)(increment & 0xFF),
+    ];
+
+    private static async Task<IReadOnlyList<(long FrameType, byte[] Payload)>> ReadFramesUntilAsync(
+        TestConnection connection,
+        Func<IReadOnlyList<(long FrameType, byte[] Payload)>, bool> predicate)
+    {
+        List<byte> accumulated = new();
+
+        for (int attempt = 0; attempt < 50; attempt++)
+        {
+            accumulated.AddRange(await connection.ReadOutputAsync());
+            IReadOnlyList<(long FrameType, byte[] Payload)> frames =
+                HttpProtocolPayloadFactory.ParseHttp2Frames(accumulated.ToArray());
+            if (predicate(frames))
+            {
+                return frames;
+            }
+        }
+
+        throw new InvalidOperationException("The expected HTTP/2 frames were not observed on the wire.");
+    }
+
+    private static async Task<IReadOnlyList<(long FrameType, byte[] Payload)>> ReadHttp3FramesUntilAsync(
+        TestConnection connection,
+        Func<IReadOnlyList<(long FrameType, byte[] Payload)>, bool> predicate)
+    {
+        List<byte> accumulated = new();
+
+        for (int attempt = 0; attempt < 50; attempt++)
+        {
+            accumulated.AddRange(await connection.ReadOutputAsync());
+            IReadOnlyList<(long FrameType, byte[] Payload)> frames =
+                HttpProtocolPayloadFactory.ParseHttp3Frames(accumulated.ToArray());
+            if (predicate(frames))
+            {
+                return frames;
+            }
+        }
+
+        throw new InvalidOperationException("The expected HTTP/3 frames were not observed on the wire.");
+    }
+
+    private static async Task<IHttpContext> ReadSingleContextAsync(IHttpConnectionContext context)
+    {
+        await using IAsyncEnumerator<IHttpContext> enumerator = context.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        return enumerator.Current;
+    }
+
+    private static byte[] Combine(params byte[][] segments)
+    {
+        int length = segments.Sum(segment => segment.Length);
+        byte[] result = new byte[length];
+        int offset = 0;
+        foreach (byte[] segment in segments)
+        {
+            Array.Copy(segment, 0, result, offset, segment.Length);
+            offset += segment.Length;
+        }
+
+        return result;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/docs/DESIGN.md
@@ -1,0 +1,96 @@
+# Assimalign.Cohesion.Http.ServerSentEvents — Design
+
+Server-Sent Events (SSE) is a feature-specific formatting layer over incremental
+response streaming, so it ships as its own package. It sits on top of
+`Assimalign.Cohesion.Http.Streaming` (the streaming feature) and the protocol core,
+and — like the other HTTP feature packages (`Http.ExtendedConnect`, `Http.Forms`,
+`Http.Cookies`, …) — surfaces its types in the `Assimalign.Cohesion.Http` namespace
+for discoverability.
+
+## Why a separate package
+
+- **SSE is not protocol machinery.** The `text/event-stream` framing is one
+  WHATWG-defined wire format over a streaming response body.
+  `Assimalign.Cohesion.Http.Streaming` owns the streaming feature
+  (`IHttpResponseStreamingFeature`); SSE is one consumer of it. Keeping SSE (and
+  streaming) out of the core keeps the core's surface to wire-level concerns.
+- **No transport coupling.** This package depends on `Assimalign.Cohesion.Http` and
+  `Assimalign.Cohesion.Http.Streaming` — never on `Assimalign.Cohesion.Http.Connections`.
+  The transport implements the raw framing behind the response-interceptor seam;
+  the streaming package taps it; SSE is pure formatting over the streaming feature
+  and has no knowledge of h1/h2/h3 framing. A host composes the three, but the SSE
+  library never references the transport.
+- **Reuse.** The same primitives back both a hand-rolled handler (get
+  `context.Response.Streaming`, call `WriteEventAsync`) and the future Web-facing
+  `ServerSentEventsResult` over `IAsyncEnumerable` (#149 / #28).
+
+## The event model
+
+`ServerSentEvent` is the value model for one SSE message — the `SseItem`
+equivalent. It carries the four data-bearing fields plus a comment:
+
+| Property | Field | Notes |
+|---|---|---|
+| `EventType` | `event` | Single-line; empty → generic `message` event. |
+| `Id` | `id` | Single-line; empty (non-null) resets the client's stored id. |
+| `Data` | `data` | May be multi-line — each line is emitted as its own `data:` field. |
+| `Retry` | `retry` | Serialized as whole milliseconds. |
+| `Comment` | (leading `:`) | Ignored by clients; the keep-alive mechanism. |
+
+`Message(data)` and `KeepAlive(comment)` are the two common factories.
+`MediaType` is the `text/event-stream` constant. The type is a `readonly struct`
+with `init`-only properties — allocation-free to construct and pass by value.
+
+`EventType`, `Id`, and `Comment` MUST be single-line (the wire format terminates a
+field at the first newline); only `Data` may contain line breaks. This is a
+documented caller contract, not enforced, to keep the formatter allocation-light.
+
+## The formatter
+
+`ServerSentEventFormatter` renders a `ServerSentEvent` to the WHATWG wire format:
+an optional comment line, the `event` / `id` / `retry` fields when present, one
+`data:` line per line of the payload (splitting on CRLF, CR, or LF), and the
+terminating blank line that dispatches the event. Field values are UTF-8 encoded
+straight into an `IBufferWriter<byte>`; the fixed field names and separators are
+ASCII. There is no reflection and no runtime code generation, so the type is trim-
+and NativeAOT-safe. `Format(event)` is the convenience overload returning a
+`byte[]`.
+
+## The bridge onto the streaming seam
+
+`ServerSentEventStreamingExtensions` adds `WriteEventAsync` and
+`WriteKeepAliveAsync` to `IHttpResponseStreamingFeature` (from
+`Assimalign.Cohesion.Http.Streaming`). Each serializes the event and does
+`WriteAsync` + `FlushAsync` so the peer observes it immediately. This is where SSE
+meets the streaming write path — no transport dependency, just the feature contract.
+A host enables streaming by registering `HttpResponseStreaming.CreateInterceptor()`
+on the transport; a handler then resolves the feature via `context.Response.Streaming`.
+
+### Header-commit and content type
+
+Headers lock once a streaming response starts (the streaming feature's contract),
+so the caller sets `Content-Type: text/event-stream`
+(`ServerSentEvent.MediaType`) — and any other SSE conventions such as
+`Cache-Control: no-cache` — **before** the first `WriteEventAsync`. The
+`Last-Event-ID` request header a reconnecting client replays is
+`HttpHeaderKey.LastEventId` in the core registry (alongside the other well-known
+header-name constants); a handler reads it to resume a stream from the last
+delivered id.
+
+## Non-goals
+
+- **The streaming write path itself.** Incremental write/flush, the transport
+  response-interceptor seam, and the raw framing live in
+  `Assimalign.Cohesion.Http.Streaming` and `Assimalign.Cohesion.Http.Connections`;
+  SSE is the formatting layer on top and adds no transport hook of its own.
+- **The Web-facing result type.** `ServerSentEventsResult` over `IAsyncEnumerable`,
+  content negotiation, and builder-time keep-alive/retry configuration land with
+  the Web result-writer work (#149 / #28); this package is the primitive layer it
+  will build on.
+- **Client-side SSE parsing.** This package serializes; it does not parse an
+  inbound event stream.
+
+## AOT posture
+
+No reflection, no runtime code generation. The event model is a value struct; the
+formatter is span/`IBufferWriter<byte>` arithmetic over UTF-8.

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/docs/OVERVIEW.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/docs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Assimalign.Cohesion.Http.ServerSentEvents — Overview
+
+Server-Sent Events (`text/event-stream`) primitives layered over the HTTP
+response-streaming seam.
+
+## Purpose
+
+Provide the value model and wire-format serializer for Server-Sent Events, plus an
+ergonomic bridge onto `IHttpResponseStreamingFeature`, so a handler can push events
+to a client over a long-lived HTTP response.
+
+## Scope
+
+- `ServerSentEvent` — the event value model (`event`, `id`, `data`, `retry`,
+  comment) with `Message` / `KeepAlive` factories and the `text/event-stream`
+  media-type constant.
+- `ServerSentEventFormatter` — WHATWG wire-format serializer (UTF-8 into an
+  `IBufferWriter<byte>`, AOT-safe).
+- `WriteEventAsync` / `WriteKeepAliveAsync` extension members on
+  `IHttpResponseStreamingFeature`.
+
+## Dependencies
+
+- `Assimalign.Cohesion.Http` (the streaming feature contract + `HttpHeaderKey`).
+- **Not** `Assimalign.Cohesion.Http.Connections` — SSE is transport-agnostic. The
+  transports implement the streaming write path; an application composes SSE with
+  a transport.
+
+## Usage
+
+```csharp
+context.Response.Headers[HttpHeaderKey.ContentType] = ServerSentEvent.MediaType;
+context.Response.Headers[HttpHeaderKey.CacheControl] = "no-cache";
+
+IHttpResponseStreamingFeature stream = context.Response.Streaming;
+await stream.WriteEventAsync(new ServerSentEvent("hello") { EventType = "greeting", Id = "1" });
+await stream.WriteKeepAliveAsync();
+```
+
+## Layering
+
+L1 foundation library (HTTP feature layer). See `DESIGN.md` for the rationale
+behind the separate package and the non-goals (response interceptor, Web result
+type, client parsing).

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Http.ServerSentEvents" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Http.Connections" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Connections.Tcp" />
+  </ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/LoopbackPortAllocator.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/LoopbackPortAllocator.cs
@@ -1,0 +1,16 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse;
+
+internal static class LoopbackPortAllocator
+{
+    public static int AllocateTcpPort()
+    {
+        using Socket socket = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Program.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Program.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections.Tcp;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Http.Connections;
+
+using ClientHttpMethod = System.Net.Http.HttpMethod;
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse;
+
+/// <summary>
+/// End-to-end Server-Sent Events sample over plain HTTP/1.1 on localhost. It composes
+/// three decoupled pieces: the <c>Assimalign.Cohesion.Http.Connections</c> transport
+/// (the streaming write path), the <c>Assimalign.Cohesion.Http</c> streaming feature
+/// (<see cref="IHttpResponseStreamingFeature"/>), and the
+/// <c>Assimalign.Cohesion.Http.ServerSentEvents</c> primitives (<see cref="ServerSentEvent"/>
+/// + <c>WriteEventAsync</c>). The server commits a <c>text/event-stream</c> head, then
+/// streams several flushed events plus a keep-alive comment; the client reads and prints
+/// each event as it arrives — before the response completes.
+/// </summary>
+internal static class Program
+{
+    private static async Task<int> Main()
+    {
+        using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(15));
+        CancellationToken cancellationToken = cancellationTokenSource.Token;
+        int port = LoopbackPortAllocator.AllocateTcpPort();
+        Uri serverUri = new($"http://127.0.0.1:{port}/events");
+
+        // Plain (no TLS) HTTP/1.1 — a TCP listener composed directly into the HTTP
+        // listener. Server-Sent Events ride plain HTTP, so no TLS is required.
+        TcpConnectionListener tcpListener = TcpConnectionListener.Create(transport =>
+        {
+            transport.EndPoint = new IPEndPoint(IPAddress.Loopback, port);
+        });
+
+        await using HttpConnectionListener listener = HttpConnectionListener.Create(options =>
+        {
+            options.UseHttp1(tcpListener);
+
+            // Opt into incremental response streaming by registering its response interceptor. The
+            // transport exposes its raw response body sink to the feature package through this seam;
+            // it has no streaming or SSE dependency of its own.
+            options.ResponseInterceptors.Add(HttpResponseStreaming.CreateInterceptor());
+        });
+
+        Task serverTask = RunServerAsync(listener, cancellationToken);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+
+        using HttpClient client = new();
+        using HttpRequestMessage request = new(ClientHttpMethod.Get, serverUri)
+        {
+            Version = NetHttpVersion.Version11,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact
+        };
+
+        // ResponseHeadersRead returns as soon as the head is committed, so the
+        // client can read events incrementally instead of buffering the whole body.
+        using HttpResponseMessage response = await client
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        Console.WriteLine($"SSE status: {(int)response.StatusCode}");
+        Console.WriteLine($"SSE content-type: {response.Content.Headers.ContentType}");
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using StreamReader reader = new(stream, Encoding.UTF8);
+
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+        {
+            // The blank line between events is the dispatch boundary; print only the
+            // field lines so the incremental arrival of each event is visible.
+            if (line.Length > 0)
+            {
+                Console.WriteLine($"[event-stream] {line}");
+            }
+        }
+
+        await serverTask.ConfigureAwait(false);
+
+        return 0;
+    }
+
+    private static async Task RunServerAsync(HttpConnectionListener listener, CancellationToken cancellationToken)
+    {
+        await using IHttpConnection connection = await listener.AcceptOrListenAsync(cancellationToken).ConfigureAwait(false);
+        IHttpConnectionContext connectionContext = await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await foreach (IHttpContext context in connectionContext.ReceiveAsync(cancellationToken).ConfigureAwait(false))
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            context.Response.Headers[HttpHeaderKey.ContentType] = ServerSentEvent.MediaType;
+            context.Response.Headers[HttpHeaderKey.CacheControl] = "no-cache";
+
+            // The streaming feature commits the head on the first write and frames
+            // each event as its own chunked write, flushed through to the client.
+            IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+            for (int tick = 1; tick <= 5; tick++)
+            {
+                ServerSentEvent @event = new($"server time tick {tick}")
+                {
+                    EventType = "tick",
+                    Id = tick.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                };
+
+                await streaming.WriteEventAsync(@event, cancellationToken).ConfigureAwait(false);
+
+                // Space the events out so the incremental streaming is observable.
+                await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken).ConfigureAwait(false);
+            }
+
+            // A comment-only heartbeat keeps an otherwise-idle stream (and any
+            // intermediaries) alive; the client ignores it.
+            await streaming.WriteKeepAliveAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // The connection loop's SendAsync finalizes the response — for a
+            // streamed response that means emitting the terminating zero-length
+            // chunk rather than writing a buffered body.
+            await connectionContext.SendAsync(context, cancellationToken).ConfigureAwait(false);
+            await context.DisposeAsync().ConfigureAwait(false);
+            break;
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Assimalign.Cohesion.Http.ServerSentEvents.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Assimalign.Cohesion.Http.ServerSentEvents.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- Deviates from AGENTS.md namespace-matches-assembly per design decision:
+		     HTTP feature packages surface their types in the Assimalign.Cohesion.Http
+		     namespace so IHttpResponseStreamingFeature extension members (WriteEventAsync)
+		     are discoverable without an extra using (matches Assimalign.Cohesion.Http.ExtendedConnect). -->
+		<RootNamespace>Assimalign.Cohesion.Http</RootNamespace>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+	</ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Extensions/ServerSentEventStreamingExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/Extensions/ServerSentEventStreamingExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Bridges the <see cref="ServerSentEvent"/> value model onto the
+/// <see cref="IHttpResponseStreamingFeature"/> write/flush seam, so a handler can
+/// emit Server-Sent Events over any transport that supports response streaming.
+/// </summary>
+/// <remarks>
+/// The caller is responsible for setting <c>Content-Type: text/event-stream</c>
+/// (see <see cref="ServerSentEvent.MediaType"/>) on the response before the first
+/// write, since headers are locked once the response starts. Each write serializes
+/// the event with <see cref="ServerSentEventFormatter"/> and flushes it so the peer
+/// observes it immediately.
+/// </remarks>
+public static class ServerSentEventStreamingExtensions
+{
+    extension(IHttpResponseStreamingFeature streaming)
+    {
+        /// <summary>
+        /// Serializes <paramref name="event"/> to the <c>text/event-stream</c>
+        /// wire format and writes it to the response, flushing so the peer
+        /// observes it immediately.
+        /// </summary>
+        /// <param name="event">The event to send.</param>
+        /// <param name="cancellationToken">A token to cancel the write.</param>
+        /// <returns>A task that completes when the event has been flushed to the transport.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="streaming"/> is <see langword="null"/>.</exception>
+        public async ValueTask WriteEventAsync(ServerSentEvent @event, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(streaming);
+
+            ArrayBufferWriter<byte> buffer = new();
+            ServerSentEventFormatter.Write(@event, buffer);
+            await streaming.WriteAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false);
+            await streaming.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Writes a keep-alive heartbeat — a comment-only event that a client
+        /// ignores but whose bytes keep the idle stream (and any intermediaries)
+        /// from timing out.
+        /// </summary>
+        /// <param name="comment">The comment text. Defaults to <c>keep-alive</c>.</param>
+        /// <param name="cancellationToken">A token to cancel the write.</param>
+        /// <returns>A task that completes when the heartbeat has been flushed.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="streaming"/> is <see langword="null"/>.</exception>
+        public ValueTask WriteKeepAliveAsync(string comment = "keep-alive", CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(streaming);
+            return streaming.WriteEventAsync(ServerSentEvent.KeepAlive(comment), cancellationToken);
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/ServerSentEvent.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/ServerSentEvent.cs
@@ -1,0 +1,91 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single Server-Sent Events message — the <c>SseItem</c>-equivalent event
+/// model for the <c>text/event-stream</c> wire format defined by the WHATWG HTML
+/// Server-Sent Events specification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An event carries any of four data-bearing fields (<c>event</c>, <c>data</c>,
+/// <c>id</c>, <c>retry</c>) plus an optional comment. All are optional: a message
+/// with only <see cref="Data"/> is the common case; a message with only
+/// <see cref="Comment"/> is a keep-alive heartbeat that a client ignores. The
+/// value object holds the fields; <see cref="ServerSentEventFormatter"/> renders
+/// them to the wire format.
+/// </para>
+/// <para>
+/// <see cref="EventType"/>, <see cref="Id"/>, and <see cref="Comment"/> are
+/// single-line field values and MUST NOT contain a line break — the wire format
+/// terminates a field at the first newline. <see cref="Data"/> MAY contain
+/// newlines: each line is emitted as its own <c>data:</c> field and the client
+/// rejoins them with <c>\n</c>.
+/// </para>
+/// </remarks>
+public readonly struct ServerSentEvent
+{
+    /// <summary>The media type of a Server-Sent Events response body.</summary>
+    public const string MediaType = "text/event-stream";
+
+    /// <summary>
+    /// Initializes a new event carrying the supplied <paramref name="data"/> payload.
+    /// </summary>
+    /// <param name="data">The event data (the <c>data</c> field). May be multi-line or <see langword="null"/>.</param>
+    public ServerSentEvent(string? data)
+    {
+        Data = data;
+    }
+
+    /// <summary>
+    /// Gets the event type (the <c>event</c> field). When <see langword="null"/>
+    /// or empty the client dispatches the message as a generic <c>message</c>
+    /// event. Must be single-line.
+    /// </summary>
+    public string? EventType { get; init; }
+
+    /// <summary>
+    /// Gets the last-event-id (the <c>id</c> field). The client echoes the most
+    /// recent id back in the <c>Last-Event-ID</c> request header on reconnect.
+    /// Must be single-line. An empty (non-null) value resets the client's stored
+    /// id.
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets the event data (the <c>data</c> field). May contain newlines; each
+    /// line is serialized as a separate <c>data:</c> field. <see langword="null"/>
+    /// emits no data field.
+    /// </summary>
+    public string? Data { get; init; }
+
+    /// <summary>
+    /// Gets the reconnection time the client should use (the <c>retry</c> field),
+    /// serialized as whole milliseconds. <see langword="null"/> emits no retry field.
+    /// </summary>
+    public TimeSpan? Retry { get; init; }
+
+    /// <summary>
+    /// Gets an optional comment (a line beginning with <c>:</c>). Comments are
+    /// ignored by clients and are the mechanism used for keep-alive heartbeats.
+    /// Must be single-line.
+    /// </summary>
+    public string? Comment { get; init; }
+
+    /// <summary>
+    /// Creates a generic <c>message</c> event carrying <paramref name="data"/>.
+    /// </summary>
+    /// <param name="data">The event data payload.</param>
+    /// <returns>An event with its <see cref="Data"/> set.</returns>
+    public static ServerSentEvent Message(string? data) => new(data);
+
+    /// <summary>
+    /// Creates a keep-alive heartbeat — an event carrying only a comment, which a
+    /// client ignores while the bytes keep the connection and any intermediaries
+    /// from timing the idle stream out.
+    /// </summary>
+    /// <param name="comment">The comment text. Defaults to <c>keep-alive</c>.</param>
+    /// <returns>An event with only its <see cref="Comment"/> set.</returns>
+    public static ServerSentEvent KeepAlive(string comment = "keep-alive") => new() { Comment = comment };
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/ServerSentEventFormatter.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/ServerSentEventFormatter.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Serializes a <see cref="ServerSentEvent"/> to the <c>text/event-stream</c>
+/// wire format defined by the WHATWG HTML Server-Sent Events specification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The renderer emits, in order, an optional comment line, the <c>event</c>,
+/// <c>id</c>, and <c>retry</c> fields when present, one <c>data:</c> line per line
+/// of <see cref="ServerSentEvent.Data"/>, and finally the blank line that
+/// dispatches the event. Field values are UTF-8 encoded; the fixed field names and
+/// separators are ASCII. There is no reflection and no runtime code generation, so
+/// the type is trim- and NativeAOT-safe.
+/// </para>
+/// </remarks>
+public static class ServerSentEventFormatter
+{
+    private const byte Colon = (byte)':';
+    private const byte Space = (byte)' ';
+    private const byte NewLine = (byte)'\n';
+
+    /// <summary>
+    /// Writes <paramref name="event"/> to <paramref name="writer"/> in the
+    /// <c>text/event-stream</c> wire format, terminated by the dispatch blank line.
+    /// </summary>
+    /// <param name="event">The event to serialize.</param>
+    /// <param name="writer">The buffer writer that receives the encoded bytes.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> is <see langword="null"/>.</exception>
+    public static void Write(ServerSentEvent @event, IBufferWriter<byte> writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (@event.Comment is { } comment)
+        {
+            // A comment is a line whose field name is empty: ": <text>".
+            WriteField(writer, ReadOnlySpan<char>.Empty, comment);
+        }
+
+        if (!string.IsNullOrEmpty(@event.EventType))
+        {
+            WriteField(writer, "event", @event.EventType);
+        }
+
+        if (@event.Id is { } id)
+        {
+            WriteField(writer, "id", id);
+        }
+
+        if (@event.Retry is { } retry)
+        {
+            long milliseconds = (long)retry.TotalMilliseconds;
+            if (milliseconds < 0)
+            {
+                milliseconds = 0;
+            }
+
+            WriteField(writer, "retry", milliseconds.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (@event.Data is { } data)
+        {
+            WriteData(writer, data);
+        }
+
+        // The blank line dispatches the event on the client.
+        WriteNewLine(writer);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="event"/> to a freshly allocated byte array in
+    /// the <c>text/event-stream</c> wire format.
+    /// </summary>
+    /// <param name="event">The event to serialize.</param>
+    /// <returns>The UTF-8 encoded event bytes, including the dispatch blank line.</returns>
+    public static byte[] Format(ServerSentEvent @event)
+    {
+        ArrayBufferWriter<byte> writer = new();
+        Write(@event, writer);
+        return writer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteData(IBufferWriter<byte> writer, string data)
+    {
+        // WHATWG SSE — a multi-line data payload is emitted as one "data:" line
+        // per source line; the client rejoins them with '\n'. Split on CRLF, CR,
+        // or LF so any newline convention round-trips.
+        int start = 0;
+
+        while (start <= data.Length)
+        {
+            int lineEnd = data.Length;
+            int nextStart = data.Length + 1; // past-end sentinel — stops the loop when no more breaks
+
+            for (int index = start; index < data.Length; index++)
+            {
+                char current = data[index];
+                if (current == '\n')
+                {
+                    lineEnd = index;
+                    nextStart = index + 1;
+                    break;
+                }
+
+                if (current == '\r')
+                {
+                    lineEnd = index;
+                    nextStart = index + 1 < data.Length && data[index + 1] == '\n' ? index + 2 : index + 1;
+                    break;
+                }
+            }
+
+            WriteField(writer, "data", data.AsSpan(start, lineEnd - start));
+            start = nextStart;
+        }
+    }
+
+    private static void WriteField(IBufferWriter<byte> writer, ReadOnlySpan<char> name, ReadOnlySpan<char> value)
+    {
+        if (!name.IsEmpty)
+        {
+            WriteUtf8(writer, name);
+        }
+
+        Span<byte> separator = writer.GetSpan(2);
+        separator[0] = Colon;
+        separator[1] = Space;
+        writer.Advance(2);
+
+        if (!value.IsEmpty)
+        {
+            WriteUtf8(writer, value);
+        }
+
+        WriteNewLine(writer);
+    }
+
+    private static void WriteUtf8(IBufferWriter<byte> writer, ReadOnlySpan<char> value)
+    {
+        int byteCount = Encoding.UTF8.GetByteCount(value);
+        Span<byte> destination = writer.GetSpan(byteCount);
+        int written = Encoding.UTF8.GetBytes(value, destination);
+        writer.Advance(written);
+    }
+
+    private static void WriteNewLine(IBufferWriter<byte> writer)
+    {
+        Span<byte> span = writer.GetSpan(1);
+        span[0] = NewLine;
+        writer.Advance(1);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/Assimalign.Cohesion.Http.ServerSentEvents.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/Assimalign.Cohesion.Http.ServerSentEvents.Tests.csproj
@@ -4,13 +4,10 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 	</PropertyGroup>
 	<ItemGroup>
-		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Connections" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.ServerSentEvents" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
-		<CohesionProjectReference Include="Assimalign.Cohesion.Http.ExtendedConnect" />
-		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Cookies" />
-		<!-- Test-only: exercises the response-interceptor seam end-to-end (the transport LIBRARY has no
-		     dependency on this feature package), mirroring the ExtendedConnect/Cookies refs above. -->
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.InMemory" />
 		<CohesionPackageReference Include="coverlet.collector" />

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/ServerSentEventFormatterTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/ServerSentEventFormatterTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Text;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.ServerSentEvents.Tests;
+
+public class ServerSentEventFormatterTests
+{
+    private static string Format(ServerSentEvent @event)
+        => Encoding.UTF8.GetString(ServerSentEventFormatter.Format(@event));
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should serialize a data-only event with the dispatch blank line")]
+    public void Format_DataOnlyEvent_ShouldEmitDataFieldAndBlankLine()
+    {
+        string wire = Format(ServerSentEvent.Message("hello"));
+
+        wire.ShouldBe("data: hello\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should serialize every field in order")]
+    public void Format_FullEvent_ShouldEmitAllFields()
+    {
+        ServerSentEvent @event = new("payload")
+        {
+            EventType = "update",
+            Id = "42",
+            Retry = TimeSpan.FromSeconds(3),
+        };
+
+        string wire = Format(@event);
+
+        // event, id, retry, then data, then the dispatch blank line.
+        wire.ShouldBe("event: update\nid: 42\nretry: 3000\ndata: payload\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should emit one data field per line for multi-line data")]
+    public void Format_MultiLineData_ShouldEmitOneDataFieldPerLine()
+    {
+        string wire = Format(ServerSentEvent.Message("line1\nline2\nline3"));
+
+        wire.ShouldBe("data: line1\ndata: line2\ndata: line3\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should split CRLF and CR line breaks in data")]
+    public void Format_DataWithMixedLineBreaks_ShouldSplitOnEachBreak()
+    {
+        string wire = Format(ServerSentEvent.Message("a\r\nb\rc"));
+
+        wire.ShouldBe("data: a\ndata: b\ndata: c\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should serialize a keep-alive as a comment line")]
+    public void Format_KeepAlive_ShouldEmitCommentLine()
+    {
+        string wire = Format(ServerSentEvent.KeepAlive());
+
+        wire.ShouldBe(": keep-alive\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should serialize an empty (non-null) data value as an empty data field")]
+    public void Format_EmptyData_ShouldEmitEmptyDataField()
+    {
+        string wire = Format(ServerSentEvent.Message(string.Empty));
+
+        wire.ShouldBe("data: \n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: Should carry a comment alongside data fields")]
+    public void Format_CommentWithData_ShouldEmitCommentThenData()
+    {
+        ServerSentEvent @event = new("body") { Comment = "note" };
+
+        string wire = Format(@event);
+
+        wire.ShouldBe(": note\ndata: body\n\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - Sse: MediaType should be text/event-stream")]
+    public void MediaType_ShouldBeTextEventStream()
+    {
+        ServerSentEvent.MediaType.ShouldBe("text/event-stream");
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/ServerSentEventStreamingExtensionsTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/ServerSentEventStreamingExtensionsTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.ServerSentEvents.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.ServerSentEvents.Tests;
+
+public class ServerSentEventStreamingExtensionsTests
+{
+    // ------------------------------------------------------------ bridge unit tests
+
+    [Fact(DisplayName = "Cohesion Test [Http.ServerSentEvents] - Bridge: WriteEventAsync serializes the event and flushes")]
+    public async Task WriteEventAsync_ShouldSerializeAndFlush()
+    {
+        RecordingStreamingFeature feature = new();
+
+        await feature.WriteEventAsync(new ServerSentEvent("hello") { EventType = "greeting", Id = "1" });
+
+        Encoding.UTF8.GetString(feature.WrittenBytes).ShouldBe("event: greeting\nid: 1\ndata: hello\n\n");
+        feature.FlushCount.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ServerSentEvents] - Bridge: WriteKeepAliveAsync writes a comment heartbeat and flushes")]
+    public async Task WriteKeepAliveAsync_ShouldWriteCommentAndFlush()
+    {
+        RecordingStreamingFeature feature = new();
+
+        await feature.WriteKeepAliveAsync();
+
+        Encoding.UTF8.GetString(feature.WrittenBytes).ShouldBe(": keep-alive\n\n");
+        feature.FlushCount.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ServerSentEvents] - Bridge: WriteEventAsync throws on a null feature")]
+    public async Task WriteEventAsync_OnNullFeature_ShouldThrow()
+    {
+        IHttpResponseStreamingFeature feature = null!;
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await feature.WriteEventAsync(ServerSentEvent.Message("x")));
+    }
+
+    // ------------------------------------------------ transport-backed round-trip
+
+    [Fact(DisplayName = "Cohesion Test [Http.ServerSentEvents] - Transport: Should stream SSE events over the HTTP/1.1 streaming write path")]
+    public async Task ServerSentEvents_OverHttp1_ShouldStreamEventsBeforeCompletion()
+    {
+        await using InMemoryHttp1Loopback loopback = new("GET /events HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        IHttpContext context = await loopback.ReadRequestAsync();
+
+        context.Response.Headers[HttpHeaderKey.ContentType] = ServerSentEvent.MediaType;
+        context.Response.Headers[HttpHeaderKey.CacheControl] = "no-cache";
+        IHttpResponseStreamingFeature streaming = context.Response.Streaming;
+
+        // First event — observed before the response is completed.
+        await streaming.WriteEventAsync(new ServerSentEvent("hello") { EventType = "greeting", Id = "1" });
+        string firstObservation = Encoding.UTF8.GetString(await loopback.ReadResponseAsync());
+
+        // Head committed at first flush, then the SSE fields ride inside a chunk.
+        firstObservation.ShouldContain("HTTP/1.1 200 OK");
+        firstObservation.ShouldContain("Content-Type: text/event-stream");
+        firstObservation.ShouldContain("Transfer-Encoding: chunked", Case.Insensitive);
+        firstObservation.ShouldContain("event: greeting\nid: 1\ndata: hello\n\n");
+
+        // Keep-alive heartbeat — a comment the client ignores.
+        await streaming.WriteKeepAliveAsync();
+        string keepAlive = Encoding.UTF8.GetString(await loopback.ReadResponseAsync());
+        keepAlive.ShouldContain(": keep-alive\n\n");
+
+        // Finalizing emits the terminating chunk.
+        await loopback.FinalizeResponseAsync(context);
+        string completion = Encoding.UTF8.GetString(await loopback.ReadResponseAsync());
+        completion.ShouldContain("0\r\n\r\n");
+
+        await context.DisposeAsync();
+    }
+
+    /// <summary>
+    /// An <see cref="IHttpResponseStreamingFeature"/> that records what the SSE bridge writes, so the
+    /// extension methods can be asserted without a live transport.
+    /// </summary>
+    private sealed class RecordingStreamingFeature : IHttpResponseStreamingFeature
+    {
+        private readonly List<byte> _written = new();
+
+        public int FlushCount { get; private set; }
+        public byte[] WrittenBytes => _written.ToArray();
+
+        public string Name => "Assimalign.Cohesion.Http.ResponseStreaming";
+        public bool HasStarted { get; private set; }
+
+        public ValueTask StartAsync(CancellationToken cancellationToken = default)
+        {
+            HasStarted = true;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
+        {
+            HasStarted = true;
+            _written.AddRange(data.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask FlushAsync(CancellationToken cancellationToken = default)
+        {
+            HasStarted = true;
+            FlushCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask CompleteAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/TestObjects/InMemoryHttp1Loopback.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/TestObjects/InMemoryHttp1Loopback.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections;
+using Assimalign.Cohesion.Connections.InMemory;
+using Assimalign.Cohesion.Http.Connections;
+
+namespace Assimalign.Cohesion.Http.ServerSentEvents.Tests.TestObjects;
+
+/// <summary>
+/// A minimal in-memory HTTP/1.1 loopback that composes the public
+/// <see cref="Connections.InMemory"/> driver with the <see cref="HttpConnectionListener"/>
+/// transport — deliberately using only public API so the Server-Sent Events package
+/// can prove an end-to-end streamed response without depending on the transport's
+/// internal test doubles.
+/// </summary>
+internal sealed class InMemoryHttp1Loopback : IAsyncDisposable
+{
+    private readonly Connection _client;
+    private readonly HttpConnectionListener _listener;
+    private IHttpConnection? _connection;
+    private IHttpConnectionContext? _connectionContext;
+    private IAsyncEnumerator<IHttpContext>? _enumerator;
+
+    public InMemoryHttp1Loopback(string requestText)
+    {
+        (Connection client, Connection server) = InMemoryConnectionPair.Create(
+            InMemoryConnectionPair.DefaultCapabilities,
+            clientEndPoint: new IPEndPoint(IPAddress.Loopback, 8080),
+            serverEndPoint: new IPEndPoint(IPAddress.Loopback, 5000));
+
+        _client = client;
+
+        // Preload the request onto the server's input (the client "sent" it, then finished).
+        _client.Output.WriteAsync(Encoding.ASCII.GetBytes(requestText)).AsTask().GetAwaiter().GetResult();
+        _client.Output.Complete();
+
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new SingleConnectionListener(server));
+        // Enable incremental response streaming by registering its response interceptor — the same
+        // opt-in a real host performs. The transport itself has no streaming/SSE dependency.
+        options.ResponseInterceptors.Add(HttpResponseStreaming.CreateInterceptor());
+        _listener = new HttpConnectionListener(options);
+    }
+
+    /// <summary>Accepts the connection and returns the first request context.</summary>
+    public async Task<IHttpContext> ReadRequestAsync()
+    {
+        _connection = await _listener.AcceptOrListenAsync().ConfigureAwait(false);
+        _connectionContext = await _connection.OpenAsync().ConfigureAwait(false);
+        _enumerator = _connectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        if (!await _enumerator.MoveNextAsync().ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("The in-memory HTTP/1.1 server produced no request context.");
+        }
+
+        return _enumerator.Current;
+    }
+
+    /// <summary>Reads whatever response bytes the server has flushed so far.</summary>
+    public async Task<byte[]> ReadResponseAsync()
+    {
+        ReadResult result = await _client.Input.ReadAsync().ConfigureAwait(false);
+        byte[] bytes = result.Buffer.ToArray();
+        _client.Input.AdvanceTo(result.Buffer.End);
+        return bytes;
+    }
+
+    /// <summary>Finalizes the response via the connection loop's send path.</summary>
+    public ValueTask FinalizeResponseAsync(IHttpContext context)
+        => _connectionContext!.SendAsync(context);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_enumerator is not null)
+        {
+            await _enumerator.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await _listener.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// A <see cref="ConnectionListener"/> that yields one pre-built connection then
+    /// waits (never producing another) so the accept loop parks cleanly.
+    /// </summary>
+    private sealed class SingleConnectionListener : ConnectionListener
+    {
+        private Connection? _pending;
+
+        public SingleConnectionListener(Connection connection)
+        {
+            _pending = connection;
+        }
+
+        public override EndPoint EndPoint { get; } = new IPEndPoint(IPAddress.Loopback, 5000);
+
+        public override ConnectionCapabilities Capabilities => InMemoryConnectionPair.DefaultCapabilities;
+
+        public override async ValueTask<Connection> AcceptAsync(CancellationToken cancellationToken = default)
+        {
+            Connection? connection = Interlocked.Exchange(ref _pending, null);
+            if (connection is not null)
+            {
+                return connection;
+            }
+
+            // No more connections; park until cancelled so the HTTP accept loop idles.
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        public override ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/docs/DESIGN.md
@@ -1,0 +1,72 @@
+# Assimalign.Cohesion.Http.Streaming — Design
+
+Incremental response streaming is a response-side capability, not protocol
+machinery, so it ships as its own feature package that plugs into the transport
+through the generic `IHttpResponseInterceptor` seam — the same way
+`Assimalign.Cohesion.Http.RequestLimits` plugs into request parsing via
+`IHttpRequestInterceptor`. Neither the protocol core nor the transport
+(`Assimalign.Cohesion.Http.Connections`) depends on this package.
+
+## Why a separate package
+
+The naive placement — a streaming feature baked into the protocol core and attached
+to every exchange by the transport — couples three layers to one capability. It
+also forces the transport to know about "streaming." This package removes that
+coupling:
+
+- **The core** owns only the generic `IHttpResponseInterceptor` seam and the raw
+  write/flush primitive (a `System.IO.Stream`). It has no streaming type.
+- **The transport** owns the per-protocol framing (chunked / `DATA` frames /
+  flow control) behind a raw response body sink (`HttpResponseBodyStream`) that it
+  exposes through the interceptor context. It has no streaming type.
+- **This package** owns the typed streaming API (`IHttpResponseStreamingFeature`),
+  the interceptor that installs it, and the ergonomic accessor. It depends only on
+  the core.
+
+Streaming is therefore **opt-in**: a host enables it by registering
+`HttpResponseStreaming.CreateInterceptor()` on the transport's response
+interceptors. Where it is not registered, the transport uses its buffered response
+path with zero streaming overhead.
+
+## How it works
+
+1. A host adds `HttpResponseStreaming.CreateInterceptor()` to
+   `HttpConnectionListenerOptions.ResponseInterceptors`.
+2. Per exchange, the transport creates its per-protocol raw response body sink and
+   runs the registered response interceptors, exposing the sink as
+   `HttpResponseInterceptorContext.ResponseBody`.
+3. `HttpResponseStreamingInterceptor.OnResponse` wraps that sink in a
+   `HttpResponseStreamingFeature` and installs it on `context.Features`.
+4. The handler resolves it — `context.Response.Streaming` — and calls
+   `WriteAsync` / `FlushAsync` / `CompleteAsync`. The bytes flow through the sink,
+   which frames and flushes them to the wire and commits the head on the first
+   write/flush.
+5. When the handler returns, the transport's `SendAsync` finalizes the sink (wire
+   terminator) if it was written, or takes the buffered path if it was not.
+
+## The feature is a thin wrapper over the sink
+
+`IHttpResponseStreamingFeature` is the typed contract; its implementation is a
+small wrapper over the `Stream` sink. The wire framing and the "commit the head
+once" rule live in the transport's sink; the wrapper owns the ergonomic surface —
+`HasStarted`, implicit start on the first write/flush, and the
+write-after-complete guard. `CompleteAsync` flushes and forbids further writes; the
+transport emits the actual end-of-body marker when it finalizes the exchange.
+
+**Header-commit timing** is the load-bearing rule: the head is committed exactly
+once, on the first `StartAsync` / `WriteAsync` / `FlushAsync`, and headers are
+locked thereafter. Callers set every response header before the first write.
+
+## Non-goals
+
+- **The wire framing.** Chunked / `DATA`-frame framing, flow-control backpressure,
+  and header-commit belong to the transport's sink, not here.
+- **A dependency on the transport.** This package references only the core; a host
+  (or a test/example project) composes it with a transport.
+- **Feature-specific formats.** Server-Sent Events builds on this package
+  (`Assimalign.Cohesion.Http.ServerSentEvents`); other formats would too.
+
+## AOT posture
+
+No reflection, no runtime code generation. The feature is plain flags over a
+`Stream`; the interceptor is a single `Features.Set` call.

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/docs/OVERVIEW.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/docs/OVERVIEW.md
@@ -1,0 +1,45 @@
+# Assimalign.Cohesion.Http.Streaming — Overview
+
+Incremental HTTP response streaming as an opt-in feature package that plugs into
+the transport via the response-interceptor seam.
+
+## Purpose
+
+Let a handler start a response and write its body incrementally — flushing bytes to
+the client as they are produced — over any transport that exposes the
+`IHttpResponseInterceptor` seam, without the transport (or the protocol core)
+depending on this package.
+
+## Scope
+
+- `IHttpResponseStreamingFeature` — the typed streaming API (`StartAsync`,
+  `WriteAsync`, `FlushAsync`, `CompleteAsync`, `HasStarted`).
+- `HttpResponseStreaming.CreateInterceptor()` — the `IHttpResponseInterceptor` a
+  host registers to make streaming available on every exchange.
+- `Response.Streaming` / `Response.SupportsStreaming` — ergonomic accessors on
+  `IHttpResponse`.
+
+## Dependencies
+
+- `Assimalign.Cohesion.Http` (the response-interceptor seam + feature collection).
+- **Not** `Assimalign.Cohesion.Http.Connections` — streaming is transport-agnostic.
+
+## Usage
+
+```csharp
+// Host / composition root — opt into streaming:
+options.ResponseInterceptors.Add(HttpResponseStreaming.CreateInterceptor());
+
+// Handler:
+context.Response.Headers[HttpHeaderKey.ContentType] = "text/plain";
+IHttpResponseStreamingFeature stream = context.Response.Streaming;
+await stream.WriteAsync(chunk1);
+await stream.FlushAsync();      // the client observes chunk1 now
+await stream.WriteAsync(chunk2);
+```
+
+## Layering
+
+L1 foundation library (HTTP feature layer). See `DESIGN.md` for why streaming is a
+separate package and how it plugs into the transport. Server-Sent Events
+(`Assimalign.Cohesion.Http.ServerSentEvents`) builds on this package.

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Assimalign.Cohesion.Http.Streaming.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Assimalign.Cohesion.Http.Streaming.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- Deviates from AGENTS.md namespace-matches-assembly per design decision:
+		     HTTP feature packages surface their types in the Assimalign.Cohesion.Http
+		     namespace so IHttpResponse extension members (Response.Streaming) are
+		     discoverable without an extra using (matches Assimalign.Cohesion.Http.ExtendedConnect). -->
+		<RootNamespace>Assimalign.Cohesion.Http</RootNamespace>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+	</ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Extensions/HttpResponseStreamingExtensions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Extensions/HttpResponseStreamingExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Ergonomic access to the <see cref="IHttpResponseStreamingFeature"/> installed on an exchange by
+/// the response-streaming interceptor, so handlers can reach the incremental write/flush seam
+/// without spelling out the feature-collection lookup at every call site.
+/// </summary>
+public static class HttpResponseStreamingExtensions
+{
+    extension(IHttpResponse response)
+    {
+        /// <summary>
+        /// Gets a value indicating whether incremental response streaming is available for this
+        /// exchange (the response-streaming interceptor is registered and installed its feature).
+        /// </summary>
+        public bool SupportsStreaming
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(response);
+                return response.HttpContext.Features.Get<IHttpResponseStreamingFeature>() is not null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IHttpResponseStreamingFeature"/> for this exchange.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        /// Response streaming is not enabled for this exchange (its interceptor was not registered on
+        /// the transport). Register <see cref="HttpResponseStreaming.CreateInterceptor"/> on the
+        /// transport's response interceptors, or check <see cref="SupportsStreaming"/> first.
+        /// </exception>
+        public IHttpResponseStreamingFeature Streaming
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(response);
+                return response.HttpContext.Features.Get<IHttpResponseStreamingFeature>()
+                    ?? throw new NotSupportedException(
+                        "Response streaming is not enabled for this exchange. Register HttpResponseStreaming.CreateInterceptor() " +
+                        "on the transport's ResponseInterceptors.");
+            }
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/HttpResponseStreaming.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/HttpResponseStreaming.cs
@@ -1,0 +1,24 @@
+using Assimalign.Cohesion.Http.Internal;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Entry point for enabling incremental response streaming on an HTTP server transport.
+/// </summary>
+/// <remarks>
+/// Register the interceptor this factory produces on the transport's response-interceptor list
+/// (<c>HttpConnectionListenerOptions.ResponseInterceptors</c>), the same way
+/// <c>Http.RequestLimits</c> registers a request interceptor. Doing so installs an
+/// <see cref="IHttpResponseStreamingFeature"/> on every exchange, which a handler resolves via
+/// <c>context.Response.Streaming</c>. The transport never references this package — it only invokes
+/// the <see cref="IHttpResponseInterceptor"/> and exposes its raw response body sink.
+/// </remarks>
+public static class HttpResponseStreaming
+{
+    /// <summary>
+    /// Creates the response interceptor that makes <see cref="IHttpResponseStreamingFeature"/>
+    /// available on every exchange served by the transport it is registered on.
+    /// </summary>
+    /// <returns>The response interceptor to add to the transport's response-interceptor list.</returns>
+    public static IHttpResponseInterceptor CreateInterceptor() => new HttpResponseStreamingInterceptor();
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/IHttpResponseStreamingFeature.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/IHttpResponseStreamingFeature.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A typed feature that lets an application <em>start</em> a response and write its body
+/// <em>incrementally</em>, flushing bytes to the transport as they are produced instead of
+/// buffering the whole body and sending it in one shot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a response feature package, not part of the protocol core or the transport. It is made
+/// available on an exchange by registering its response interceptor
+/// (<see cref="HttpResponseStreaming.CreateInterceptor"/>) on the server transport's
+/// <c>ResponseInterceptors</c>; the interceptor wraps the transport's raw response body sink and
+/// installs this feature, so the transport never depends on this package. A handler resolves it via
+/// <c>context.Features.Get&lt;IHttpResponseStreamingFeature&gt;()</c> or the ergonomic
+/// <c>context.Response.Streaming</c> accessor.
+/// </para>
+/// <para>
+/// <b>Header-commit timing (the load-bearing rule).</b> The response status line and header block
+/// are committed to the wire exactly once, at the moment the response <em>starts</em> — the first of
+/// <see cref="StartAsync"/>, <see cref="WriteAsync"/>, <see cref="FlushAsync"/>, or
+/// <see cref="CompleteAsync"/> to run. After the response has started (<see cref="HasStarted"/> is
+/// <see langword="true"/>) the status code and headers are <em>locked</em>: they have already been
+/// transmitted, so further mutation has no effect on the wire. Set every header before the first
+/// call.
+/// </para>
+/// <para>
+/// <b>Framing and backpressure</b> are the transport's concern: HTTP/1.1 uses chunked transfer
+/// coding when no <c>Content-Length</c> was set; HTTP/2 and HTTP/3 emit incremental <c>DATA</c>
+/// frames. Writes respect transport flow control and therefore <em>await</em> available send credit
+/// rather than buffering unbounded. The wire terminator is emitted when the transport finalizes the
+/// exchange; <see cref="CompleteAsync"/> flushes and forbids further writes.
+/// </para>
+/// <para>
+/// <b>Threading.</b> Like <see cref="System.IO.Stream"/>, an implementation is <em>not</em> safe for
+/// concurrent use: a single exchange's response is written by one logical caller.
+/// </para>
+/// </remarks>
+public interface IHttpResponseStreamingFeature : IHttpFeature
+{
+    /// <summary>
+    /// Gets a value indicating whether the response has started — that is, whether the status line
+    /// and headers have been committed to the wire. Once <see langword="true"/>, the status code and
+    /// headers are locked.
+    /// </summary>
+    bool HasStarted { get; }
+
+    /// <summary>
+    /// Starts the response by committing the status line and header block to the transport, locking
+    /// the status code and headers. Idempotent.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the header write.</param>
+    /// <returns>A task that completes when the head has been flushed to the transport.</returns>
+    ValueTask StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes a chunk of response-body bytes, starting the response first if it has not started. The
+    /// write awaits transport flow-control credit rather than buffering unbounded.
+    /// </summary>
+    /// <param name="data">The body bytes to write. An empty buffer is a no-op beyond starting the response.</param>
+    /// <param name="cancellationToken">A token to cancel the write.</param>
+    /// <returns>A task that completes when the bytes have been handed to the transport.</returns>
+    /// <exception cref="InvalidOperationException">The response has already been completed.</exception>
+    ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flushes any buffered body bytes through to the transport so the peer can observe them,
+    /// starting the response first if it has not started.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the flush.</param>
+    /// <returns>A task that completes when the buffered bytes have been flushed.</returns>
+    /// <exception cref="InvalidOperationException">The response has already been completed.</exception>
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes the response body: flushes and forbids further writes. Idempotent. Starts the
+    /// response first if it never started — so calling only <see cref="CompleteAsync"/> still commits
+    /// the head and locks the headers (an empty streamed response). The transport emits the wire
+    /// end-of-body marker (terminating zero-length chunk / <c>END_STREAM</c>) when it finalizes the
+    /// exchange.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the completion.</param>
+    /// <returns>A task that completes when the body has been flushed.</returns>
+    ValueTask CompleteAsync(CancellationToken cancellationToken = default);
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Internal/HttpResponseStreamingFeature.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Internal/HttpResponseStreamingFeature.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Internal;
+
+/// <summary>
+/// Default <see cref="IHttpResponseStreamingFeature"/> implementation. A thin typed API over the
+/// transport's raw response body sink (<see cref="HttpResponseInterceptorContext.ResponseBody"/>):
+/// the sink owns the wire framing and header-commit timing, while this feature owns the ergonomic
+/// start/write/flush/complete surface and the write-after-complete guard.
+/// </summary>
+internal sealed class HttpResponseStreamingFeature : IHttpResponseStreamingFeature
+{
+    /// <summary>The name under which the response-streaming feature is registered.</summary>
+    public const string FeatureName = "Assimalign.Cohesion.Http.ResponseStreaming";
+
+    private readonly Stream _sink;
+    private bool _started;
+    private bool _completed;
+
+    public HttpResponseStreamingFeature(Stream sink)
+    {
+        _sink = sink;
+    }
+
+    /// <inheritdoc />
+    public string Name => FeatureName;
+
+    /// <inheritdoc />
+    public bool HasStarted => _started;
+
+    /// <inheritdoc />
+    public async ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+        // Flushing the sink with no body written commits the head (the sink commits headers on the
+        // first write or flush).
+        await _sink.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompleted();
+        _started = true;
+        await _sink.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompleted();
+        _started = true;
+        await _sink.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _started = true;
+        _completed = true;
+        // Flush the buffered bytes; the transport emits the wire terminator when it finalizes the
+        // exchange (the sink's own completion).
+        await _sink.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "The streaming response has already been completed; no further body bytes can be written.");
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Internal/HttpResponseStreamingInterceptor.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/src/Internal/HttpResponseStreamingInterceptor.cs
@@ -1,0 +1,16 @@
+namespace Assimalign.Cohesion.Http.Internal;
+
+/// <summary>
+/// The response interceptor that makes incremental response streaming available on an exchange. It
+/// wraps the transport's raw response body sink in a typed <see cref="IHttpResponseStreamingFeature"/>
+/// and installs it on the exchange's feature collection — the seam by which streaming plugs into the
+/// transport without the transport depending on this package.
+/// </summary>
+internal sealed class HttpResponseStreamingInterceptor : IHttpResponseInterceptor
+{
+    /// <inheritdoc />
+    public void OnResponse(HttpResponseInterceptorContext context)
+    {
+        context.Features.Set(new HttpResponseStreamingFeature(context.ResponseBody));
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/Assimalign.Cohesion.Http.Streaming.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/Assimalign.Cohesion.Http.Streaming.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>disable</ImplicitUsings>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/HttpResponseStreamingFeatureTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Streaming/tests/HttpResponseStreamingFeatureTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Streaming.Tests;
+
+public class HttpResponseStreamingFeatureTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Interceptor: Should install a streaming feature over the response body sink")]
+    public void Interceptor_OnResponse_ShouldInstallStreamingFeature()
+    {
+        RecordingSink sink = new();
+        HttpResponseInterceptorContext context = CreateContext(sink);
+
+        HttpResponseStreaming.CreateInterceptor().OnResponse(context);
+
+        context.Features.Get<IHttpResponseStreamingFeature>().ShouldNotBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Feature: WriteAsync forwards bytes to the sink and marks started")]
+    public async Task WriteAsync_ShouldForwardToSinkAndStart()
+    {
+        (IHttpResponseStreamingFeature feature, RecordingSink sink) = CreateFeature();
+
+        feature.HasStarted.ShouldBeFalse();
+        await feature.WriteAsync(Encoding.UTF8.GetBytes("hello"));
+        await feature.WriteAsync(Encoding.UTF8.GetBytes(" world"));
+
+        feature.HasStarted.ShouldBeTrue();
+        Encoding.UTF8.GetString(sink.Written).ShouldBe("hello world");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Feature: StartAsync commits the head via a flush and is idempotent")]
+    public async Task StartAsync_ShouldFlushOnceAndStart()
+    {
+        (IHttpResponseStreamingFeature feature, RecordingSink sink) = CreateFeature();
+
+        await feature.StartAsync();
+        await feature.StartAsync();
+
+        feature.HasStarted.ShouldBeTrue();
+        sink.FlushCount.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Feature: FlushAsync starts the response and flushes")]
+    public async Task FlushAsync_ShouldStartAndFlush()
+    {
+        (IHttpResponseStreamingFeature feature, RecordingSink sink) = CreateFeature();
+
+        await feature.FlushAsync();
+
+        feature.HasStarted.ShouldBeTrue();
+        sink.FlushCount.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Feature: CompleteAsync is idempotent")]
+    public async Task CompleteAsync_CalledTwice_ShouldFlushOnce()
+    {
+        (IHttpResponseStreamingFeature feature, RecordingSink sink) = CreateFeature();
+
+        await feature.WriteAsync(Encoding.UTF8.GetBytes("x"));
+        await feature.CompleteAsync();
+        await feature.CompleteAsync();
+
+        sink.FlushCount.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Feature: Writing after completion throws")]
+    public async Task WriteAsync_AfterComplete_ShouldThrow()
+    {
+        (IHttpResponseStreamingFeature feature, RecordingSink _) = CreateFeature();
+
+        await feature.WriteAsync(Encoding.UTF8.GetBytes("x"));
+        await feature.CompleteAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await feature.WriteAsync(Encoding.UTF8.GetBytes("y")));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Accessor: Response.Streaming resolves the installed feature")]
+    public void ResponseStreamingAccessor_ShouldResolveInstalledFeature()
+    {
+        RecordingSink sink = new();
+        HttpResponseInterceptorContext context = CreateContext(sink);
+        HttpResponseStreaming.CreateInterceptor().OnResponse(context);
+
+        FakeHttpResponse response = new(context.Features);
+
+        response.SupportsStreaming.ShouldBeTrue();
+        response.Streaming.ShouldBeSameAs(context.Features.Get<IHttpResponseStreamingFeature>());
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Streaming] - Accessor: Response.Streaming throws when streaming is not enabled")]
+    public void ResponseStreamingAccessor_WhenNotEnabled_ShouldThrow()
+    {
+        FakeHttpResponse response = new(new HttpFeatureCollection());
+
+        response.SupportsStreaming.ShouldBeFalse();
+        Should.Throw<NotSupportedException>(() => _ = response.Streaming);
+    }
+
+    private static (IHttpResponseStreamingFeature Feature, RecordingSink Sink) CreateFeature()
+    {
+        RecordingSink sink = new();
+        HttpResponseInterceptorContext context = CreateContext(sink);
+        HttpResponseStreaming.CreateInterceptor().OnResponse(context);
+        return (context.Features.Get<IHttpResponseStreamingFeature>()!, sink);
+    }
+
+    private static HttpResponseInterceptorContext CreateContext(Stream sink) => new()
+    {
+        Version = HttpVersion.Http11,
+        Headers = new HttpHeaderCollection(),
+        Features = new HttpFeatureCollection(),
+        ConnectionInfo = new HttpConnectionInfo(),
+        ResponseBody = sink,
+    };
+
+    /// <summary>A write-only stream that records the bytes and flushes written through the feature.</summary>
+    private sealed class RecordingSink : Stream
+    {
+        private readonly List<byte> _written = new();
+
+        public byte[] Written => _written.ToArray();
+        public int FlushCount { get; private set; }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _written.AddRange(buffer.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            FlushCount++;
+            return Task.CompletedTask;
+        }
+
+        public override void Flush() => FlushCount++;
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => _written.AddRange(new ReadOnlySpan<byte>(buffer, offset, count).ToArray());
+    }
+
+    /// <summary>A minimal <see cref="IHttpResponse"/> exposing a feature collection, for the accessor tests.</summary>
+    private sealed class FakeHttpResponse : IHttpResponse, IHttpContext
+    {
+        public FakeHttpResponse(IHttpFeatureCollection features)
+        {
+            Features = features;
+        }
+
+        // IHttpResponse
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+        public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+        public IHttpContext HttpContext => this;
+        public Stream Body { get; set; } = Stream.Null;
+
+        // IHttpContext (only Features is exercised by the accessor)
+        public HttpVersion Version => HttpVersion.Http11;
+        public IHttpRequest Request => throw new NotSupportedException();
+        public IHttpResponse Response => this;
+        public IHttpConnectionInfo ConnectionInfo => throw new NotSupportedException();
+        public IHttpFeatureCollection Features { get; }
+        public IDictionary<string, object?> Items => throw new NotSupportedException();
+        public CancellationToken RequestCancelled => CancellationToken.None;
+        public void Cancel() { }
+        public Task CancelAsync() => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.slnx
+++ b/libraries/Http/Assimalign.Cohesion.Http.slnx
@@ -86,6 +86,23 @@
 	<Folder Name="/Http/Assimalign.Cohesion.Http.ExtendedConnect/tests/">
 		<Project Path="Assimalign.Cohesion.Http.ExtendedConnect/tests/Assimalign.Cohesion.Http.ExtendedConnect.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.Streaming/" />
+	<Folder Name="/Http/Assimalign.Cohesion.Http.Streaming/src/">
+		<Project Path="Assimalign.Cohesion.Http.Streaming/src/Assimalign.Cohesion.Http.Streaming.csproj" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.Streaming/tests/">
+		<Project Path="Assimalign.Cohesion.Http.Streaming/tests/Assimalign.Cohesion.Http.Streaming.Tests.csproj" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.ServerSentEvents/" />
+	<Folder Name="/Http/Assimalign.Cohesion.Http.ServerSentEvents/src/">
+		<Project Path="Assimalign.Cohesion.Http.ServerSentEvents/src/Assimalign.Cohesion.Http.ServerSentEvents.csproj" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.ServerSentEvents/tests/">
+		<Project Path="Assimalign.Cohesion.Http.ServerSentEvents/tests/Assimalign.Cohesion.Http.ServerSentEvents.Tests.csproj" />
+	</Folder>
+	<Folder Name="/Http/Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/">
+		<Project Path="Assimalign.Cohesion.Http.ServerSentEvents/examples/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse/Assimalign.Cohesion.Http.ServerSentEvents.Examples.Sse.csproj" />
+	</Folder>
 	<Folder Name="/Http/Assimalign.Cohesion.Http.Forms/">
 		<File Path="Assimalign.Cohesion.Http.Forms/README.md" />
 	</Folder>

--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -449,3 +449,50 @@ the Items-key bridge.
 
 Interface dispatch plus the existing dictionary-backed feature lookup — no
 reflection, no codegen.
+
+## The response interceptor seam
+
+`IHttpResponseInterceptor` (+ `HttpResponseInterceptorContext`) is the symmetric
+counterpart to `IHttpRequestInterceptor`: a generic hook the server transport
+invokes while an exchange's response pipeline is being set up, before the handler
+runs. It exists so **response-side capabilities stay out of both the protocol core
+and the transport**. Incremental response streaming — and Server-Sent Events on top
+of it — is the first consumer, and neither the core nor the transport carries any
+streaming/SSE type.
+
+### Why generic, and how a feature plugs in
+
+The request side already established the pattern: `Http.RequestLimits` participates
+in request parsing via an `IHttpRequestInterceptor` (registered on the listener
+options), and the transport enforces it without ever referencing that package. The
+response side mirrors it exactly:
+
+- The transport exposes its per-protocol **raw response body sink** as a plain
+  `System.IO.Stream` on `HttpResponseInterceptorContext.ResponseBody`. That sink
+  frames each write (HTTP/1.1 chunked, HTTP/2 / HTTP/3 `DATA` frames with
+  flow-control backpressure), commits the head on the first write/flush, and is
+  finalized by the transport when the exchange completes.
+- A feature package (`Assimalign.Cohesion.Http.Streaming`) ships an
+  `IHttpResponseInterceptor` that wraps that sink in a typed
+  `IHttpResponseStreamingFeature` and installs it on `context.Features`. A handler
+  resolves the feature (`context.Response.Streaming`) and writes.
+
+So the streaming write/flush API, its state machine, and the SSE wire format all
+live in feature packages; the core owns only the generic interceptor seam, and the
+transport owns only the framing. The one streaming-adjacent thing that stays in the
+core is the well-known **header-name constant** `HttpHeaderKey.LastEventId`,
+alongside the other feature-specific header names already centralized there
+(`Sec-WebSocket-*`, `Grpc-*`).
+
+### Header-commit timing
+
+Because the sink commits the head on the first write or flush, the status line and
+headers are committed exactly once and locked thereafter — a rule the streaming
+feature surfaces to callers and the SSE package relies on (set `Content-Type:
+text/event-stream` before the first write). The interceptor runs *before* any
+response byte is produced, so an interceptor may still set default response headers
+on `HttpResponseInterceptorContext.Headers`.
+
+### AOT posture
+
+Interface dispatch over a snapshotted interceptor array; no reflection, no codegen.

--- a/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpResponseInterceptor.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/Abstractions/IHttpResponseInterceptor.cs
@@ -1,0 +1,48 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A server-side interception point applied while the response pipeline for an exchange is being
+/// set up, before the application handler runs. Response interceptors are the symmetric
+/// counterpart to <see cref="IHttpRequestInterceptor"/>: they let feature packages participate in
+/// the response — attaching typed <see cref="IHttpFeature"/>s and tapping the transport's raw
+/// response body sink — <b>without the transport taking a dependency on any feature package</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the seam that keeps response-side capabilities (incremental streaming, Server-Sent
+/// Events, and later response compression) out of both the protocol core and the transport. A
+/// feature package ships an <see cref="IHttpResponseInterceptor"/> that, in
+/// <see cref="OnResponse"/>, wraps the transport-provided
+/// <see cref="HttpResponseInterceptorContext.ResponseBody"/> sink and installs a typed feature on
+/// <see cref="HttpResponseInterceptorContext.Features"/>; the application resolves that feature
+/// and drives it. The transport invokes the interceptors and enforces the wire framing, but never
+/// references the feature package — exactly how <c>Http.RequestLimits</c> plugs into request
+/// parsing via <see cref="IHttpRequestInterceptor"/>.
+/// </para>
+/// <para>
+/// Interceptors are registered on the server transport's listener options and are invoked in
+/// registration order. A registered instance is shared across <b>all</b> connections and requests
+/// served by the listener: implementations must be stateless and thread-safe, and any per-request
+/// state belongs in <see cref="HttpResponseInterceptorContext.Features"/>, never in instance
+/// fields.
+/// </para>
+/// <para>
+/// The hook ships a default implementation so an interceptor overrides only what it needs; future
+/// interception points are added the same way without breaking existing implementations. Hooks run
+/// inline while the exchange is being set up, before any response byte is produced, so they must be
+/// CPU-only — no I/O, no blocking waits.
+/// </para>
+/// </remarks>
+public interface IHttpResponseInterceptor
+{
+    /// <summary>
+    /// Called once per exchange, after the request head has been parsed and before the application
+    /// handler runs. Implementations attach response features and may wrap the raw response body
+    /// sink exposed on the context; nothing has been written to the wire yet, so the response
+    /// status and headers are still fully mutable by the application afterward.
+    /// </summary>
+    /// <param name="context">The response-setup view of the exchange.</param>
+    void OnResponse(HttpResponseInterceptorContext context)
+    {
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpHeaderKey.cs
@@ -198,6 +198,15 @@ public readonly struct HttpHeaderKey : IEquatable<HttpHeaderKey>, IComparable<Ht
     /// <summary>Gets the <c>If-Unmodified-Since</c> HTTP header name.</summary>
     public static HttpHeaderKey IfUnmodifiedSince {get;}= new( "If-Unmodified-Since");
 
+    /// <summary>Gets the <c>Last-Event-ID</c> HTTP header name.</summary>
+    /// <remarks>
+    /// Defined by the WHATWG HTML Server-Sent Events specification. A browser
+    /// reconnecting to an <c>text/event-stream</c> endpoint replays the last event
+    /// id it saw in this request header so the server can resume the stream from
+    /// that point.
+    /// </remarks>
+    public static HttpHeaderKey LastEventId {get;}= new( "Last-Event-ID");
+
     /// <summary>Gets the <c>Last-Modified</c> HTTP header name.</summary>
     public static HttpHeaderKey LastModified {get;}= new( "Last-Modified");
 

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpResponseInterceptorContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpResponseInterceptorContext.cs
@@ -1,0 +1,62 @@
+using System.IO;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The response-setup view of an exchange handed to <see cref="IHttpResponseInterceptor"/>
+/// implementations by the server transport, before the application handler runs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The transport constructs one context per exchange and owns it for the exchange's lifetime.
+/// Features attached to <see cref="Features"/> are visible to the application from the first
+/// middleware onward and participate in the exchange's normal feature-disposal walk.
+/// </para>
+/// <para>
+/// The context is not thread-safe; it must only be touched from the exchange's setup/dispatch
+/// flow. All required members are set by the transport at construction. Members added in future
+/// versions will be optional with sensible defaults so existing construction sites (including test
+/// fakes) keep compiling.
+/// </para>
+/// </remarks>
+public sealed class HttpResponseInterceptorContext
+{
+    /// <summary>
+    /// Gets the HTTP version of the exchange.
+    /// </summary>
+    public required HttpVersion Version { get; init; }
+
+    /// <summary>
+    /// Gets the response header collection. Mutable — an interceptor may set default response
+    /// headers here (they are committed to the wire when the response starts). Once the response
+    /// has started the headers are locked, so interceptor edits made during
+    /// <see cref="IHttpResponseInterceptor.OnResponse"/> always precede the commit.
+    /// </summary>
+    public required HttpHeaderCollection Headers { get; init; }
+
+    /// <summary>
+    /// Gets the feature collection for the exchange. Interceptors install the response feature they
+    /// provide here (for example an incremental streaming writer that wraps
+    /// <see cref="ResponseBody"/>).
+    /// </summary>
+    public required IHttpFeatureCollection Features { get; init; }
+
+    /// <summary>
+    /// Gets the transport connection metadata for the exchange (local/remote endpoints).
+    /// </summary>
+    public required HttpConnectionInfo ConnectionInfo { get; init; }
+
+    /// <summary>
+    /// Gets the transport's raw response body sink — a write-only stream that frames each write for
+    /// the negotiated protocol (chunked transfer coding for HTTP/1.1, <c>DATA</c> frames with
+    /// flow-control backpressure for HTTP/2 / HTTP/3), commits the response head on the first write
+    /// or flush, and is finalized by the transport when the exchange completes.
+    /// </summary>
+    /// <remarks>
+    /// This is the seam a response feature taps: writing to it (or a wrapper over it) streams the
+    /// response body incrementally. It is a generic <see cref="Stream"/> so the protocol core and
+    /// feature packages carry no per-protocol framing knowledge. When no interceptor writes to it
+    /// the transport falls back to the buffered response path.
+    /// </remarks>
+    public required Stream ResponseBody { get; init; }
+}


### PR DESCRIPTION
## Summary

No transport supported starting a response and incrementally writing/flushing it — the write paths buffered one response per exchange, which blocks SSE, progress feeds, and efficient large responses. This adds the streaming response write path across all three transports plus Server-Sent Events primitives — architected so **neither the protocol core nor the transport carries any streaming/SSE type**: features tap into the connection pipeline through a generic response-interceptor seam.

Program sequencing: Stage 2, Lane A/B in `docs/HTTP_WEB_PROGRAM_PLAN.md`. Builds on #750 / PR #849 (merged): the h2 background frame pump from #849 is what makes send-side backpressure deadlock-free under the sequential dispatcher.

## Architecture (two commits)

**Commit 1 — the seam + the packages**

- **core `Assimalign.Cohesion.Http`** — only the *generic* `IHttpResponseInterceptor` + `HttpResponseInterceptorContext` (the symmetric counterpart to `IHttpRequestInterceptor`). The transport exposes its raw per-protocol response body sink (a `Stream`) through it; feature packages tap in without the transport depending on them. Plus the `Last-Event-ID` `HttpHeaderKey`.
- **`Http.Connections` (transport)** — `HttpResponseBodyStream` + `Http1/2/3ResponseBodyStream`: write-only sinks that frame chunked transfer coding (h1) / DATA frames (h2/h3) and **commit the head on first write/flush** (headers locked thereafter). `ResponseInterceptors` on the listener options, snapshotted and run per exchange across all three protocols; `SendAsync` finalizes the sink only if it was written, else the buffered path (zero-interceptor fast path). **No dependency on any streaming/SSE package.**
- **new `Assimalign.Cohesion.Http.Streaming`** — `IHttpResponseStreamingFeature` + `HttpResponseStreaming.CreateInterceptor()` (the `Http.RequestLimits` registration pattern) + `Response.Streaming` accessor. Depends on core Http only. Streaming is **opt-in per listener**.
- **new `Assimalign.Cohesion.Http.ServerSentEvents`** — `ServerSentEvent` + `ServerSentEventFormatter` (WHATWG `text/event-stream`) + `WriteEventAsync`/`WriteKeepAliveAsync` over the streaming feature. Depends on `Http.Streaming`, never the transport.

**Commit 2 — merge of main (#849) + send-side flow control layered onto its pump**

- Adopts #849's h2 architecture (background `PumpAsync`, per-stream body pipes, consumption-driven receive credit, `_syncRoot` + per-stream `_stateLock`) and layers the send side onto it: `WriteStreamingDataAsync` → `AcquireSendWindowAsync` consumes connection+stream send credit (RFC 9113 §5.2) and parks on a signal the pump completes when `WINDOW_UPDATE` / `SETTINGS` credit arrives — the pump runs concurrently with the handler, so a parked writer is always unblocked.
- Hardening from adversarial review: a writer parked for send credit **fails fast with a wire-level `IOException` when the pump exits** (wire failure/teardown) instead of hanging forever; the `SETTINGS_INITIAL_WINDOW_SIZE` send-window adjustment moved under `_syncRoot`; completed streamed responses **reap their stream** (via `RemoveStreamAsync`, reclaiming receive-window debt) with `RST_STREAM(NO_ERROR)` for undrained request bodies.

## Tests (Shouldly, co-located)

- SSE formatter + `WriteEventAsync` bridge; streaming feature state machine (start-once, header-lock, idempotent complete, write-after-complete throws); `Response.Streaming` accessor.
- Per-protocol round-trip tests proving a client **observes bytes before the response completes** (h1 chunked, h2/h3 DATA with no `Content-Length`), driven through the registered interceptor.
- **Deadlock regression**: a write past a 4-octet send window resolves via the frame pump without the caller driving the receive loop. **Reap regression**: `StreamCount` 1 → 0 after a streamed response. Opt-in regression: no interceptor → no feature, buffered path intact.
- Full suites green: core Http 496, Http.Connections 241 (incl. #849's flow-control tests), Http.Streaming 8, ServerSentEvents 12.

## Docs & example

- Streaming/header-commit model + the response-interceptor seam documented in `docs/DESIGN.md` for core Http, Http.Connections, Http.Streaming, and ServerSentEvents.
- Runnable end-to-end SSE example under `Http.ServerSentEvents/examples` (composes transport + streaming interceptor + SSE; verified: 5 events observed incrementally + keep-alive before completion). Registered in the three `.slnx` files.

## Standards & compliance

- WHATWG HTML Server-Sent Events (`text/event-stream`)
- RFC 9112 §7.1 (chunked), RFC 9113 §5.2/§5.1/§8.1 (h2 flow control, END_STREAM, resets), RFC 9114 §7 (h3 DATA)
- AGENTS.md throughout: interface-first + internal impls, file-scoped namespaces, `CohesionProjectReference` only, no `Microsoft.Extensions.*`, XML docs, AOT/no-reflection, Shouldly tests, DESIGN.md updated in the same change.

## Notes / follow-ups (not in scope)

- The Web-facing `ServerSentEventsResult` over `IAsyncEnumerable` + builder-time keep-alive/retry config follows under #149 / #28.
- A future response-side feature needing a transport hook (e.g. response compression #779) reuses the same `IHttpResponseInterceptor` seam.

## Work items resolved by this PR
Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)