### PR TITLE
[L01.01.11.27] Alt-Svc advertisement for HTTP/3 discovery (RFC 7838)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -2013,6 +2013,109 @@ falls back to a pooled buffer otherwise. The scheduler is a plain lock + list wi
 a pure selection function. Builds clean under the trim/AOT analyzers
 (`IsAotCompatible=true`).
 
+## Alt-Svc advertisement (RFC 7838)
+
+### What it is
+
+A server that speaks HTTP/3 over QUIC alongside HTTP/1.1 / HTTP/2 over TCP has a
+discovery problem: a client that connects on a TCP-based protocol has no way to
+learn the h3 endpoint exists unless the server tells it. RFC 7838 solves this with
+the `Alt-Svc` response header — `Alt-Svc: h3=":443"; ma=86400` advertises "the same
+origin is also reachable via HTTP/3 on port 443, cache that for 86400 seconds"
+(RFC 9114 §3.1 makes this the standard h3 discovery path). Without it the h3
+listener this package can already stand up is dark to every client that didn't
+already know to try it.
+
+Two pieces cooperate: the **typed value** `HttpAltService` in the core
+`Assimalign.Cohesion.Http` library (RFC 7838 §3 alt-value: `protocol-id`, quoted
+alt-authority with optional host + required port, `ma`, `persist`, and the special
+`clear` token — with round-trip `Format`/`TryParse`), and the **emission** here,
+where the listener is the only component that knows whether an HTTP/3
+`IMultiplexedConnectionListener` is registered alongside the stream listeners.
+
+### Where the advertisement is decided and injected
+
+Advertisement is opt-in via `HttpConnectionListenerOptions.AltServiceAdvertisement`
+(or the `AdvertiseAltService(...)` fluent form): an `Enabled` flag, a `MaxAge`
+(emitted as `ma`, default 24h), and an optional explicit `Authority`. Parameters
+beyond `ma` (such as `persist=1`) are deliberately not server knobs — an application
+that needs them sets the header itself via the typed `HttpAltService`, and the
+server's guarded injection yields to it. `HttpConnectionListener` computes the
+header value **once, at construction**,
+after every listener has been materialized so the h3 endpoint is known. The value is
+produced only when advertisement is enabled **and** at least one HTTP/3 listener is
+registered **and** at least one stream listener exists to carry it; otherwise it is
+`null` and nothing is injected. The h3 port is derived as `:"<port>"` from the first
+multiplexed listener's `EndPoint` (advertising the alternative on the request's own
+host), unless `Authority` overrides it — needed when the QUIC bind port is not the
+port clients reach (port-mapping load balancer) or the alternative lives on another
+host. If advertisement is enabled but the port cannot be determined (endpoint exposes
+no port and no explicit `Authority`), construction fails loud rather than silently
+not advertising.
+
+The precomputed value is pushed onto the stream connection factories
+(`HttpConnectionFactory.AltSvcHeaderValue`) before the first connection is accepted
+— the accept loops start lazily on the first `AcceptOrListenAsync`, so no factory
+observes a half-set value — and flows factory → connection → connection context.
+
+### Why injection is at head-commit, guarded — not an exchange interceptor
+
+The header is injected at the point each transport serializes the response head, via
+the shared `HttpAltServiceInjector.Inject`, which adds `Alt-Svc` **only when the
+header is absent**. The injection runs after the application handler *and* after the
+`BeforeResponseHead` lifecycle hooks have fired, so any `Alt-Svc` set by the
+application or by a hook always wins (an explicit acceptance requirement, and the
+natural RFC 7838 posture — the server fills a gap, it does not override policy).
+
+Riding the exchange-interceptor seam (`IHttpExchangeInterceptor`, whose
+`BeforeResponseHeadAsync` hook does fire at exactly this commit point) was
+deliberately rejected, for two reasons. First, a server-registered interceptor is
+listener-wide: it would run on HTTP/3 exchanges too, which must never be decorated —
+you do not advertise h3 to a client already on h3 — turning a constant header add
+into a per-exchange version check inside a hook. Second, and more structurally, the
+interceptor list's zero-registration fast path is scope-exact: when no interceptor
+declares the response scope, no response sink or exchange control is ever
+constructed. Registering an internal interceptor just to add one precomputed header
+would push **every** exchange onto the interceptor slow path whenever advertisement
+is enabled. Direct injection is one `ContainsKey` + assignment at each head-commit
+site and leaves the fast path intact.
+
+The four commit sites are the h1 buffered path (`Http1ConnectionContext.SendAsync` →
+`Http1MessageWriter`), the h1 streaming sink
+(`Http1ResponseBodyStream.CommitHeadersAsync`), the h2 buffered path
+(`Http2ConnectionContext.SendAsync`), and the h2 streaming head
+(`WriteStreamingHeadersAsync`). On every one of them the injection sits after the
+lifecycle hooks and the abort/takeover directive re-checks, immediately before the
+head is serialized. Interim (1xx) responses are not decorated — only the final
+response head carries the advertisement.
+
+This is, by design, the **first server-injected response header** in this package
+(there is no automatic `Date`/`Server` injection); the guard-on-absence pattern and
+the shared injector are the seam a future auto-header would reuse.
+
+### AOT posture
+
+No reflection or dynamic dispatch. `HttpAltService` is a span-based value type; the
+per-listener header value is a single string computed at construction and read on the
+response path. `IsAotCompatible=true` holds.
+
+### Non-goals
+
+- **The HTTP/2 `ALTSVC` frame (type `0x0a`, RFC 7838 §4).** Not implemented. The
+  `Alt-Svc` **response header** is valid on HTTP/2 responses and is what mainstream
+  servers (e.g. Kestrel) emit for h3 discovery, so it fully satisfies the discovery
+  need. The frame is an alternative delivery mechanism (notably it can advertise for
+  an origin the current request is not for), which this package has no requirement
+  for; adding it would be wire machinery with no consumer. Recorded here so its
+  absence is understood as intentional.
+- **Client-side `Alt-Svc` cache / alt-authority selection.** `HttpAltService` parses
+  the header and models `ma`/`persist` caching semantics as data, but this package is
+  the server side; honoring a received `Alt-Svc` (maintaining the client's alternative
+  cache, racing connections) is a client concern and out of scope.
+- **`clear` emission on the live server path.** `HttpAltService.ClearToken` and parse
+  support exist for completeness and round-tripping, but the server emitter only
+  advertises the configured h3 alternative; it never emits `Alt-Svc: clear`.
+
 ## Scope decision: server push (de-scoped)
 
 Cohesion **does not implement HTTP/2 or HTTP/3 server push.** This is a

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpAltServiceAdvertisementOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpAltServiceAdvertisementOptions.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace Assimalign.Cohesion.Http.Connections;
+
+/// <summary>
+/// Configures whether an <see cref="HttpConnectionListener"/> advertises its HTTP/3 (QUIC) listener
+/// to HTTP/1.1 and HTTP/2 clients via an RFC 7838 <c>Alt-Svc</c> response header, so a client that
+/// started on a TCP-based protocol can discover and upgrade to the h3 endpoint (RFC 9114 §3.1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Advertisement only takes effect when it is <see cref="Enabled"/> <em>and</em> the listener is
+/// configured with both a stream protocol (HTTP/1.1 or HTTP/2) and an HTTP/3 multiplexed listener —
+/// there is otherwise nothing to advertise or no TCP response to carry the header. When active, the
+/// server injects <c>Alt-Svc: h3="&lt;authority&gt;"; ma=&lt;seconds&gt;</c> on HTTP/1.1 and HTTP/2
+/// responses, deriving the port from the registered HTTP/3 listener endpoint unless
+/// <see cref="Authority"/> supplies one explicitly.
+/// </para>
+/// <para>
+/// The server never overwrites an <c>Alt-Svc</c> header the application set itself: the injection is
+/// applied at response-head commit time only when the header is absent.
+/// </para>
+/// </remarks>
+public sealed class HttpAltServiceAdvertisementOptions
+{
+    private TimeSpan _maxAge = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HTTP/3 advertisement is enabled. Defaults to
+    /// <see langword="false"/> — advertisement is opt-in.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the freshness lifetime emitted as the <c>ma</c> parameter (RFC 7838 §3.1).
+    /// Defaults to 24 hours. Serialized as whole seconds (fractional seconds are truncated).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the assigned value is negative.</exception>
+    public TimeSpan MaxAge
+    {
+        get => _maxAge;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The max-age must be non-negative.");
+            }
+
+            _maxAge = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets an explicit alt-authority for the advertised HTTP/3 endpoint, of the form
+    /// <c>host:port</c> or <c>:port</c> (an empty host advertises the alternative on the request's
+    /// own host). When <see langword="null"/> (the default), the authority is derived as
+    /// <c>:&lt;port&gt;</c> from the registered HTTP/3 listener endpoint.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set this when the QUIC listener's bound port is not the port clients should reach it on — for
+    /// example when the endpoint is behind a port-mapping load balancer — or when the alternative
+    /// lives on a different host.
+    /// </para>
+    /// <para>
+    /// Parameters beyond <c>ma</c> (such as <c>persist=1</c>) are deliberately not configurable
+    /// here: an application that needs them sets the <c>Alt-Svc</c> header itself (for example via
+    /// <see cref="HttpAltService"/>), and the server's injection always yields to an
+    /// application-set value.
+    /// </para>
+    /// </remarks>
+    public string? Authority { get; set; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListener.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListener.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -81,6 +82,20 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
         }
 
         Protocols = protocols;
+
+        // Compute the Alt-Svc advertisement once — every listener has now been materialized, so the
+        // HTTP/3 endpoint (if any) is known — and push it onto the stream factories that inject it on
+        // their responses. Set before the first connection is accepted (accept loops start lazily on
+        // the first AcceptOrListenAsync), so no factory observes a half-set value.
+        string? altSvcHeaderValue = BuildAltSvcHeaderValue(options.AltServiceAdvertisement, _multiplexedListeners, _streamListeners.Count);
+        if (altSvcHeaderValue is not null)
+        {
+            foreach ((HttpConnectionFactory factory, IConnectionListener _) in _streamListeners)
+            {
+                factory.AltSvcHeaderValue = altSvcHeaderValue;
+            }
+        }
+
         _acceptLoops = new List<Task>(_streamListeners.Count + _multiplexedListeners.Count);
         _acceptedConnections = Channel.CreateBounded<HttpConnection>(new BoundedChannelOptions(options.BacklogCapacity)
         {
@@ -96,6 +111,95 @@ public sealed class HttpConnectionListener : IHttpConnectionListener
     /// Gets the configured HTTP protocols supported by this listener.
     /// </summary>
     public HttpProtocol Protocols { get; }
+
+    /// <summary>
+    /// Builds the RFC 7838 <c>Alt-Svc</c> header value the stream protocols advertise, or
+    /// <see langword="null"/> when advertisement does not apply. Advertisement requires the opt-in
+    /// flag, at least one HTTP/3 listener to advertise, and at least one stream listener to carry the
+    /// header. The h3 port is taken from the first HTTP/3 listener endpoint unless an explicit
+    /// authority is configured.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when advertisement is enabled but the h3 port cannot be determined — the configured
+    /// authority is malformed, or the HTTP/3 listener endpoint exposes no port and no explicit
+    /// authority was supplied.
+    /// </exception>
+    private static string? BuildAltSvcHeaderValue(
+        HttpAltServiceAdvertisementOptions advertisement,
+        List<(HttpMultiplexedConnectionFactory Factory, IMultiplexedConnectionListener Listener)> multiplexedListeners,
+        int streamListenerCount)
+    {
+        if (!advertisement.Enabled || multiplexedListeners.Count == 0 || streamListenerCount == 0)
+        {
+            return null;
+        }
+
+        long maxAgeSeconds = (long)advertisement.MaxAge.TotalSeconds;
+
+        HttpAltService alternative;
+        if (!string.IsNullOrEmpty(advertisement.Authority))
+        {
+            if (!TryParseAuthority(advertisement.Authority, out string? host, out int port))
+            {
+                throw new InvalidOperationException(
+                    $"The configured Alt-Svc authority '{advertisement.Authority}' is not a valid 'host:port' or ':port' value.");
+            }
+
+            alternative = HttpAltService.Http3(host, port, maxAgeSeconds);
+        }
+        else if (TryGetPort(multiplexedListeners[0].Listener.EndPoint, out int derivedPort))
+        {
+            // Advertise on the request's own host (empty host); only the port is carried over.
+            alternative = HttpAltService.Http3(host: null, derivedPort, maxAgeSeconds);
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "Alt-Svc advertisement is enabled but the HTTP/3 listener endpoint does not expose a port; " +
+                $"set {nameof(HttpAltServiceAdvertisementOptions)}.{nameof(HttpAltServiceAdvertisementOptions.Authority)} explicitly.");
+        }
+
+        return alternative.Format();
+    }
+
+    private static bool TryGetPort(EndPoint endPoint, out int port)
+    {
+        switch (endPoint)
+        {
+            case IPEndPoint ipEndPoint:
+                port = ipEndPoint.Port;
+                return true;
+            case DnsEndPoint dnsEndPoint:
+                port = dnsEndPoint.Port;
+                return true;
+            default:
+                port = 0;
+                return false;
+        }
+    }
+
+    private static bool TryParseAuthority(string authority, out string? host, out int port)
+    {
+        host = null;
+        port = 0;
+
+        int colonIndex = authority.LastIndexOf(':');
+        if (colonIndex < 0
+            || !int.TryParse(authority.AsSpan(colonIndex + 1), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out int parsedPort)
+            || parsedPort < 0
+            || parsedPort > 65535)
+        {
+            return false;
+        }
+
+        port = parsedPort;
+        if (colonIndex > 0)
+        {
+            host = authority.Substring(0, colonIndex);
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Accepts the next available HTTP connection from the configured connection listeners.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListenerOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/HttpConnectionListenerOptions.cs
@@ -67,6 +67,37 @@ public sealed class HttpConnectionListenerOptions
     public IList<IHttpExchangeInterceptor> Interceptors { get; } = new List<IHttpExchangeInterceptor>();
 
     /// <summary>
+    /// Gets the HTTP/3 (QUIC) <c>Alt-Svc</c> advertisement configuration for this listener.
+    /// </summary>
+    /// <remarks>
+    /// Advertisement is opt-in and off by default. When it is enabled and the listener serves both
+    /// a stream protocol (HTTP/1.1 or HTTP/2) and an HTTP/3 multiplexed listener, the server injects
+    /// an RFC 7838 <c>Alt-Svc</c> header on HTTP/1.1 and HTTP/2 responses so clients can discover the
+    /// h3 endpoint. See <see cref="HttpAltServiceAdvertisementOptions"/> and
+    /// <see cref="AdvertiseAltService(Action{HttpAltServiceAdvertisementOptions})"/>.
+    /// </remarks>
+    public HttpAltServiceAdvertisementOptions AltServiceAdvertisement { get; } = new HttpAltServiceAdvertisementOptions();
+
+    /// <summary>
+    /// Enables HTTP/3 <c>Alt-Svc</c> advertisement and configures its parameters (max-age, explicit
+    /// authority). Equivalent to setting
+    /// <see cref="HttpAltServiceAdvertisementOptions.Enabled"/> to <see langword="true"/> and
+    /// applying <paramref name="configure"/> to <see cref="AltServiceAdvertisement"/>.
+    /// </summary>
+    /// <param name="configure">Configures the advertisement parameters.</param>
+    /// <returns>The current options instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+    public HttpConnectionListenerOptions AdvertiseAltService(Action<HttpAltServiceAdvertisementOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        AltServiceAdvertisement.Enabled = true;
+        configure(AltServiceAdvertisement);
+
+        return this;
+    }
+
+    /// <summary>
     /// Gets or sets the maximum number of accepted HTTP connections that may be buffered
     /// before producers wait for <see cref="HttpConnectionListener.AcceptOrListenAsync(System.Threading.CancellationToken)"/>
     /// to dequeue them.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1Connection.cs
@@ -12,15 +12,17 @@ internal sealed class Http1Connection : HttpConnection
     private readonly Http1ConnectionListenerOptions.Http1Limits _limits;
     private readonly IHttpExchangeInterceptor[] _interceptors;
     private readonly IHttpExchangeInterceptor[] _responseInterceptors;
+    private readonly string? _altSvcHeaderValue;
     private Http1ConnectionContext? _openContext;
 
-    public Http1Connection(IConnection connection, bool isSecure, Http1ConnectionListenerOptions.Http1Limits limits, IHttpExchangeInterceptor[] interceptors, IHttpExchangeInterceptor[] responseInterceptors)
+    public Http1Connection(IConnection connection, bool isSecure, Http1ConnectionListenerOptions.Http1Limits limits, IHttpExchangeInterceptor[] interceptors, IHttpExchangeInterceptor[] responseInterceptors, string? altSvcHeaderValue)
         : base(isSecure)
     {
         _connection = connection;
         _limits = limits;
         _interceptors = interceptors;
         _responseInterceptors = responseInterceptors;
+        _altSvcHeaderValue = altSvcHeaderValue;
     }
 
     public override ConnectionId Id => _connection.Id;
@@ -38,7 +40,7 @@ internal sealed class Http1Connection : HttpConnection
     {
         // The wrapped connection is already live (connections are produced live by the
         // listener), so opening the HTTP context is a synchronous projection.
-        return _openContext ??= new Http1ConnectionContext(_connection, IsSecure, _limits, _interceptors, _responseInterceptors);
+        return _openContext ??= new Http1ConnectionContext(_connection, IsSecure, _limits, _interceptors, _responseInterceptors, _altSvcHeaderValue);
     }
 
     public override ValueTask<HttpConnectionContext> OpenAsync(CancellationToken cancellationToken = default)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionContext.cs
@@ -18,13 +18,15 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
     private readonly Http1ConnectionListenerOptions.Http1Limits _limits;
     private readonly IHttpExchangeInterceptor[] _interceptors;
     private readonly IHttpExchangeInterceptor[] _responseInterceptors;
+    private readonly string? _altSvcHeaderValue;
 
-    public Http1ConnectionContext(IConnection connection, bool isSecure, Http1ConnectionListenerOptions.Http1Limits limits, IHttpExchangeInterceptor[] interceptors, IHttpExchangeInterceptor[] responseInterceptors)
+    public Http1ConnectionContext(IConnection connection, bool isSecure, Http1ConnectionListenerOptions.Http1Limits limits, IHttpExchangeInterceptor[] interceptors, IHttpExchangeInterceptor[] responseInterceptors, string? altSvcHeaderValue)
         : base(connection, isSecure)
     {
         _limits = limits;
         _interceptors = interceptors;
         _responseInterceptors = responseInterceptors;
+        _altSvcHeaderValue = altSvcHeaderValue;
     }
 
     /// <summary>
@@ -65,7 +67,7 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
             {
                 context.RunResponseInterceptors(
                     _responseInterceptors,
-                    new Http1ResponseBodyStream(Stream, context, _limits.MinResponseDataRate, _timeProvider),
+                    new Http1ResponseBodyStream(Stream, context, _limits.MinResponseDataRate, _timeProvider, _altSvcHeaderValue),
                     new Http1ExchangeControl(context, Stream));
             }
 
@@ -115,8 +117,9 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
         }
 
         // If a response feature streamed to the raw sink, the head and body are already on the
-        // wire (the BeforeResponseHead hooks fired at the sink's head commit); finalize (emit the
-        // terminating zero-length chunk) rather than writing a second, buffered response.
+        // wire (the BeforeResponseHead hooks fired at the sink's head commit, which also injected
+        // the Alt-Svc advertisement); finalize (emit the terminating zero-length chunk) rather
+        // than writing a second, buffered response.
         if (http1Context.ResponseBodySink is { HasStarted: true } sink)
         {
             await sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
@@ -148,6 +151,11 @@ internal sealed class Http1ConnectionContext : HttpStreamConnectionContext
             await http1Context.InvokeAfterResponseAsync(cancellationToken).ConfigureAwait(false);
             return;
         }
+
+        // Advertise the HTTP/3 endpoint on this buffered response unless the application (or a
+        // lifecycle hook — they have all run by now) set its own Alt-Svc (RFC 7838 — the server
+        // never overwrites an application value).
+        HttpAltServiceInjector.Inject(http1Context.Response.Headers, _altSvcHeaderValue);
 
         // Commit point: from here the final response is on the wire, so the exchange control's
         // probes must report the response as started (no more interim writes or takeover).

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionFactory.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ConnectionFactory.cs
@@ -21,5 +21,5 @@ internal sealed class Http1ConnectionFactory : HttpConnectionFactory
     }
 
     public override HttpConnection Create(IConnection connection, bool isSecure)
-        => new Http1Connection(connection, isSecure, _limits, _interceptors, _responseInterceptors);
+        => new Http1Connection(connection, isSecure, _limits, _interceptors, _responseInterceptors, AltSvcHeaderValue);
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1ResponseBodyStream.cs
@@ -30,20 +30,26 @@ internal sealed class Http1ResponseBodyStream : HttpResponseBodyStream
     private readonly Stream _stream;
     private readonly Http1Context _context;
     private readonly MinDataRateGate? _gate;
+    private readonly string? _altSvcHeaderValue;
     private bool _chunked;
     private bool _suppressBody;
 
-    public Http1ResponseBodyStream(Stream stream, Http1Context context, HttpMinDataRate? minResponseDataRate, TimeProvider timeProvider)
+    public Http1ResponseBodyStream(Stream stream, Http1Context context, HttpMinDataRate? minResponseDataRate, TimeProvider timeProvider, string? altSvcHeaderValue)
         : base(context)
     {
         _stream = stream;
         _context = context;
         _gate = minResponseDataRate is not null ? new MinDataRateGate(minResponseDataRate, timeProvider) : null;
+        _altSvcHeaderValue = altSvcHeaderValue;
     }
 
     protected override async ValueTask CommitHeadersAsync(CancellationToken cancellationToken)
     {
         HttpHeaderCollection headers = _context.Response.Headers;
+
+        // Advertise the HTTP/3 endpoint on this streamed response unless the application set its own
+        // Alt-Svc (RFC 7838 — the server never overwrites an application value).
+        HttpAltServiceInjector.Inject(headers, _altSvcHeaderValue);
 
         // RFC 9110 §9.3.2 — a HEAD response carries the same header section a GET would but never a
         // body, so suppress every body write and the terminator.

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Connection.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2Connection.cs
@@ -12,15 +12,17 @@ internal sealed class Http2Connection : HttpConnection
     private readonly Http2ConnectionListenerOptions.Http2Limits _limits;
     private readonly IHttpExchangeInterceptor[] _requestInterceptors;
     private readonly IHttpExchangeInterceptor[] _responseInterceptors;
+    private readonly string? _altSvcHeaderValue;
     private Http2ConnectionContext? _context;
 
-    public Http2Connection(IConnection connection, bool isSecure, Http2ConnectionListenerOptions.Http2Limits limits, IHttpExchangeInterceptor[] requestInterceptors, IHttpExchangeInterceptor[] responseInterceptors)
+    public Http2Connection(IConnection connection, bool isSecure, Http2ConnectionListenerOptions.Http2Limits limits, IHttpExchangeInterceptor[] requestInterceptors, IHttpExchangeInterceptor[] responseInterceptors, string? altSvcHeaderValue)
         : base(isSecure)
     {
         _connection = connection;
         _limits = limits;
         _requestInterceptors = requestInterceptors;
         _responseInterceptors = responseInterceptors;
+        _altSvcHeaderValue = altSvcHeaderValue;
     }
 
     public override ConnectionId Id => _connection.Id;
@@ -38,7 +40,7 @@ internal sealed class Http2Connection : HttpConnection
     {
         // The wrapped connection is already live (connections are produced live by the
         // listener), so opening the HTTP context is a synchronous projection.
-        return _context ??= new Http2ConnectionContext(_connection, IsSecure, _limits, _requestInterceptors, _responseInterceptors);
+        return _context ??= new Http2ConnectionContext(_connection, IsSecure, _limits, _requestInterceptors, _responseInterceptors, _altSvcHeaderValue);
     }
 
     public override ValueTask<HttpConnectionContext> OpenAsync(CancellationToken cancellationToken = default)

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionContext.cs
@@ -124,11 +124,16 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     private readonly Http2ConnectionListenerOptions.Http2Limits _http2Limits;
     private readonly Http2FloodGuard _floodGuard;
 
-    public Http2ConnectionContext(IConnection connection, bool isSecure, Http2ConnectionListenerOptions.Http2Limits limits, IHttpExchangeInterceptor[] requestInterceptors, IHttpExchangeInterceptor[] responseInterceptors)
+    // The precomputed RFC 7838 Alt-Svc value injected on every response head (unless the application
+    // set its own), advertising the listener's HTTP/3 endpoint. Null when advertisement is off.
+    private readonly string? _altSvcHeaderValue;
+
+    public Http2ConnectionContext(IConnection connection, bool isSecure, Http2ConnectionListenerOptions.Http2Limits limits, IHttpExchangeInterceptor[] requestInterceptors, IHttpExchangeInterceptor[] responseInterceptors, string? altSvcHeaderValue)
         : base(connection, isSecure)
     {
         _http2Limits = limits;
         _floodGuard = new Http2FloodGuard(limits);
+        _altSvcHeaderValue = altSvcHeaderValue;
         // RFC 9113 §10.5.1 — the decoder enforces the advertised MAX_HEADER_LIST_SIZE on the
         // decoded field list; the stream's header-block accumulator enforces the raw-byte cap.
         _headerDecoder = new HPackDecoder(maxHeaderListSize: limits.MaxRequestHeaderListSize);
@@ -536,6 +541,11 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
         http2Context.MarkFinalResponseStarted();
 
         byte[] bodyBytes = await ReadBodyAsync(http2Context.Response.Body, cancellationToken).ConfigureAwait(false);
+
+        // Advertise the HTTP/3 endpoint on this buffered response unless the application set its own
+        // Alt-Svc (RFC 7838 — the server never overwrites an application value).
+        HttpAltServiceInjector.Inject(http2Context.Response.Headers, _altSvcHeaderValue);
+
         byte[] headerBlock = HPackEncoder.EncodeResponseHeaders(http2Context.Response.StatusCode, http2Context.Response.Headers, bodyBytes.Length);
 
         // RFC 9113 §4.1 — frames from concurrent senders MUST NOT interleave.
@@ -1727,6 +1737,10 @@ internal sealed class Http2ConnectionContext : HttpStreamConnectionContext, IAsy
     {
         // RFC 9110 §15.2 — the final (streamed) response head must not carry a 1xx status.
         HttpInterimResponseRules.EnsureFinalStatusCode(context.Response.StatusCode);
+
+        // Advertise the HTTP/3 endpoint on this streamed response unless the application set its own
+        // Alt-Svc (RFC 7838 — the server never overwrites an application value).
+        HttpAltServiceInjector.Inject(context.Response.Headers, _altSvcHeaderValue);
 
         byte[] headerBlock = HPackEncoder.EncodeResponseHeaders(context.Response.StatusCode, context.Response.Headers);
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionFactory.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http2/Http2ConnectionFactory.cs
@@ -24,5 +24,5 @@ internal sealed class Http2ConnectionFactory : HttpConnectionFactory
     }
 
     public override HttpConnection Create(IConnection connection, bool isSecure)
-        => new Http2Connection(connection, isSecure, _limits, _requestInterceptors, _responseInterceptors);
+        => new Http2Connection(connection, isSecure, _limits, _requestInterceptors, _responseInterceptors, AltSvcHeaderValue);
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpAltServiceInjector.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpAltServiceInjector.cs
@@ -1,0 +1,28 @@
+namespace Assimalign.Cohesion.Http.Connections.Internal;
+
+/// <summary>
+/// Injects the server's precomputed RFC 7838 <c>Alt-Svc</c> advertisement into a response's headers
+/// at head-commit time, shared by the HTTP/1.1 and HTTP/2 response-head write paths so both advertise
+/// identically.
+/// </summary>
+internal static class HttpAltServiceInjector
+{
+    /// <summary>
+    /// Adds <paramref name="altSvcHeaderValue"/> as the <c>Alt-Svc</c> header when the server has an
+    /// advertisement to make and the application did not already set the header. Applied just before
+    /// the head is serialized, so an application-set value always wins (RFC 7838 — the server never
+    /// overwrites an application's <c>Alt-Svc</c>).
+    /// </summary>
+    /// <param name="headers">The response headers about to be committed.</param>
+    /// <param name="altSvcHeaderValue">
+    /// The precomputed <c>Alt-Svc</c> field value, or <see langword="null"/> when advertisement is
+    /// off (no injection occurs).
+    /// </param>
+    public static void Inject(HttpHeaderCollection headers, string? altSvcHeaderValue)
+    {
+        if (altSvcHeaderValue is not null && !headers.ContainsKey(HttpHeaderKey.AltSvc))
+        {
+            headers[HttpHeaderKey.AltSvc] = altSvcHeaderValue;
+        }
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpConnectionFactory.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/HttpConnectionFactory.cs
@@ -11,6 +11,15 @@ namespace Assimalign.Cohesion.Http.Connections.Internal;
 internal abstract class HttpConnectionFactory
 {
     /// <summary>
+    /// The precomputed RFC 7838 <c>Alt-Svc</c> response-header value this stream protocol injects on
+    /// its responses to advertise the listener's HTTP/3 endpoint, or <see langword="null"/> when
+    /// advertisement is disabled or no HTTP/3 listener is registered. Set once by
+    /// <see cref="HttpConnectionListener"/> after every listener has been materialized (so the h3
+    /// endpoint is known) and before the first connection is accepted; read on the response path.
+    /// </summary>
+    public string? AltSvcHeaderValue { get; set; }
+
+    /// <summary>
     /// Wraps <paramref name="connection"/> in the protocol-specific connection.
     /// </summary>
     /// <param name="connection">The accepted transport connection.</param>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpAltServiceAdvertisementTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpAltServiceAdvertisementTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+public class HttpAltServiceAdvertisementTests
+{
+    // TestMultiplexedConnectionListener binds its endpoint to loopback:16000.
+    private const int Http3Port = 16000;
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should advertise the h3 endpoint on an HTTP/1.1 response")]
+    public async Task Http1_OnAdvertisementEnabledWithHttp3_ShouldEmitAltSvcHeader()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request("GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        options.AdvertiseAltService(advertisement => advertisement.MaxAge = TimeSpan.FromHours(24));
+
+        // Act
+        string responseText = await RunHttp1ExchangeAsync(connection, options);
+
+        // Assert
+        responseText.ShouldContain($"Alt-Svc: h3=\":{Http3Port}\"; ma=86400", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should not advertise when no HTTP/3 listener is registered")]
+    public async Task Http1_OnNoHttp3Listener_ShouldNotEmitAltSvcHeader()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request("GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        options.AdvertiseAltService(_ => { });
+
+        // Act
+        string responseText = await RunHttp1ExchangeAsync(connection, options);
+
+        // Assert
+        responseText.ShouldNotContain("Alt-Svc");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should not advertise when advertisement is disabled")]
+    public async Task Http1_OnAdvertisementDisabled_ShouldNotEmitAltSvcHeader()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request("GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        // Advertisement left disabled (the default).
+
+        // Act
+        string responseText = await RunHttp1ExchangeAsync(connection, options);
+
+        // Assert
+        responseText.ShouldNotContain("Alt-Svc");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should not overwrite an application-set Alt-Svc on HTTP/1.1")]
+    public async Task Http1_OnApplicationSetAltSvc_ShouldNotOverwrite()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request("GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        options.AdvertiseAltService(_ => { });
+
+        // Act
+        string responseText = await RunHttp1ExchangeAsync(
+            connection,
+            options,
+            httpContext => httpContext.Response.Headers[HttpHeaderKey.AltSvc] = "h3=\":9999\"; ma=1");
+
+        // Assert — the application value is emitted and the server default (:16000) is not.
+        responseText.ShouldContain("Alt-Svc: h3=\":9999\"; ma=1", Case.Sensitive);
+        responseText.ShouldNotContain($":{Http3Port}");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should use an explicitly configured authority on HTTP/1.1")]
+    public async Task Http1_OnExplicitAuthority_ShouldEmitConfiguredAuthority()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request("GET / HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        options.AdvertiseAltService(advertisement =>
+        {
+            advertisement.Authority = "alt.example.com:8443";
+            advertisement.MaxAge = TimeSpan.FromHours(1);
+        });
+
+        // Act
+        string responseText = await RunHttp1ExchangeAsync(connection, options);
+
+        // Assert
+        responseText.ShouldContain("Alt-Svc: h3=\"alt.example.com:8443\"; ma=3600", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should advertise the h3 endpoint on an HTTP/2 response")]
+    public async Task Http2_OnAdvertisementEnabledWithHttp3_ShouldEmitAltSvcHeader()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        options.AdvertiseAltService(advertisement => advertisement.MaxAge = TimeSpan.FromHours(24));
+
+        // Act
+        Dictionary<string, string> headers = await RunHttp2ExchangeAsync(connection, options);
+
+        // Assert
+        headers.ShouldContainKey("alt-svc");
+        headers["alt-svc"].ShouldBe($"h3=\":{Http3Port}\"; ma=86400");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should not advertise on HTTP/2 when no HTTP/3 listener is registered")]
+    public async Task Http2_OnNoHttp3Listener_ShouldNotEmitAltSvcHeader()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+        options.AdvertiseAltService(_ => { });
+
+        // Act
+        Dictionary<string, string> headers = await RunHttp2ExchangeAsync(connection, options);
+
+        // Assert
+        headers.ShouldNotContainKey("alt-svc");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - AltSvc: Should not overwrite an application-set Alt-Svc on HTTP/2")]
+    public async Task Http2_OnApplicationSetAltSvc_ShouldNotOverwrite()
+    {
+        // Arrange
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", "/", "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+        options.UseHttp3(new TestMultiplexedConnectionListener());
+        options.AdvertiseAltService(_ => { });
+
+        // Act
+        Dictionary<string, string> headers = await RunHttp2ExchangeAsync(
+            connection,
+            options,
+            httpContext => httpContext.Response.Headers[HttpHeaderKey.AltSvc] = "h3=\":9999\"; ma=1");
+
+        // Assert
+        headers.ShouldContainKey("alt-svc");
+        headers["alt-svc"].ShouldBe("h3=\":9999\"; ma=1");
+    }
+
+    private static async Task<string> RunHttp1ExchangeAsync(
+        TestConnection connection,
+        HttpConnectionListenerOptions options,
+        Action<IHttpContext>? configureResponse = null)
+    {
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        httpContext.Response.StatusCode = HttpStatusCode.Ok;
+        configureResponse?.Invoke(httpContext);
+        await httpConnectionContext.SendAsync(httpContext);
+
+        return Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+    }
+
+    private static async Task<Dictionary<string, string>> RunHttp2ExchangeAsync(
+        TestConnection connection,
+        HttpConnectionListenerOptions options,
+        Action<IHttpContext>? configureResponse = null)
+    {
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(httpConnectionContext);
+
+        httpContext.Response.StatusCode = HttpStatusCode.Ok;
+        configureResponse?.Invoke(httpContext);
+        await httpConnectionContext.SendAsync(httpContext);
+
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames = HttpProtocolPayloadFactory.ParseHttp2Frames(await connection.ReadOutputAsync());
+
+        foreach ((long FrameType, byte[] Payload) frame in frames)
+        {
+            if (frame.FrameType == 1) // HEADERS
+            {
+                return HttpProtocolPayloadFactory.DecodeLiteralHttp2Headers(frame.Payload);
+            }
+        }
+
+        throw new InvalidOperationException("The HTTP/2 response did not contain a HEADERS frame.");
+    }
+
+    private static async Task<IHttpContext> ReadSingleContextAsync(IHttpConnectionContext context)
+    {
+        await using IAsyncEnumerator<IHttpContext> enumerator = context.ReceiveAsync().GetAsyncEnumerator();
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        return enumerator.Current;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -421,6 +421,45 @@ No reflection or dynamic serialization; parsing is span-based via the structured
 the ASCII→`char` bridge on the transport side is stack-allocated for the small field values that
 occur in practice. Builds clean under the trim/AOT analyzers (`IsAotCompatible=true`).
 
+## Alternative services (RFC 7838 `Alt-Svc`)
+
+### The value object
+
+`HttpAltService` is a `readonly struct` modeling one RFC 7838 §3 *alt-value*: an ALPN
+`ProtocolId` bound to an alt-authority (`Host` — optional, `null` meaning "the request's own
+host" — plus a required `Port`), with the caching parameters `MaxAgeSeconds` (`ma`) and `Persist`
+(`persist=1`). It carries `Format`/`ToString` for the single alt-value, static
+`FormatHeader`/`TryParseHeader` for the comma-separated list form and the special case-sensitive
+`clear` token, and value equality — the same shape as the other core value objects
+(`HttpMediaType`, `HttpPriority`, `HttpEntityTag`). The alt-authority is serialized as a
+quoted-string (`h3=":443"`, `h2="alt.example.com:8000"`) so a host that contains a colon (an IPv6
+literal) round-trips; the parser splits the authority at its last colon to keep the port.
+
+### Why it lives in the protocol core, and who emits it
+
+The type is pure parsing/representation with no transport dependency, so it sits in Lane B beside
+the other field value objects. It is the discovery primitive for HTTP/3 (RFC 9114 §3.1): a server
+that speaks h3 over QUIC alongside h1/h2 over TCP advertises the h3 endpoint by emitting an
+`Alt-Svc` response header, and a TCP client learns the alternative from it. **Emission is the
+transport's job**, not the core's — `Assimalign.Cohesion.Http.Connections` is the only component
+that knows whether an h3 multiplexed listener is registered alongside the stream listeners, so it
+owns the advertisement policy (opt-in, `ma`, explicit-authority override) and the header injection.
+This core type only formats and parses the value; see the Http.Connections `DESIGN.md` for the
+advertisement design. `ma`/`persist` are modeled as data for a future client-side alternative
+cache; honoring a received `Alt-Svc` is a client concern this library does not implement.
+
+### Tolerant parsing, strict port
+
+Parsing skips OWS, ignores unrecognized parameters (RFC 7838 §3), and treats an empty alt-authority
+host as same-host, but rejects a missing or non-numeric port and an unquoted alt-authority — a
+malformed alt-value fails its `TryParse` rather than being silently coerced. `clear` is matched
+case-sensitively per the RFC.
+
+### AOT posture
+
+No reflection or dynamic serialization; the format path uses a small `StringBuilder` and the parse
+path is span-based. Builds clean under the trim/AOT analyzers (`IsAotCompatible=true`).
+
 ## The exchange interceptor seam
 
 ### One seam, one interface, one registration

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpAltService.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpAltService.cs
@@ -1,0 +1,598 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// A single RFC 7838 §3 <c>Alt-Svc</c> alternative service (<em>alt-value</em>): an
+/// ALPN <see cref="ProtocolId"/> bound to an <em>alt-authority</em>
+/// (<see cref="Host"/> plus <see cref="Port"/>), with the optional caching parameters
+/// <see cref="MaxAgeSeconds"/> (<c>ma</c>) and <see cref="Persist"/> (<c>persist</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the typed projection of one member of the <c>Alt-Svc</c> response header field
+/// (<see cref="HttpHeaderKey.AltSvc"/>). The header advertises alternative endpoints — most
+/// commonly the HTTP/3 (QUIC) listener — so a client that started on HTTP/1.1 or HTTP/2 can
+/// discover them (RFC 9114 §3.1). The value object formats and parses a single alt-value;
+/// <see cref="FormatHeader(IReadOnlyList{HttpAltService})"/> and
+/// <see cref="TryParseHeader(ReadOnlySpan{char}, out IReadOnlyList{HttpAltService}, out bool)"/>
+/// handle the comma-separated list form and the special <c>clear</c> token.
+/// </para>
+/// <para>
+/// The alt-authority is serialized as a quoted-string of the form <c>[uri-host] ":" port</c>
+/// (RFC 7838 §3): the host is omitted (empty) to advertise an alternative on the request's own
+/// host, and supplied to point at a different host. Parsing is tolerant of the optional host and
+/// of unrecognized parameters (which are ignored), but a missing or non-numeric port is rejected.
+/// </para>
+/// <para>
+/// The type is span-based and allocation-light on the format path, carries no reflection, and is
+/// therefore AOT-safe.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{ToString(),nq}")]
+public readonly struct HttpAltService : IEquatable<HttpAltService>
+{
+    /// <summary>
+    /// The case-sensitive <c>clear</c> token (RFC 7838 §3) that, when it is the entire
+    /// <c>Alt-Svc</c> field value, tells a client to invalidate every cached alternative service
+    /// for the origin.
+    /// </summary>
+    public const string ClearToken = "clear";
+
+    /// <summary>The ALPN protocol identifier of the HTTP/3 alternative (<c>h3</c>).</summary>
+    public const string Http3ProtocolId = "h3";
+
+    private const string MaxAgeParameter = "ma";
+    private const string PersistParameter = "persist";
+
+    /// <summary>
+    /// Initializes a new alternative service.
+    /// </summary>
+    /// <param name="protocolId">The ALPN protocol identifier (an RFC 7230 token, for example <c>h3</c>).</param>
+    /// <param name="host">
+    /// The alt-authority host, or <see langword="null"/>/empty to advertise the alternative on the
+    /// request's own host.
+    /// </param>
+    /// <param name="port">The alt-authority port, in the range 0..65535.</param>
+    /// <param name="maxAgeSeconds">
+    /// The freshness lifetime in seconds (the <c>ma</c> parameter), or <see langword="null"/> to
+    /// omit it (RFC 7838 §3.1 default of 24 hours applies at the client).
+    /// </param>
+    /// <param name="persist">
+    /// Whether the alternative should persist across network changes (the <c>persist=1</c>
+    /// parameter, RFC 7838 §3.1).
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="protocolId"/> is empty or contains a non-token character.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="port"/> is outside 0..65535, or <paramref name="maxAgeSeconds"/>
+    /// is negative.
+    /// </exception>
+    public HttpAltService(string protocolId, string? host, int port, long? maxAgeSeconds = null, bool persist = false)
+    {
+        if (string.IsNullOrEmpty(protocolId) || !IsToken(protocolId))
+        {
+            throw new ArgumentException("The protocol identifier must be a non-empty RFC 7230 token.", nameof(protocolId));
+        }
+
+        if (port < 0 || port > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(port), port, "The port must be within 0..65535.");
+        }
+
+        if (maxAgeSeconds is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxAgeSeconds), maxAgeSeconds, "The max-age must be non-negative.");
+        }
+
+        ProtocolId = protocolId;
+        Host = string.IsNullOrEmpty(host) ? null : host;
+        Port = port;
+        MaxAgeSeconds = maxAgeSeconds;
+        Persist = persist;
+    }
+
+    /// <summary>Gets the ALPN protocol identifier of the alternative (for example <c>h3</c>).</summary>
+    public string ProtocolId { get; }
+
+    /// <summary>
+    /// Gets the alt-authority host, or <see langword="null"/> when the alternative is advertised on
+    /// the request's own host.
+    /// </summary>
+    public string? Host { get; }
+
+    /// <summary>Gets the alt-authority port.</summary>
+    public int Port { get; }
+
+    /// <summary>
+    /// Gets the freshness lifetime in seconds (the <c>ma</c> parameter), or <see langword="null"/>
+    /// when it is absent.
+    /// </summary>
+    public long? MaxAgeSeconds { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the alternative persists across network changes (the
+    /// <c>persist=1</c> parameter).
+    /// </summary>
+    public bool Persist { get; }
+
+    /// <summary>
+    /// Creates an HTTP/3 (<c>h3</c>) alternative service.
+    /// </summary>
+    /// <param name="host">
+    /// The alt-authority host, or <see langword="null"/>/empty to advertise HTTP/3 on the request's
+    /// own host (the common case).
+    /// </param>
+    /// <param name="port">The UDP port the QUIC listener is bound to.</param>
+    /// <param name="maxAgeSeconds">The freshness lifetime in seconds, or <see langword="null"/> to omit <c>ma</c>.</param>
+    /// <param name="persist">Whether to emit <c>persist=1</c>.</param>
+    /// <returns>The HTTP/3 alternative service.</returns>
+    public static HttpAltService Http3(string? host, int port, long? maxAgeSeconds = null, bool persist = false)
+        => new(Http3ProtocolId, host, port, maxAgeSeconds, persist);
+
+    /// <summary>
+    /// Serializes this alternative to its RFC 7838 §3 alt-value form, for example
+    /// <c>h3=":443"; ma=86400</c>.
+    /// </summary>
+    /// <returns>The canonical alt-value text.</returns>
+    public string Format()
+    {
+        StringBuilder builder = new();
+        builder.Append(ProtocolId);
+        builder.Append("=\"");
+        AppendAltAuthority(builder);
+        builder.Append('"');
+
+        if (MaxAgeSeconds is long maxAge)
+        {
+            builder.Append("; ").Append(MaxAgeParameter).Append('=').Append(maxAge.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (Persist)
+        {
+            builder.Append("; ").Append(PersistParameter).Append("=1");
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Serializes a list of alternatives to a single RFC 7838 §3 <c>Alt-Svc</c> field value,
+    /// joining the alt-values with <c>", "</c>.
+    /// </summary>
+    /// <param name="services">The alternatives to serialize.</param>
+    /// <returns>
+    /// The comma-separated field value, or the empty string when <paramref name="services"/> is
+    /// empty (an empty <c>Alt-Svc</c> value is not emitted).
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    public static string FormatHeader(IReadOnlyList<HttpAltService> services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (services.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder builder = new();
+        for (int i = 0; i < services.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            builder.Append(services[i].Format());
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Parses a single RFC 7838 §3 alt-value (for example <c>h3=":443"; ma=86400</c>).
+    /// </summary>
+    /// <param name="input">The alt-value text.</param>
+    /// <param name="result">
+    /// When this method returns <see langword="true"/>, the parsed alternative service.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="input"/> is a well-formed alt-value with a valid
+    /// alt-authority port; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out HttpAltService result)
+    {
+        result = default;
+
+        ReadOnlySpan<char> remaining = TrimOptionalWhitespace(input);
+        if (remaining.IsEmpty)
+        {
+            return false;
+        }
+
+        // protocol-id "=" alt-authority
+        int equalsIndex = remaining.IndexOf('=');
+        if (equalsIndex <= 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> protocolId = TrimOptionalWhitespace(remaining.Slice(0, equalsIndex));
+        if (protocolId.IsEmpty || !IsToken(protocolId))
+        {
+            return false;
+        }
+
+        remaining = TrimOptionalWhitespace(remaining.Slice(equalsIndex + 1));
+
+        // alt-authority is a quoted-string.
+        if (!TryReadQuotedString(ref remaining, out string altAuthority))
+        {
+            return false;
+        }
+
+        if (!TryParseAltAuthority(altAuthority, out string? host, out int port))
+        {
+            return false;
+        }
+
+        long? maxAge = null;
+        bool persist = false;
+
+        // *( OWS ";" OWS parameter )
+        remaining = TrimOptionalWhitespace(remaining);
+        while (!remaining.IsEmpty)
+        {
+            if (remaining[0] != ';')
+            {
+                return false;
+            }
+
+            remaining = TrimOptionalWhitespace(remaining.Slice(1));
+
+            if (!TryReadParameter(ref remaining, out ReadOnlySpan<char> name, out string value))
+            {
+                return false;
+            }
+
+            if (name.Equals(MaxAgeParameter, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out long parsedMaxAge))
+                {
+                    return false;
+                }
+
+                maxAge = parsedMaxAge;
+            }
+            else if (name.Equals(PersistParameter, StringComparison.OrdinalIgnoreCase))
+            {
+                // RFC 7838 §3.1 — persist=1 is the only defined value; any other value clears it.
+                persist = value == "1";
+            }
+
+            // Unrecognized parameters are ignored (RFC 7838 §3).
+            remaining = TrimOptionalWhitespace(remaining);
+        }
+
+        result = new HttpAltService(protocolId.ToString(), host, port, maxAge, persist);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a complete RFC 7838 §3 <c>Alt-Svc</c> field value: either the case-sensitive
+    /// <c>clear</c> token, or a comma-separated list of alt-values.
+    /// </summary>
+    /// <param name="value">The field value to parse.</param>
+    /// <param name="services">
+    /// When this method returns <see langword="true"/>, the parsed alternatives (empty when
+    /// <paramref name="isClear"/> is <see langword="true"/>).
+    /// </param>
+    /// <param name="isClear">
+    /// When this method returns <see langword="true"/>, whether the value was the <c>clear</c> token.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the value is <c>clear</c> or contains at least one well-formed
+    /// alt-value; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryParseHeader(ReadOnlySpan<char> value, out IReadOnlyList<HttpAltService> services, out bool isClear)
+    {
+        services = Array.Empty<HttpAltService>();
+        isClear = false;
+
+        ReadOnlySpan<char> trimmed = TrimOptionalWhitespace(value);
+        if (trimmed.IsEmpty)
+        {
+            return false;
+        }
+
+        // RFC 7838 §3 — "clear" is case-sensitive and is the entire field value.
+        if (trimmed.Equals(ClearToken, StringComparison.Ordinal))
+        {
+            isClear = true;
+            return true;
+        }
+
+        List<HttpAltService> parsed = new();
+        foreach (Range segment in SplitTopLevelCommas(trimmed))
+        {
+            ReadOnlySpan<char> element = TrimOptionalWhitespace(trimmed[segment]);
+            if (element.IsEmpty)
+            {
+                continue;
+            }
+
+            if (!TryParse(element, out HttpAltService service))
+            {
+                return false;
+            }
+
+            parsed.Add(service);
+        }
+
+        if (parsed.Count == 0)
+        {
+            return false;
+        }
+
+        services = parsed;
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(HttpAltService other)
+        => string.Equals(ProtocolId, other.ProtocolId, StringComparison.Ordinal)
+        && string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase)
+        && Port == other.Port
+        && MaxAgeSeconds == other.MaxAgeSeconds
+        && Persist == other.Persist;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HttpAltService other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(
+            ProtocolId,
+            Host is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(Host),
+            Port,
+            MaxAgeSeconds,
+            Persist);
+
+    /// <inheritdoc />
+    public override string ToString() => Format();
+
+    /// <summary>Determines whether two alternatives are equal.</summary>
+    /// <param name="left">The first alternative.</param>
+    /// <param name="right">The second alternative.</param>
+    /// <returns><see langword="true"/> if the alternatives are equal; otherwise <see langword="false"/>.</returns>
+    public static bool operator ==(HttpAltService left, HttpAltService right) => left.Equals(right);
+
+    /// <summary>Determines whether two alternatives are unequal.</summary>
+    /// <param name="left">The first alternative.</param>
+    /// <param name="right">The second alternative.</param>
+    /// <returns><see langword="true"/> if the alternatives are unequal; otherwise <see langword="false"/>.</returns>
+    public static bool operator !=(HttpAltService left, HttpAltService right) => !left.Equals(right);
+
+    private void AppendAltAuthority(StringBuilder builder)
+    {
+        if (Host is not null)
+        {
+            // Defensively escape the quoted-string metacharacters, though a uri-host never
+            // legitimately contains them (RFC 7838 §3 / RFC 7230 §3.2.6).
+            foreach (char c in Host)
+            {
+                if (c is '"' or '\\')
+                {
+                    builder.Append('\\');
+                }
+
+                builder.Append(c);
+            }
+        }
+
+        builder.Append(':');
+        builder.Append(Port.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static bool TryParseAltAuthority(string altAuthority, out string? host, out int port)
+    {
+        host = null;
+        port = 0;
+
+        // alt-authority = [ uri-host ] ":" port. Split at the LAST colon so an IPv6 literal
+        // host (e.g. "[::1]") keeps its own colons.
+        int colonIndex = altAuthority.LastIndexOf(':');
+        if (colonIndex < 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> portSpan = altAuthority.AsSpan(colonIndex + 1);
+        if (portSpan.IsEmpty
+            || !int.TryParse(portSpan, NumberStyles.None, CultureInfo.InvariantCulture, out int parsedPort)
+            || parsedPort < 0
+            || parsedPort > 65535)
+        {
+            return false;
+        }
+
+        port = parsedPort;
+        if (colonIndex > 0)
+        {
+            host = altAuthority.Substring(0, colonIndex);
+        }
+
+        return true;
+    }
+
+    private static bool TryReadQuotedString(ref ReadOnlySpan<char> input, out string value)
+    {
+        value = string.Empty;
+
+        if (input.IsEmpty || input[0] != '"')
+        {
+            return false;
+        }
+
+        StringBuilder builder = new();
+        int index = 1;
+        while (index < input.Length)
+        {
+            char c = input[index];
+            if (c == '\\')
+            {
+                // quoted-pair: the backslash escapes the next character.
+                if (index + 1 >= input.Length)
+                {
+                    return false;
+                }
+
+                builder.Append(input[index + 1]);
+                index += 2;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                value = builder.ToString();
+                input = input.Slice(index + 1);
+                return true;
+            }
+
+            builder.Append(c);
+            index++;
+        }
+
+        // Unterminated quoted-string.
+        return false;
+    }
+
+    private static bool TryReadParameter(ref ReadOnlySpan<char> input, out ReadOnlySpan<char> name, out string value)
+    {
+        name = default;
+        value = string.Empty;
+
+        int nameLength = 0;
+        while (nameLength < input.Length && IsTokenChar(input[nameLength]))
+        {
+            nameLength++;
+        }
+
+        if (nameLength == 0)
+        {
+            return false;
+        }
+
+        name = input.Slice(0, nameLength);
+        ReadOnlySpan<char> afterName = TrimOptionalWhitespace(input.Slice(nameLength));
+        if (afterName.IsEmpty || afterName[0] != '=')
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> afterEquals = TrimOptionalWhitespace(afterName.Slice(1));
+        if (afterEquals.IsEmpty)
+        {
+            return false;
+        }
+
+        if (afterEquals[0] == '"')
+        {
+            if (!TryReadQuotedString(ref afterEquals, out value))
+            {
+                return false;
+            }
+
+            input = afterEquals;
+            return true;
+        }
+
+        int valueLength = 0;
+        while (valueLength < afterEquals.Length && IsTokenChar(afterEquals[valueLength]))
+        {
+            valueLength++;
+        }
+
+        if (valueLength == 0)
+        {
+            return false;
+        }
+
+        value = afterEquals.Slice(0, valueLength).ToString();
+        input = afterEquals.Slice(valueLength);
+        return true;
+    }
+
+    private static IEnumerable<Range> SplitTopLevelCommas(ReadOnlySpan<char> input)
+    {
+        // Commas inside a quoted-string are part of the alt-authority, not list separators, so the
+        // split must skip over quoted regions. Materialized up front because a span cannot be
+        // captured by the iterator.
+        List<Range> ranges = new();
+        int start = 0;
+        bool inQuotes = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char c = input[i];
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == '\\' && inQuotes)
+            {
+                // Skip the escaped character.
+                i++;
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                ranges.Add(new Range(start, i));
+                start = i + 1;
+            }
+        }
+
+        ranges.Add(new Range(start, input.Length));
+        return ranges;
+    }
+
+    private static ReadOnlySpan<char> TrimOptionalWhitespace(ReadOnlySpan<char> input)
+    {
+        // RFC 7230 OWS = *( SP / HTAB ).
+        int start = 0;
+        while (start < input.Length && (input[start] == ' ' || input[start] == '\t'))
+        {
+            start++;
+        }
+
+        int end = input.Length;
+        while (end > start && (input[end - 1] == ' ' || input[end - 1] == '\t'))
+        {
+            end--;
+        }
+
+        return input.Slice(start, end - start);
+    }
+
+    private static bool IsToken(ReadOnlySpan<char> value)
+    {
+        foreach (char c in value)
+        {
+            if (!IsTokenChar(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsTokenChar(char c)
+        => c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')
+            or '!' or '#' or '$' or '%' or '&' or '\'' or '*'
+            or '+' or '-' or '.' or '^' or '_' or '`' or '|' or '~';
+}

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/HttpAltServiceTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/HttpAltServiceTests.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Tests;
+
+public class HttpAltServiceTests
+{
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should format an h3 alt-value with same-host authority and ma")]
+    public void Format_OnHttp3WithMaxAge_ShouldEmitSameHostAltValue()
+    {
+        // Arrange
+        HttpAltService service = HttpAltService.Http3(host: null, port: 443, maxAgeSeconds: 86400);
+
+        // Act
+        string formatted = service.Format();
+
+        // Assert
+        formatted.ShouldBe("h3=\":443\"; ma=86400");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should format an explicit host, port, ma and persist")]
+    public void Format_OnExplicitHostWithPersist_ShouldEmitFullAltValue()
+    {
+        // Arrange
+        HttpAltService service = new("h3", "alt.example.com", 8443, maxAgeSeconds: 3600, persist: true);
+
+        // Act
+        string formatted = service.Format();
+
+        // Assert
+        formatted.ShouldBe("h3=\"alt.example.com:8443\"; ma=3600; persist=1");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should omit ma when max-age is absent")]
+    public void Format_OnNoMaxAge_ShouldOmitMaParameter()
+    {
+        // Arrange
+        HttpAltService service = HttpAltService.Http3(host: null, port: 443);
+
+        // Act
+        string formatted = service.Format();
+
+        // Assert
+        formatted.ShouldBe("h3=\":443\"");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - HttpAltService: Should round-trip a single alt-value")]
+    [InlineData("h3=\":443\"; ma=86400")]
+    [InlineData("h3=\":443\"")]
+    [InlineData("h2=\"alt.example.com:8000\"; ma=3600; persist=1")]
+    [InlineData("h3=\"[::1]:8443\"; ma=60")]
+    public void TryParse_Then_Format_ShouldRoundTrip(string altValue)
+    {
+        // Act
+        bool parsed = HttpAltService.TryParse(altValue, out HttpAltService service);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        service.Format().ShouldBe(altValue);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should parse the alt-authority host, port, ma and persist")]
+    public void TryParse_OnFullAltValue_ShouldExposeTypedMembers()
+    {
+        // Act
+        bool parsed = HttpAltService.TryParse("h3=\"alt.example.com:8443\"; ma=3600; persist=1", out HttpAltService service);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        service.ProtocolId.ShouldBe("h3");
+        service.Host.ShouldBe("alt.example.com");
+        service.Port.ShouldBe(8443);
+        service.MaxAgeSeconds.ShouldBe(3600);
+        service.Persist.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should treat an empty alt-authority host as same-host")]
+    public void TryParse_OnEmptyHost_ShouldYieldNullHost()
+    {
+        // Act
+        bool parsed = HttpAltService.TryParse("h3=\":443\"", out HttpAltService service);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        service.Host.ShouldBeNull();
+        service.Port.ShouldBe(443);
+        service.MaxAgeSeconds.ShouldBeNull();
+        service.Persist.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should ignore unrecognized parameters")]
+    public void TryParse_OnUnknownParameter_ShouldIgnoreIt()
+    {
+        // Act
+        bool parsed = HttpAltService.TryParse("h3=\":443\"; ma=60; foo=bar", out HttpAltService service);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        service.Port.ShouldBe(443);
+        service.MaxAgeSeconds.ShouldBe(60);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http] - HttpAltService: Should reject malformed alt-values")]
+    [InlineData("")]
+    [InlineData("h3")]                    // no '=' and no authority
+    [InlineData("h3=:443")]               // alt-authority not quoted
+    [InlineData("h3=\"443\"")]            // missing ':' — no port
+    [InlineData("h3=\":\"")]              // empty port
+    [InlineData("h3=\":notaport\"")]      // non-numeric port
+    [InlineData("=\":443\"")]             // empty protocol-id
+    [InlineData("h3=\":443\" ma=60")]     // missing ';' before parameter
+    public void TryParse_OnMalformedInput_ShouldReturnFalse(string altValue)
+    {
+        // Act
+        bool parsed = HttpAltService.TryParse(altValue, out _);
+
+        // Assert
+        parsed.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should parse the case-sensitive clear token")]
+    public void TryParseHeader_OnClear_ShouldSignalClear()
+    {
+        // Act
+        bool parsed = HttpAltService.TryParseHeader("clear", out IReadOnlyList<HttpAltService> services, out bool isClear);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        isClear.ShouldBeTrue();
+        services.ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should not treat a differently-cased Clear as the clear token")]
+    public void TryParseHeader_OnMixedCaseClear_ShouldNotSignalClear()
+    {
+        // RFC 7838 §3 — "clear" is case-sensitive.
+        // Act
+        bool parsed = HttpAltService.TryParseHeader("Clear", out _, out bool isClear);
+
+        // Assert
+        parsed.ShouldBeFalse();
+        isClear.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should parse and round-trip a multi-value header")]
+    public void TryParseHeader_OnMultipleAltValues_ShouldRoundTrip()
+    {
+        // Arrange
+        const string header = "h3=\":443\"; ma=3600, h2=\"alt.example.com:8000\"";
+
+        // Act
+        bool parsed = HttpAltService.TryParseHeader(header, out IReadOnlyList<HttpAltService> services, out bool isClear);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        isClear.ShouldBeFalse();
+        services.Count.ShouldBe(2);
+        services[0].ProtocolId.ShouldBe("h3");
+        services[0].Port.ShouldBe(443);
+        services[1].ProtocolId.ShouldBe("h2");
+        services[1].Host.ShouldBe("alt.example.com");
+        services[1].Port.ShouldBe(8000);
+
+        HttpAltService.FormatHeader(services).ShouldBe(header);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should not split on a comma inside the quoted alt-authority")]
+    public void TryParseHeader_OnCommaInsideQuotes_ShouldNotSplit()
+    {
+        // A comma inside the quoted alt-authority is part of the value, not a list separator.
+        // Act
+        bool parsed = HttpAltService.TryParseHeader("h3=\"weird,host:443\"", out IReadOnlyList<HttpAltService> services, out _);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        services.Count.ShouldBe(1);
+        services[0].Host.ShouldBe("weird,host");
+        services[0].Port.ShouldBe(443);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should format an empty list as the empty string")]
+    public void FormatHeader_OnEmptyList_ShouldBeEmpty()
+    {
+        // Act
+        string formatted = HttpAltService.FormatHeader(System.Array.Empty<HttpAltService>());
+
+        // Assert
+        formatted.ShouldBe(string.Empty);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpAltService: Should compare alternatives by value")]
+    public void Equals_OnSameMembers_ShouldBeEqual()
+    {
+        // Arrange
+        HttpAltService left = HttpAltService.Http3(host: null, port: 443, maxAgeSeconds: 60);
+        HttpAltService right = HttpAltService.Http3(host: null, port: 443, maxAgeSeconds: 60);
+
+        // Assert
+        left.ShouldBe(right);
+        (left == right).ShouldBeTrue();
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+    }
+}


### PR DESCRIPTION
## Summary

Nothing in the repo modeled or emitted `Alt-Svc`, so a client that started on HTTP/1.1 or HTTP/2 could never discover the HTTP/3 endpoint — h3 only worked for clients configured out-of-band. This adds RFC 7838 alternative-service support: a typed value helper plus server-side emission advertising the QUIC listener from h1/h2 responses.

Implements **#754** (`L01.01.11.27`, Stage 2 / Lane A of the HTTP/Web program).

> **Rebased 2026-07-09** onto main after #872 (h1 streaming request body), #873 (exchange-interceptor seam + 1xx interim), and #867 (QPACK) merged. Injection now sits after the new `BeforeResponseHead` lifecycle hooks and the abort/takeover directive re-checks on every commit path, and the design rationale was re-argued against the new seam (below).

## What changed

**Typed value helper — core `Assimalign.Cohesion.Http` (Lane B)**
- New `HttpAltService` (`readonly struct`): one RFC 7838 §3 *alt-value* — ALPN `ProtocolId`, quoted alt-authority (`Host` optional + required `Port`), `ma` (`MaxAgeSeconds`), `persist`. Ships `Format`/`ToString`, static `FormatHeader`/`TryParseHeader` for the comma-separated list form and the case-sensitive `clear` token, and value equality.
- Span-based, AOT-safe; tolerant parse (skips OWS, ignores unknown params, empty host = same-host) but rejects a missing/non-numeric port or an unquoted alt-authority.
- `HttpHeaderKey.AltSvc` **already existed** (emits `Alt-Svc`), so no header-key change was needed.

**Emission — `Assimalign.Cohesion.Http.Connections` (Lane A)**
- `HttpAltServiceAdvertisementOptions` (opt-in `Enabled`, `MaxAge` → `ma` default 24h, explicit `Authority`) on `HttpConnectionListenerOptions`, plus an `AdvertiseAltService(...)` fluent helper. Parameters beyond `ma` (e.g. `persist=1`) are deliberately **not** server knobs — an app that needs them sets the header itself via `HttpAltService`, and the server's injection yields to it.
- `HttpConnectionListener` computes the header value **once at construction** — after every listener is materialized, so the h3 endpoint is known — only when advertisement is enabled **and** an h3 multiplexed listener **and** a stream listener are both present. The h3 port is derived as `:"<port>"` from the multiplexed listener's `EndPoint` (advertising on the request's own host) unless `Authority` overrides it. Enabled-but-underivable fails loud.
- The value is pushed onto the stream connection factories and injected at each transport's **response head-commit** (h1 buffered + streaming sink, h2 buffered + streaming head) via a shared `HttpAltServiceInjector`, guarded on **absence** so an application-set `Alt-Svc` is never overwritten. h3 responses and interim (1xx) responses are never decorated.

## Design decisions
- **Head-commit injection, not an exchange interceptor.** The seam-v3 `IHttpExchangeInterceptor.BeforeResponseHeadAsync` hook does fire at exactly this commit point, but riding it was rejected: (1) a server-registered interceptor is listener-wide and would run on h3 exchanges too, turning a constant header add into a per-exchange version check; (2) the interceptor list's zero-registration fast path is scope-exact — an internal interceptor would force every exchange onto the response-sink slow path whenever advertisement is on. Direct injection is one `ContainsKey` + assignment after the app handler *and* all `BeforeResponseHead` hooks have run, so any app- or hook-set value always wins. This is the first server-injected response header in the package; the guard-on-absence pattern is the seam a future auto-header reuses.
- **h2 `ALTSVC` frame (0x0a) de-scoped** to a documented non-goal — the `Alt-Svc` response header is valid on h2 and is what mainstream servers (e.g. Kestrel) emit for discovery.

## Tests
- `HttpAltServiceTests` (core) — 24 cases: format, single/multi-value round-trip, host/IPv6/ma/persist, unknown-parameter tolerance, malformed rejection, case-sensitive `clear`, comma-inside-quotes, equality.
- `HttpAltServiceAdvertisementTests` (transport) — 8 in-memory cases over h1 and h2: header presence + exact format, absence when no h3 listener, absence when disabled, application-set value not overwritten, explicit authority.
- Full suites green post-rebase: Http **1141**, Http.Connections **413**, Streaming **8**, ProtocolUpgrade **14**.

## Docs
- `Assimalign.Cohesion.Http.Connections/docs/DESIGN.md`: new "Alt-Svc advertisement (RFC 7838)" section (design, injection rationale vs the exchange-interceptor seam, non-goals incl. the h2 ALTSVC frame).
- `Assimalign.Cohesion.Http/docs/DESIGN.md`: `HttpAltService` value-object section.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)
