### PR TITLE
[L03.01.02.01.04] Add builder-time route groups (MapGroup equivalent) (#786)

### DIFF
--- a/resources/Web/Assimalign.Cohesion.Web.Routing/README.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/README.md
@@ -19,6 +19,10 @@ controllers, metadata, results).
   `decimal`, `double`, `float`, `bool`, `guid`, `datetime`), **convert** the value to its CLR type —
   parsed once, invariant culture — plus text/value validators (`length`, `minlength`, `maxlength`,
   `min`, `max`, `range`, `regex`, `alpha`, `when`).
+- Composes **route groups** (`MapGroup`) at builder time: a prefix (which may itself contain
+  parameters, e.g. `{tenant}/api`), shared parameter policies, and shared endpoint metadata are
+  merged onto each child route **at registration**, so grouped routes match at exactly the cost
+  of directly-mapped ones and participate normally in precedence.
 - Carries an immutable, typed **endpoint-metadata bag** on each route and surfaces the
   **route-match result** (route + typed values + metadata) as a strongly-typed HTTP feature — the
   reflection-free seam that auth, docs, and observability consume.
@@ -37,6 +41,7 @@ controllers, metadata, results).
 | `RouteParameterPolicy` / `TypedRouteParameterPolicy` | Inline constraint base types. `TypedRouteParameterPolicy` validates **and** converts (parse-once); the public extension point for custom typed constraints. |
 | `RouteParameterPolicyMap` | Resolves inline policy names (`int`, `guid`, `length(n)`, `min(n)`, `range(a,b)`, …) to executable policies; `CreateDefault()` registers the built-ins. |
 | `IRouterRouteMetadataCollection` / `RouterRouteMetadataCollection` | Immutable, ordered, reflection-free endpoint-metadata bag (`GetMetadata<T>` is last-wins). |
+| `IRouterGroupBuilder` / `RouterBuilderExtensions.MapGroup` | Builder-time route groups: prefix + shared policies + shared metadata composed onto children at registration; nestable; child-over-group overrides. |
 | `IRouteMatchFeature` | The per-request feature carrying the matched route, its values, and its metadata. |
 | `HttpContextRoutingExtensions` | `SetRouteMatch` / `GetRouteMatch` / `TryGetRoute` / `TryGetRouteValues` / `GetEndpointMetadata`(`<T>`) over that feature. |
 | `RoutingExtensions.UseRouting` | Pipeline integration (dispatch / 405 / fall-through). |
@@ -50,6 +55,13 @@ var router = new Router(new IRouterRoute[]
     new Route(HttpMethod.Get, "/api/{id:int}", getHandler),    // constrained parameter
     new Route(new[] { HttpMethod.Get, HttpMethod.Post }, "/items", itemsHandler),
 });
+
+// Or compose grouped endpoints on a builder — shared config first, children second:
+var builder = new RouterBuilder();
+builder.MapGroup("api/v1")
+    .WithMetadata(new AuthMetadata("members"))          // applies to every child
+    .Map(HttpMethod.Get, "orders/{id:int}", getOrder)   // matches /api/v1/orders/{id:int}
+    .Map(HttpMethod.Get, "", index);                    // matches /api/v1
 
 RouteMatch match = router.Match(context);
 switch (match.Status)

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/docs/DESIGN.md
@@ -7,7 +7,7 @@ given an inbound `IHttpContext`, which handler (if any) should run, and — when
 should — whether that is a *no route* (404) or a *wrong method* (405) situation. It also
 carries the **endpoint metadata** each route declares and surfaces the **route-match
 result** to the rest of the pipeline as a typed feature. It is a foundation primitive: the
-API, function, controller, and metadata programming models (issues #149, #151, #786–#788,
+API, function, controller, and metadata programming models (issues #149, #151, #787, #788,
 #796) all build on the matcher, the typed route values, and the metadata seam defined here, so
 their behavior must be predictable, standards-aware, and reflection-free before those layers are added.
 
@@ -21,6 +21,8 @@ Scope of this library:
   and HTTP method semantics.
 - An **endpoint metadata bag** (`IRouterRouteMetadataCollection`) and a **route-match feature**
   (`IRouteMatchFeature`) — the reflection-free seam auth, docs, and observability consume (#150).
+- **Route groups** (`IRouterGroupBuilder`, via `MapGroup`) — builder-time composition of a path
+  prefix, shared parameter policies, and shared endpoint metadata onto child routes (#786).
 - Minimal **pipeline integration** (`UseRouting`) so a web application can dispatch through
   the router.
 
@@ -221,6 +223,73 @@ no shared string constants across assemblies and no reflection — `Get<TFeature
 When nothing has matched, the `GetEndpointMetadata*` accessors degrade to `Empty`/`null` rather than
 throwing — metadata queries are safe to make unconditionally.
 
+## Route groups (#786)
+
+### Registration-time composition — the group disappears before the router exists
+
+`IRouterBuilder.MapGroup(prefix)` (an `extension(...)` member in `RouterBuilderExtensions`)
+returns an `IRouterGroupBuilder` — the `MapGroup` equivalent. A group composes three things onto
+its children: a **path prefix**, **shared parameter policies**, and **shared endpoint metadata**.
+The defining property is *when* composition happens: at **child registration**. Each
+`group.Map(...)` joins the group's prefix and the child template as **raw text**, re-parses the
+composed template through `RoutePatternParser`, and maps one ordinary fully-composed `Route` into
+the underlying `IRouterBuilder`. The router never sees a group; there is no per-request prefix
+matching, no group node in the match path, and a grouped route costs exactly what a
+directly-mapped route costs at request time.
+
+**Why raw-text re-parse, not segment-list splicing.** The alternative — parsing prefix and child
+separately and concatenating their `RoutePatternPathSegment` lists via `RoutePatternFactory` —
+would bypass the parser's cross-segment validation (duplicate parameter names, catch-all-must-be-
+last, separator rules), forcing the group to re-implement those rules and inevitably drift from
+the parser. Re-parsing the joined text makes the parser's existing semantics *the* conflict rules
+for composition: a parameter name duplicated between prefix and child (`{id}` + `{id:int}`), a
+catch-all prefix followed by child segments (`files/{*path}` + `download`), or malformed syntax
+all throw `RoutePatternException` exactly as they would for a hand-written template. The cost is
+one extra parse per registered child — builder-time only, and negligible.
+
+Prefixes are templates, not strings-with-slashes: `{tenant}/api` is a valid group prefix and its
+parameters capture route values like any other. Inputs are normalized (leading `~/` or `/` and
+trailing `/` trimmed) so `MapGroup("/api/")` + `Map(GET, "/orders/")` composes cleanly to
+`api/orders`. An **empty child template** maps the prefix itself (`GET /api/v1`); an **empty
+prefix** creates a pure configuration group that only shares policies/metadata.
+
+### Precedence falls out of composition
+
+Because the prefix segments are part of the composed `RoutePattern`,
+`RoutePrecedence.ComputeInbound` scores the full path — a literal contributed through a group
+outranks a parameter at the same depth regardless of which was registered first or whether either
+came from a group. No group-aware code exists in `Router` or `RoutePrecedence`.
+
+### Deterministic sharing: snapshot at creation, freeze at first child
+
+A group's shared state is a **snapshot**: a nested group copies its parent's policy map
+(`RouteParameterPolicyMap`'s copy constructor) and metadata list at creation, so siblings and
+parents stay isolated. A root group starts from `RouteParameterPolicyMap.CreateDefault()`.
+
+Shared configuration is declared first, children second — enforced, not conventional: once a
+group registers its first child route **or** nested group, its shared configuration **freezes**
+and later `WithMetadata`/`WithParameterPolicy` calls throw `InvalidOperationException`. This is
+the deliberate divergence from ASP.NET's `RouteGroupBuilder`, which defers convention application
+to endpoint-build time so late-added conventions still reach earlier children. Deferral needs a
+build-time flush hook and mutable pending state on the builder; the freeze rule gets the same
+guarantee — *shared values apply to every child* — with immediate composition, immutable routes,
+and an order-independent result. The failure mode it prevents is silent: without it, metadata
+added after the third of five children would apply to only the last two.
+
+### Override rules (child over group, always)
+
+- **Metadata:** each child's `IRouterRouteMetadataCollection` is built by concatenation — outer
+  group items, then inner group items, then route-level items. The bag's last-wins
+  `GetMetadata<T>` therefore resolves the most specific declaration, and `GetOrderedMetadata<T>`
+  exposes the full broad-to-narrow layering (this is precisely the composition the #150 design
+  anticipated). Routes with no metadata at any level share `RouterRouteMetadataCollection.Empty`.
+- **Parameter policies:** `WithParameterPolicy` registers by inline name into the group's map;
+  registering a name again (a built-in's, or an outer group's) replaces it for this group's
+  children — dictionary-assignment semantics, deterministic. A single route can override the
+  group by passing a configure action to the full `Map` overload, which acts on a *copy* of the
+  group map scoped to that route only. Unknown policy references in a composed template still
+  fail at `Route` construction (builder time), never at request time.
+
 ## Pipeline integration (`UseRouting`)
 
 The `UseRouting` middleware resolves the `IRouterFeature`, calls `router.Match(context)` once,
@@ -334,8 +403,9 @@ without re-parsing (`ConversionType.IsInstanceOfType`), so conversion is genuine
 
 The endpoint-metadata seam (#150) is consumed by:
 
-- **#786 Route groups (`MapGroup`)** — compose group metadata into each child route by concatenating
-  into a new `RouterRouteMetadataCollection` (last-wins makes endpoint-level override group-level).
+- **Route groups (`MapGroup`, delivered here — #786)** — compose group metadata into each child route
+  by concatenating into a new `RouterRouteMetadataCollection` (last-wins makes endpoint-level
+  override group-level). See the route-groups section above.
 - **#788 Host-based matching (`RequireHost`)** — contributes host metadata the matcher consults.
 - **#790 Auth scheme model / handlers** — read authorization metadata off the matched endpoint via
   `GetEndpointMetadata<T>()`.
@@ -347,10 +417,11 @@ The endpoint-metadata seam (#150) is consumed by:
 - **#789 Typed route values, expanded constraints, per-application router state** — see the constraint
   model and per-application router state sections above. The additive routing items #786/#787/#788
   build on the route model and match feature here and were intentionally held until #789 merged.
+- **#786 Route groups (`MapGroup`)** — builder-time prefix/policy/metadata composition; see the
+  route-groups section above.
 
 ## Non-goals (delivered elsewhere in the routing epic #28)
 
-- **Route groups (`MapGroup`)** — #786.
 - **Named routes + link generation (outbound URL building)** — #787. `OutboundPrecedence` is
   computed and preserved for this future work but is not consumed by the matcher.
 - **Host-based matching (`RequireHost`)** — #788.

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouterGroupBuilder.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Abstractions/IRouterGroupBuilder.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Routing.Policies;
+
+namespace Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// Composes a path prefix, shared parameter policies, and shared endpoint metadata onto child
+/// routes at registration time (the <c>MapGroup</c> model).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A route group is a <em>builder-time</em> composition tool: every child route registered through
+/// the group is stored as a single fully-composed route whose template is the group prefix joined
+/// with the child template. The composed template is parsed once, at registration, by the ordinary
+/// route-template parser — so the router evaluates grouped routes exactly like directly-mapped
+/// ones, with no per-request prefix matching, and all template conflict rules (duplicate parameter
+/// names across the prefix and the child, catch-all placement, separator rules) are enforced by
+/// the parser's existing semantics. Because the prefix segments are part of the composed pattern,
+/// precedence is computed over the full path: a literal contributed by a group still outranks a
+/// parameter at the same depth.
+/// </para>
+/// <para>
+/// Shared configuration is declared first, children second. <see cref="WithMetadata"/> and the
+/// <see cref="WithParameterPolicy(string, RouteParameterPolicy)"/> overloads may only be called
+/// before the group registers its first child route or nested group; afterwards the group's shared
+/// configuration is <em>frozen</em> and further calls throw. This freeze rule is what makes the
+/// composition deterministic: shared values are guaranteed to apply to <em>every</em> child, and a
+/// child can never observe a different group state depending on registration order.
+/// </para>
+/// <para>
+/// Overrides are child-over-group, deterministically: group metadata items are placed
+/// <em>before</em> route-level items in each child's <see cref="IRouterRouteMetadataCollection"/>,
+/// so the collection's last-wins <c>GetMetadata&lt;T&gt;</c> rule resolves the route-level
+/// (most specific) declaration; nested groups layer outer items before inner items. A route-level
+/// parameter-policy registration for a name the group also registered replaces the group's
+/// registration for that route only.
+/// </para>
+/// </remarks>
+public interface IRouterGroupBuilder
+{
+    /// <summary>
+    /// Gets the full composed route-template prefix applied to child routes, including every
+    /// ancestor group's prefix.
+    /// </summary>
+    /// <remarks>
+    /// The prefix is normalized: leading <c>~/</c> or <c>/</c> and trailing <c>/</c> are removed
+    /// (for example <c>"api/v1"</c>). An empty string identifies a prefix-less group used purely
+    /// to share parameter policies or endpoint metadata.
+    /// </remarks>
+    string Prefix { get; }
+
+    /// <summary>
+    /// Creates a nested route group whose prefix is this group's prefix joined with
+    /// <paramref name="prefix"/>, and which inherits a snapshot of this group's shared parameter
+    /// policies and endpoint metadata.
+    /// </summary>
+    /// <param name="prefix">
+    /// The route-template prefix of the nested group, relative to this group. May contain
+    /// parameters (for example <c>{tenant}/api</c>) and may be empty to share only policies and
+    /// metadata.
+    /// </param>
+    /// <returns>The nested route group builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prefix"/> is <see langword="null"/>.</exception>
+    /// <exception cref="Exceptions.RoutePatternException">
+    /// The composed prefix is not a valid route template (for example a syntax error, or a
+    /// parameter name duplicated across the nesting levels).
+    /// </exception>
+    /// <remarks>
+    /// Creating a nested group freezes this group's shared configuration (the nested group
+    /// snapshots it), so declare all shared metadata and policies before nesting.
+    /// </remarks>
+    IRouterGroupBuilder MapGroup(string prefix);
+
+    /// <summary>
+    /// Adds shared endpoint metadata applied to every child route subsequently registered through
+    /// this group (and inherited by nested groups).
+    /// </summary>
+    /// <param name="items">The metadata items to share. Must not contain <see langword="null"/> entries.</param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="items"/> contains a <see langword="null"/> entry.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A child route or nested group has already been registered — the group's shared
+    /// configuration is frozen.
+    /// </exception>
+    /// <remarks>
+    /// Group items are placed before route-level items in each child's metadata collection, so the
+    /// last-wins <c>GetMetadata&lt;T&gt;</c> rule lets a route-level item of the same type override
+    /// the group's.
+    /// </remarks>
+    IRouterGroupBuilder WithMetadata(params object[] items);
+
+    /// <summary>
+    /// Registers a shared route parameter policy for an inline policy name, applied when resolving
+    /// the inline policies of every child route registered through this group (and inherited by
+    /// nested groups).
+    /// </summary>
+    /// <param name="policyName">The inline policy name referenced from child templates (for example <c>version</c> in <c>{v:version}</c>).</param>
+    /// <param name="policy">The route parameter policy instance.</param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="policyName"/> or <paramref name="policy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="policyName"/> is empty.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A child route or nested group has already been registered — the group's shared
+    /// configuration is frozen.
+    /// </exception>
+    /// <remarks>
+    /// Registering a name that is already registered (a built-in, or an outer group's registration)
+    /// replaces it for this group's children — nested/child registrations deterministically
+    /// override group-level ones.
+    /// </remarks>
+    IRouterGroupBuilder WithParameterPolicy(string policyName, RouteParameterPolicy policy);
+
+    /// <summary>
+    /// Registers a shared route parameter policy factory for an inline policy name, applied when
+    /// resolving the inline policies of every child route registered through this group (and
+    /// inherited by nested groups).
+    /// </summary>
+    /// <param name="policyName">The inline policy name referenced from child templates.</param>
+    /// <param name="factory">The factory used to create the executable policy from the inline argument text.</param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="policyName"/> or <paramref name="factory"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="policyName"/> is empty.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A child route or nested group has already been registered — the group's shared
+    /// configuration is frozen.
+    /// </exception>
+    IRouterGroupBuilder WithParameterPolicy(string policyName, Func<string?, RouteParameterPolicy> factory);
+
+    /// <summary>
+    /// Registers a child route whose template is this group's prefix joined with
+    /// <paramref name="template"/>.
+    /// </summary>
+    /// <param name="method">The HTTP method accepted by the route.</param>
+    /// <param name="template">
+    /// The child route template, relative to the group prefix. An empty string maps the group
+    /// prefix itself.
+    /// </param>
+    /// <param name="handler">The handler invoked when the composed route matches.</param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="template"/> or <paramref name="handler"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="Exceptions.RoutePatternException">
+    /// The composed template is not a valid route template (for example a parameter name duplicated
+    /// between the prefix and the child, or a prefix catch-all followed by child segments).
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The composed template references an inline policy name unknown to the group's policy map.
+    /// </exception>
+    IRouterGroupBuilder Map(HttpMethod method, string template, IRouterRouteHandler handler);
+
+    /// <summary>
+    /// Registers a child route with route-level endpoint metadata whose template is this group's
+    /// prefix joined with <paramref name="template"/>.
+    /// </summary>
+    /// <param name="method">The HTTP method accepted by the route.</param>
+    /// <param name="template">
+    /// The child route template, relative to the group prefix. An empty string maps the group
+    /// prefix itself.
+    /// </param>
+    /// <param name="handler">The handler invoked when the composed route matches.</param>
+    /// <param name="metadata">
+    /// Route-level endpoint metadata, appended after the group's shared metadata so it overrides
+    /// group items under the last-wins rule.
+    /// </param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="template"/>, <paramref name="handler"/>, or <paramref name="metadata"/>
+    /// is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="Exceptions.RoutePatternException">The composed template is not a valid route template.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The composed template references an inline policy name unknown to the group's policy map.
+    /// </exception>
+    IRouterGroupBuilder Map(HttpMethod method, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection metadata);
+
+    /// <summary>
+    /// Registers a child route accepting multiple HTTP methods whose template is this group's
+    /// prefix joined with <paramref name="template"/>.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="template">
+    /// The child route template, relative to the group prefix. An empty string maps the group
+    /// prefix itself.
+    /// </param>
+    /// <param name="handler">The handler invoked when the composed route matches.</param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="methods"/>, <paramref name="template"/>, or <paramref name="handler"/>
+    /// is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="Exceptions.RoutePatternException">The composed template is not a valid route template.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The composed template references an inline policy name unknown to the group's policy map.
+    /// </exception>
+    IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler);
+
+    /// <summary>
+    /// Registers a child route accepting multiple HTTP methods, with route-level endpoint metadata,
+    /// whose template is this group's prefix joined with <paramref name="template"/>.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="template">
+    /// The child route template, relative to the group prefix. An empty string maps the group
+    /// prefix itself.
+    /// </param>
+    /// <param name="handler">The handler invoked when the composed route matches.</param>
+    /// <param name="metadata">
+    /// Route-level endpoint metadata, appended after the group's shared metadata so it overrides
+    /// group items under the last-wins rule.
+    /// </param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="methods"/>, <paramref name="template"/>, <paramref name="handler"/>, or
+    /// <paramref name="metadata"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="Exceptions.RoutePatternException">The composed template is not a valid route template.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The composed template references an inline policy name unknown to the group's policy map.
+    /// </exception>
+    IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection metadata);
+
+    /// <summary>
+    /// Registers a child route accepting multiple HTTP methods, with optional route-level endpoint
+    /// metadata and route-level parameter-policy overrides, whose template is this group's prefix
+    /// joined with <paramref name="template"/>.
+    /// </summary>
+    /// <param name="methods">The HTTP methods accepted by the route. An empty sequence accepts any method.</param>
+    /// <param name="template">
+    /// The child route template, relative to the group prefix. An empty string maps the group
+    /// prefix itself.
+    /// </param>
+    /// <param name="handler">The handler invoked when the composed route matches.</param>
+    /// <param name="metadata">
+    /// Optional route-level endpoint metadata, appended after the group's shared metadata so it
+    /// overrides group items under the last-wins rule.
+    /// </param>
+    /// <param name="policies">
+    /// Configures a copy of the group's parameter policy map for this route only. Registering a
+    /// policy name the group also registered replaces the group's registration for this route —
+    /// the deterministic child-over-group override for parameter policies.
+    /// </param>
+    /// <returns>The current route group builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="methods"/>, <paramref name="template"/>, <paramref name="handler"/>, or
+    /// <paramref name="policies"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="Exceptions.RoutePatternException">The composed template is not a valid route template.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The composed template references an inline policy name unknown to the configured policy map.
+    /// </exception>
+    IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection? metadata, Action<RouteParameterPolicyMap> policies);
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Extensions/RouterBuilderExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Extensions/RouterBuilderExtensions.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// Route-group composition extensions for <see cref="IRouterBuilder"/>.
+/// </summary>
+public static class RouterBuilderExtensions
+{
+    extension(IRouterBuilder builder)
+    {
+        /// <summary>
+        /// Creates a route group that composes <paramref name="prefix"/>, shared parameter
+        /// policies, and shared endpoint metadata onto child routes at registration time.
+        /// </summary>
+        /// <param name="prefix">
+        /// The route-template prefix applied to child routes. May contain parameters (for example
+        /// <c>{tenant}/api</c>) and may be empty to share only policies and metadata.
+        /// </param>
+        /// <returns>A route group builder mapping composed child routes into this router builder.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="prefix"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="Exceptions.RoutePatternException">
+        /// <paramref name="prefix"/> is not a valid route template.
+        /// </exception>
+        /// <remarks>
+        /// Each child route registered through the group is stored as a single fully-composed
+        /// route — the router evaluates it exactly like a directly-mapped route, with no
+        /// per-request prefix matching. See <see cref="IRouterGroupBuilder"/> for composition,
+        /// override, and freeze semantics.
+        /// </remarks>
+        public IRouterGroupBuilder MapGroup(string prefix)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(prefix);
+
+            return new RouterGroupBuilder(builder, parent: null, prefix);
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/src/Internal/RouterGroupBuilder.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/src/Internal/RouterGroupBuilder.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Routing.Patterns;
+using Assimalign.Cohesion.Web.Routing.Policies;
+
+namespace Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// Default <see cref="IRouterGroupBuilder"/>. Composes the group prefix onto child templates as
+/// raw text and re-parses the composed template, so every registered child is an ordinary
+/// fully-composed <see cref="Route"/> in the underlying <see cref="IRouterBuilder"/> — the router
+/// never sees the group.
+/// </summary>
+internal sealed class RouterGroupBuilder : IRouterGroupBuilder
+{
+    private readonly IRouterBuilder _routerBuilder;
+    private readonly RouteParameterPolicyMap _policyMap;
+    private readonly List<object> _metadata;
+    private bool _frozen;
+
+    internal RouterGroupBuilder(IRouterBuilder routerBuilder, RouterGroupBuilder? parent, string prefix)
+    {
+        _routerBuilder = routerBuilder;
+
+        Prefix = CombineTemplates(parent?.Prefix ?? string.Empty, NormalizeTemplate(prefix));
+
+        if (Prefix.Length > 0)
+        {
+            // Fail fast at group creation: template syntax errors and parameter names duplicated
+            // across nesting levels surface here rather than at the first child registration.
+            RoutePatternParser.Parse(Prefix);
+        }
+
+        // Snapshot the parent's shared configuration. Copies (not references) keep sibling groups
+        // and the parent isolated from this group's own WithMetadata/WithParameterPolicy calls.
+        _policyMap = parent is null
+            ? RouteParameterPolicyMap.CreateDefault()
+            : new RouteParameterPolicyMap(parent._policyMap);
+        _metadata = parent is null
+            ? new List<object>()
+            : new List<object>(parent._metadata);
+    }
+
+    /// <inheritdoc />
+    public string Prefix { get; }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder MapGroup(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        RouterGroupBuilder nested = new(_routerBuilder, this, prefix);
+
+        // The nested group snapshotted this group's shared configuration; later mutations here
+        // would silently not reach it, so freeze instead.
+        _frozen = true;
+
+        return nested;
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder WithMetadata(params object[] items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ThrowIfFrozen();
+
+        foreach (object item in items)
+        {
+            if (item is null)
+            {
+                throw new ArgumentException("Endpoint metadata items must not be null.", nameof(items));
+            }
+        }
+
+        _metadata.AddRange(items);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder WithParameterPolicy(string policyName, RouteParameterPolicy policy)
+    {
+        ThrowIfFrozen();
+
+        _policyMap.Add(policyName, policy);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder WithParameterPolicy(string policyName, Func<string?, RouteParameterPolicy> factory)
+    {
+        ThrowIfFrozen();
+
+        _policyMap.Add(policyName, factory);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder Map(HttpMethod method, string template, IRouterRouteHandler handler)
+    {
+        return MapCore(new[] { method }, template, handler, metadata: null, policies: null);
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder Map(HttpMethod method, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection metadata)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        return MapCore(new[] { method }, template, handler, metadata, policies: null);
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler)
+    {
+        return MapCore(methods, template, handler, metadata: null, policies: null);
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection metadata)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        return MapCore(methods, template, handler, metadata, policies: null);
+    }
+
+    /// <inheritdoc />
+    public IRouterGroupBuilder Map(IEnumerable<HttpMethod> methods, string template, IRouterRouteHandler handler, IRouterRouteMetadataCollection? metadata, Action<RouteParameterPolicyMap> policies)
+    {
+        ArgumentNullException.ThrowIfNull(policies);
+
+        return MapCore(methods, template, handler, metadata, policies);
+    }
+
+    private IRouterGroupBuilder MapCore(
+        IEnumerable<HttpMethod> methods,
+        string template,
+        IRouterRouteHandler handler,
+        IRouterRouteMetadataCollection? metadata,
+        Action<RouteParameterPolicyMap>? policies)
+    {
+        ArgumentNullException.ThrowIfNull(methods);
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        // Registration-time composition: join the prefix and the child template as raw text and
+        // re-parse, so the parser's own conflict rules govern the composed template and precedence
+        // is computed over the full path.
+        string composedTemplate = CombineTemplates(Prefix, NormalizeTemplate(template));
+        RoutePattern pattern = RoutePatternParser.Parse(composedTemplate);
+
+        RouteParameterPolicyMap policyMap = _policyMap;
+        if (policies is not null)
+        {
+            // Route-level overrides act on a copy: re-registering a name the group registered
+            // replaces it for this route only, leaving the group and its other children untouched.
+            policyMap = new RouteParameterPolicyMap(_policyMap);
+            policies(policyMap);
+        }
+
+        Route route = new(methods, pattern, policyMap, handler, BuildMetadata(metadata));
+
+        _routerBuilder.Map(route);
+        _frozen = true;
+
+        return this;
+    }
+
+    private IRouterRouteMetadataCollection BuildMetadata(IRouterRouteMetadataCollection? routeMetadata)
+    {
+        int routeCount = routeMetadata?.Count ?? 0;
+
+        if (_metadata.Count == 0)
+        {
+            // Metadata collections are immutable by contract, so the route-level one is reusable as-is.
+            return routeCount == 0
+                ? RouterRouteMetadataCollection.Empty
+                : routeMetadata!;
+        }
+
+        List<object> items = new(_metadata.Count + routeCount);
+        items.AddRange(_metadata);
+
+        if (routeMetadata is not null)
+        {
+            // Group items first, route-level items last: the collection's last-wins GetMetadata<T>
+            // makes the route-level (most specific) declaration the override.
+            items.AddRange(routeMetadata);
+        }
+
+        return new RouterRouteMetadataCollection(items);
+    }
+
+    private void ThrowIfFrozen()
+    {
+        if (_frozen)
+        {
+            throw new InvalidOperationException(
+                "The route group's shared configuration is frozen because a child route or nested group has " +
+                "already been registered. Declare group-level metadata and parameter policies before mapping " +
+                "children so they apply to all child routes.");
+        }
+    }
+
+    private static string NormalizeTemplate(string template)
+    {
+        ReadOnlySpan<char> span = template.AsSpan();
+
+        if (span.StartsWith("~/", StringComparison.Ordinal))
+        {
+            span = span[2..];
+        }
+
+        span = span.Trim('/');
+
+        return span.Length == template.Length ? template : span.ToString();
+    }
+
+    private static string CombineTemplates(string left, string right)
+    {
+        if (left.Length == 0)
+        {
+            return right;
+        }
+
+        if (right.Length == 0)
+        {
+            return left;
+        }
+
+        return $"{left}/{right}";
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouterGroupTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Routing/tests/RouterGroupTests.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Cohesion.Web.Routing.Exceptions;
+using Assimalign.Cohesion.Web.Routing.Policies;
+using Assimalign.Cohesion.Web.Routing.Tests.TestObjects;
+
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.Routing.Tests;
+
+public class RouterGroupTests
+{
+    private sealed class TestMetadata
+    {
+        public TestMetadata(string value) => Value = value;
+
+        public string Value { get; }
+    }
+
+    private sealed class ExactValueRouteParameterPolicy : RouteParameterPolicy
+    {
+        private readonly string _expected;
+
+        public ExactValueRouteParameterPolicy(string expected) => _expected = expected;
+
+        public override bool Applies(RouteParameterPolicyContext context)
+        {
+            return context.TryGetParameterValue(out object? value)
+                && value is string text
+                && string.Equals(text, _expected, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Composes the prefix onto child templates at registration time")]
+    public void MapGroup_WithPrefix_ShouldComposePrefixAtRegistrationTime()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler handler = new();
+
+        builder.MapGroup("api").Map(HttpMethod.Get, "orders", handler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/orders"));
+        RouteMatch unprefixed = router.Match(TestHttpContext.Create(HttpMethod.Get, "/orders"));
+
+        // Assert — the registered route is a single fully-composed route; the bare child
+        // template does not exist as a route of its own.
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeOfType<Route>().Pattern.RawText.ShouldBe("api/orders");
+        unprefixed.Status.ShouldBe(RouteMatchStatus.NoMatch);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Nested groups compose every ancestor prefix")]
+    public void MapGroup_NestedGroups_ShouldComposeAllPrefixes()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler handler = new();
+
+        IRouterGroupBuilder nested = builder.MapGroup("api").MapGroup("v1");
+        nested.Prefix.ShouldBe("api/v1");
+        nested.Map(HttpMethod.Get, "orders/{id:int}", handler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/v1/orders/42"));
+
+        // Assert — the typed 'int' constraint still converts the captured value on the composed route.
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Values["id"].ShouldBeOfType<int>().ShouldBe(42);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Template-parameter prefixes capture route values")]
+    public void MapGroup_TemplateParameterPrefix_ShouldCapturePrefixParameters()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler handler = new();
+
+        builder.MapGroup("{tenant}/api").Map(HttpMethod.Get, "orders", handler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/contoso/api/orders"));
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Values["tenant"].ShouldBe("contoso");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Match: Grouped literal beats a parameter at the same depth")]
+    public void Match_GroupedLiteral_ShouldBeatParameterAtSameDepth()
+    {
+        // Arrange — the parameter route is registered FIRST and directly; the literal arrives
+        // later through a group. Precedence must still prefer the literal.
+        RouterBuilder builder = new();
+        Route parameterRoute = new(HttpMethod.Get, "api/{id}");
+        RecordingRouterRouteHandler groupedHandler = new();
+
+        builder.Map(parameterRoute);
+        builder.MapGroup("api").Map(HttpMethod.Get, "status", groupedHandler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch literalMatch = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/status"));
+        RouteMatch parameterMatch = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/42"));
+
+        // Assert
+        literalMatch.Status.ShouldBe(RouteMatchStatus.Matched);
+        literalMatch.Route!.Handler.ShouldBeSameAs(groupedHandler);
+        parameterMatch.Status.ShouldBe(RouteMatchStatus.Matched);
+        parameterMatch.Route.ShouldBeSameAs(parameterRoute);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - WithMetadata: Group metadata applies to every child route")]
+    public void WithMetadata_OnGroup_ShouldApplyToAllChildRoutes()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        TestMetadata shared = new("group");
+
+        builder.MapGroup("api")
+            .WithMetadata(shared)
+            .Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler())
+            .Map(HttpMethod.Get, "customers", new RecordingRouterRouteHandler());
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch orders = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/orders"));
+        RouteMatch customers = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/customers"));
+
+        // Assert
+        orders.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(shared);
+        customers.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(shared);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - WithMetadata: Merge order is outer group, inner group, then route")]
+    public void WithMetadata_NestedGroups_ShouldLayerOuterBeforeInnerBeforeRoute()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        TestMetadata outer = new("outer");
+        TestMetadata inner = new("inner");
+        TestMetadata route = new("route");
+
+        builder.MapGroup("api")
+            .WithMetadata(outer)
+            .MapGroup("v1")
+            .WithMetadata(inner)
+            .Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler(), new RouterRouteMetadataCollection(route));
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/v1/orders"));
+
+        // Assert — broader scope first, narrower scope last; last-wins resolves the route level.
+        IRouterRouteMetadataCollection metadata = match.Route!.Metadata;
+        IReadOnlyList<TestMetadata> ordered = metadata.GetOrderedMetadata<TestMetadata>();
+        ordered.Count.ShouldBe(3);
+        ordered[0].ShouldBeSameAs(outer);
+        ordered[1].ShouldBeSameAs(inner);
+        ordered[2].ShouldBeSameAs(route);
+        metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(route);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - GetMetadata: Route-level metadata overrides group-level metadata")]
+    public void GetMetadata_RouteLevelSameType_ShouldOverrideGroupLevel()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        TestMetadata groupLevel = new("group");
+        TestMetadata routeLevel = new("route");
+
+        builder.MapGroup("api")
+            .WithMetadata(groupLevel)
+            .Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler(), new RouterRouteMetadataCollection(routeLevel));
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/orders"));
+
+        // Assert
+        match.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(routeLevel);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - WithMetadata: Throws after a child route is registered")]
+    public void WithMetadata_AfterChildRouteMapped_ShouldThrow()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder group = builder.MapGroup("api");
+        group.Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler());
+
+        // Act & Assert — shared configuration is frozen once the group has produced a child.
+        Should.Throw<InvalidOperationException>(() => group.WithMetadata(new TestMetadata("late")));
+        Should.Throw<InvalidOperationException>(() =>
+            group.WithParameterPolicy("late", new ExactValueRouteParameterPolicy("x")));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - WithMetadata: Throws after a nested group is created")]
+    public void WithMetadata_AfterNestedGroupCreated_ShouldThrow()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder group = builder.MapGroup("api");
+        group.MapGroup("v1");
+
+        // Act & Assert — the nested group snapshotted the parent's configuration, so the parent freezes.
+        Should.Throw<InvalidOperationException>(() => group.WithMetadata(new TestMetadata("late")));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - WithParameterPolicy: Group policies apply to child routes")]
+    public void WithParameterPolicy_OnGroup_ShouldApplyToChildRoutes()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+
+        builder.MapGroup("api")
+            .WithParameterPolicy("flavor", new ExactValueRouteParameterPolicy("vanilla"))
+            .Map(HttpMethod.Get, "{value:flavor}", new RecordingRouterRouteHandler());
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch accepted = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/vanilla"));
+        RouteMatch rejected = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/chocolate"));
+
+        // Assert
+        accepted.Status.ShouldBe(RouteMatchStatus.Matched);
+        rejected.Status.ShouldBe(RouteMatchStatus.NoMatch);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Map: Route-level policy registration overrides the group's")]
+    public void Map_RoutePolicyOverride_ShouldOverrideGroupPolicy()
+    {
+        // Arrange — the group accepts only 'vanilla'; one child re-registers the same policy
+        // name to accept only 'chocolate'. The override must be scoped to that child.
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler overriddenHandler = new();
+        RecordingRouterRouteHandler inheritedHandler = new();
+
+        builder.MapGroup("api")
+            .WithParameterPolicy("flavor", new ExactValueRouteParameterPolicy("vanilla"))
+            .Map(
+                new[] { HttpMethod.Get },
+                "custom/{value:flavor}",
+                overriddenHandler,
+                metadata: null,
+                policies: map => map.Add("flavor", new ExactValueRouteParameterPolicy("chocolate")))
+            .Map(HttpMethod.Get, "shared/{value:flavor}", inheritedHandler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch overridden = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/custom/chocolate"));
+        RouteMatch overriddenRejected = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/custom/vanilla"));
+        RouteMatch inherited = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/shared/vanilla"));
+
+        // Assert
+        overridden.Status.ShouldBe(RouteMatchStatus.Matched);
+        overridden.Route!.Handler.ShouldBeSameAs(overriddenHandler);
+        overriddenRejected.Status.ShouldBe(RouteMatchStatus.NoMatch);
+        inherited.Status.ShouldBe(RouteMatchStatus.Matched);
+        inherited.Route!.Handler.ShouldBeSameAs(inheritedHandler);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Map: Duplicate parameter across prefix and child throws")]
+    public void Map_DuplicateParameterAcrossPrefixAndChild_ShouldThrow()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder group = builder.MapGroup("{id}");
+
+        // Act & Assert — the composed template is re-parsed, so the parser's duplicate-parameter
+        // rule governs prefix/child conflicts.
+        Should.Throw<RoutePatternException>(() =>
+            group.Map(HttpMethod.Get, "{id:int}", new RecordingRouterRouteHandler()));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Map: Child segments after a catch-all prefix throw")]
+    public void Map_ChildAfterCatchAllPrefix_ShouldThrow()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder group = builder.MapGroup("files/{*path}");
+
+        // Act & Assert — catch-all must be the last segment of the composed template.
+        Should.Throw<RoutePatternException>(() =>
+            group.Map(HttpMethod.Get, "download", new RecordingRouterRouteHandler()));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Invalid prefix syntax throws at group creation")]
+    public void MapGroup_InvalidPrefixSyntax_ShouldThrow()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+
+        // Act & Assert
+        Should.Throw<RoutePatternException>(() => builder.MapGroup("{unclosed"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Duplicate parameter across nesting levels throws at creation")]
+    public void MapGroup_NestedDuplicateParameter_ShouldThrowAtCreation()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder outer = builder.MapGroup("{id}");
+
+        // Act & Assert — the composed prefix is validated when the nested group is created,
+        // not deferred to the first child registration.
+        Should.Throw<RoutePatternException>(() => outer.MapGroup("{id}"));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Map: Unknown inline policy in the composed template throws at registration")]
+    public void Map_UnknownPolicyName_ShouldThrowAtRegistration()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        IRouterGroupBuilder group = builder.MapGroup("api");
+
+        // Act & Assert — unresolved policy references fail at builder time, not at request time.
+        Should.Throw<InvalidOperationException>(() =>
+            group.Map(HttpMethod.Get, "{id:unregistered}", new RecordingRouterRouteHandler()));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - Map: Empty child template maps the group prefix itself")]
+    public void Map_EmptyTemplate_ShouldMapGroupPrefixItself()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler handler = new();
+
+        builder.MapGroup("api/v1").Map(HttpMethod.Get, string.Empty, handler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/v1"));
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route!.Handler.ShouldBeSameAs(handler);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Empty prefix shares configuration without prefixing")]
+    public void MapGroup_EmptyPrefix_ShouldShareConfigurationWithoutPrefix()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        TestMetadata shared = new("shared");
+
+        builder.MapGroup(string.Empty)
+            .WithMetadata(shared)
+            .Map(HttpMethod.Get, "health", new RecordingRouterRouteHandler());
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/health"));
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(shared);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Leading and trailing separators are normalized")]
+    public void MapGroup_SeparatorNormalization_ShouldComposeCleanTemplates()
+    {
+        // Arrange
+        RouterBuilder builder = new();
+        RecordingRouterRouteHandler handler = new();
+
+        IRouterGroupBuilder group = builder.MapGroup("/api/");
+        group.Prefix.ShouldBe("api");
+        group.Map(HttpMethod.Get, "/orders/", handler);
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/orders"));
+
+        // Assert
+        match.Status.ShouldBe(RouteMatchStatus.Matched);
+        match.Route.ShouldBeOfType<Route>().Pattern.RawText.ShouldBe("api/orders");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Routing] - MapGroup: Sibling groups do not share configuration")]
+    public void MapGroup_SiblingGroups_ShouldNotShareConfiguration()
+    {
+        // Arrange — each nested group snapshots its parent; siblings stay isolated.
+        RouterBuilder builder = new();
+        TestMetadata v1Metadata = new("v1");
+
+        IRouterGroupBuilder api = builder.MapGroup("api");
+        IRouterGroupBuilder v1 = api.MapGroup("v1").WithMetadata(v1Metadata);
+        IRouterGroupBuilder v2 = api.MapGroup("v2");
+
+        v1.Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler());
+        v2.Map(HttpMethod.Get, "orders", new RecordingRouterRouteHandler());
+
+        IRouter router = builder.Build();
+
+        // Act
+        RouteMatch v1Match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/v1/orders"));
+        RouteMatch v2Match = router.Match(TestHttpContext.Create(HttpMethod.Get, "/api/v2/orders"));
+
+        // Assert
+        v1Match.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeSameAs(v1Metadata);
+        v2Match.Route!.Metadata.GetMetadata<TestMetadata>().ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Adds builder-time route groups to `resources/Web/Assimalign.Cohesion.Web.Routing` — the `MapGroup` equivalent (Stage 3 · Lane F; built on the post-#789 routing internals: typed route values, per-application router state).

- **`IRouterGroupBuilder`** (public, interface-first) + `internal sealed RouterGroupBuilder`, created via an `extension(IRouterBuilder)` member `MapGroup(prefix)` in `RouterBuilderExtensions`.
- **Registration-time composition:** each `group.Map(...)` joins the group prefix and child template as raw text, re-parses through `RoutePatternParser`, and maps one ordinary fully-composed `Route` into the underlying builder. The router never sees a group — **zero runtime prefix-matching cost**, and conflict rules (duplicate parameter names across prefix/child, catch-all placement, separators) are exactly the template parser's existing semantics.
- **Precedence falls out of composition:** prefix segments are part of the composed `RoutePattern`, so a grouped literal still beats a parameter at the same depth. No group-aware code in `Router`/`RoutePrecedence`.
- **Nested groups** snapshot the parent's shared policy map + metadata at creation (siblings isolated); prefixes may contain template parameters (`{tenant}/api`).
- **Deterministic child-over-group overrides:** group metadata is concatenated before route-level metadata (last-wins `GetMetadata<T>` resolves the most specific declaration — the #150 composition model); a route-level parameter-policy registration overrides the group's by name, scoped to that route via a map copy.
- **Freeze rule:** shared configuration (`WithMetadata`/`WithParameterPolicy`) throws once the group registers its first child route or nested group. This is a deliberate divergence from ASP.NET's deferred conventions — it guarantees shared values apply to *all* child routes with immediate composition and immutable routes (rationale recorded in `docs/DESIGN.md`).

## Testing

- 18 new Shouldly tests in `RouterGroupTests` covering nesting, template-parameter prefixes, metadata merge order (outer→inner→route + last-wins override), shared/overridden parameter policies, precedence (grouped literal vs. parameter), separator normalization, empty prefix/template, sibling isolation, and conflict cases (duplicate parameter across prefix/child, catch-all prefix + child segments, invalid prefix syntax, unknown policy name, frozen-config throws).
- Full Web.Routing suite: **129/129 passing** (111 pre-existing, no regressions).

## Docs

- `docs/DESIGN.md`: new “Route groups (#786)” section (raw-text re-parse vs. segment-splicing rationale, snapshot/freeze semantics, override rules); #786 moved out of non-goals into delivered.
- `README.md`: feature bullet, key-types row, grouped usage example.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Post-merge update (main @ #884/#886):** merged main and aligned with the new endpoint-metadata carrier discipline:

- Adopted the `Metadata/` move — group builder and tests now construct `RouterRouteMetadataCollection` from `Assimalign.Cohesion.Web.Routing.Metadata`.
- Groups introduce **no metadata types of their own**; shared items are the ordinary sealed carriers. Documented in the route-groups DESIGN.md section and demonstrated with two new tests: a group-level `RouteHostMetadata` host-constrains every child, and a route-level `RouteHostMetadata` **replaces** (never merges with) the group's, per the router's last-wins resolution.
- README group example now uses the real sealed carrier (`RouteHostMetadata`) instead of a hypothetical metadata type.
- Full suite post-merge: **213/213 passing**.
