### PR TITLE
feat(web): Web.Testing in-memory WebApplicationTestFactory + full-pipeline hosting tests [L03.01.01.15]

### DIFF
--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -2097,6 +2097,19 @@
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Sessions/tests/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.Sessions/tests/Assimalign.Cohesion.Web.Sessions.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Testing/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Testing/README.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Testing/docs/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Testing/docs/DESIGN.md" />
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Testing/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Testing/src/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Testing/src/Assimalign.Cohesion.Web.Testing.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Testing/tests/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Testing/tests/Assimalign.Cohesion.Web.Testing.Tests.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/sdks/">
 		<File Path="sdks/Directory.Build.props" />
 		<File Path="sdks/Directory.Build.targets" />

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
@@ -193,6 +193,27 @@ The gate is chosen for AOT-safety: a semaphore, stored `Task`s, and a
 context disposal is a `switch` type test, not a reflection probe. No runtime code
 generation, no `Assembly.LoadFrom`, no reflection-based serialization.
 
+## Application feature seeding
+
+`IWebApplicationBuilder.AddFeature` registers `IHttpFeature` singletons (routing's
+per-application `IRouterFeature` is the canonical example), but a feature is only
+useful once it is present on each exchange's `IHttpContext.Features` collection.
+That bridging happens when the pipeline is built: `WebApplication`'s pipeline
+`Build()` resolves the registered features **once** and, when any exist, wraps the
+composed pipeline in a seeding middleware that stamps each feature onto every
+exchange before any user middleware runs.
+
+Two deliberate properties:
+
+- **Builder-time snapshot, not request-time service location.** The feature set is
+  materialized at pipeline build (which happens when the server is resolved). Per
+  the hosting philosophy, nothing resolves services per request — the per-exchange
+  work is a plain array walk. Features registered after the pipeline is built are
+  not observed, the same snapshot rule the middleware list follows.
+- **Application-registered features are per-application.** Each application seeds
+  only its own DI-registered features, which is half of the process-wide isolation
+  story (#789's per-application router state is the other half).
+
 ## Testing
 
 Behaviour is verified in `tests/` with xUnit + Shouldly against instrumented
@@ -204,6 +225,16 @@ keep-alive non-starvation, single-connection fault isolation with continued
 service, connection+context disposal on every exit path, graceful `StopAsync`
 drain + listener disposal, and the concurrency cap holding connections back until
 a slot frees.
+
+The same properties are additionally pinned **end to end** by the full-pipeline
+integration suite (`WebApplicationPipelineIntegrationTests`,
+`WebApplicationServerIntegrationTests`), which drives the real server over the
+in-memory transport through `Assimalign.Cohesion.Web.Testing`'s
+`WebApplicationTestFactory` — a real `HttpClient`, real HTTP/1.1 exchanges, no
+sockets. It covers middleware onion ordering and short-circuiting, per-connection
+dispatch (a parked connection does not starve others), application-fault isolation
+with continued service, and graceful shutdown draining (in-flight unwind, idle
+keep-alive unblock, post-stop connection refusal).
 
 ## Non-goals
 

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/src/WebApplication.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/src/WebApplication.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,21 +29,6 @@ public sealed class WebApplication : Host<WebApplicationContext>, IWebApplicatio
         _middleware = new List<Func<WebApplicationMiddleware, WebApplicationMiddleware>>();
     }
 
-
-    // TODO: Need to create an API that allows feature registration on HttpContext creation from the transport layer
-    private void Init()
-    {
-        Use((context, next) =>
-        {
-            var features = Context.ServiceProvider.GetRequiredService<IEnumerable<IHttpFeature>>();
-            foreach (var feature in features)
-            {
-                context.Features.Set(feature);
-            }
-            return next.Invoke(context);
-        });
-    }
-
     public override WebApplicationContext Context => _context;
 
     public WebApplication Use(Func<IHttpContext, WebApplicationMiddleware, Task> middleware)
@@ -68,6 +54,28 @@ public sealed class WebApplication : Host<WebApplicationContext>, IWebApplicatio
         for (int i = _middleware.Count - 1; i >= 0; i--)
         {
             middleware = _middleware[i].Invoke(middleware);
+        }
+
+        // Seed every application-registered feature (IWebApplicationBuilder.AddFeature, e.g.
+        // routing's per-application IRouterFeature) onto each exchange before any user
+        // middleware runs. The feature set is snapshotted once here, at pipeline build — per
+        // the hosting philosophy, DI integration is builder-time only, so no service is
+        // resolved per request.
+        IHttpFeature[] features = Context.ServiceProvider.GetRequiredService<IEnumerable<IHttpFeature>>().ToArray();
+
+        if (features.Length > 0)
+        {
+            WebApplicationMiddleware pipeline = middleware;
+
+            middleware = new WebApplicationMiddleware(context =>
+            {
+                foreach (IHttpFeature feature in features)
+                {
+                    context.Features.Set(feature);
+                }
+
+                return pipeline.Invoke(context);
+            });
         }
 
         return new WebApplicationPipeline(middleware);

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/Assimalign.Cohesion.Web.Hosting.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/Assimalign.Cohesion.Web.Hosting.Tests.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <CohesionProjectReference Include="Assimalign.Cohesion.Web.Hosting" />
+    <CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.RequestLimits" />

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebApplicationPipelineIntegrationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebApplicationPipelineIntegrationTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Hosting.Tests;
+
+/// <summary>
+/// Full-pipeline integration coverage for middleware composition, driven end to end over the
+/// in-memory transport through <see cref="WebApplicationTestFactory"/> (no sockets, no
+/// ports): real client, real HTTP/1.1 wire exchange, real server dispatch.
+/// </summary>
+public class WebApplicationPipelineIntegrationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Pipeline: Middleware should run in registration (onion) order end to end")]
+    public async Task Pipeline_MultipleMiddleware_ShouldRunInRegistrationOnionOrder()
+    {
+        // Arrange — two wrapping middleware around a terminal handler; each records entry and
+        // exit so both the inbound order and the unwind order are observable.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        ConcurrentQueue<string> order = new();
+        WebApplication app = factory.Application;
+
+        app.Use(async (context, next) =>
+        {
+            order.Enqueue("outer:in");
+            await next.Invoke(context);
+            order.Enqueue("outer:out");
+        });
+        app.Use(async (context, next) =>
+        {
+            order.Enqueue("inner:in");
+            await next.Invoke(context);
+            order.Enqueue("inner:out");
+        });
+        app.Use(async (context, next) =>
+        {
+            order.Enqueue("terminal");
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+
+            byte[] payload = Encoding.UTF8.GetBytes("onion");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/order", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("onion");
+        order.ShouldBe(new[] { "outer:in", "inner:in", "terminal", "inner:out", "outer:out" });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Pipeline: A short-circuiting middleware should skip everything downstream")]
+    public async Task Pipeline_ShortCircuitingMiddleware_ShouldSkipDownstreamMiddleware()
+    {
+        // Arrange — the first middleware answers 403 without calling next; the downstream
+        // middleware records whether it ever ran.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        bool downstreamRan = false;
+        WebApplication app = factory.Application;
+
+        app.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Forbidden;
+            return Task.CompletedTask;
+        });
+        app.Use((context, next) =>
+        {
+            downstreamRan = true;
+            return next.Invoke(context);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/guarded", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.Forbidden);
+        downstreamRan.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Pipeline: A middleware fault should cost only its own connection, not the server")]
+    public async Task Pipeline_MiddlewareThrows_ShouldIsolateFaultToItsConnection()
+    {
+        // Arrange — the application-exception isolation boundary (#762): a throwing exchange
+        // tears down its own connection while the accept loop keeps serving new ones.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use((context, next) =>
+        {
+            if (context.Request.Path.ToString() == "/faulty")
+            {
+                throw new InvalidOperationException("Deliberate application fault.");
+            }
+
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient faultyClient = factory.CreateClient();
+        using HttpClient healthyClient = factory.CreateClient();
+
+        // Act & Assert — the faulting exchange surfaces as a transport-level failure on its
+        // own connection...
+        await Should.ThrowAsync<HttpRequestException>(() => faultyClient.GetAsync("/faulty", cancellationToken));
+
+        // ...and the server keeps serving fresh connections afterwards.
+        using HttpResponseMessage healthy = await healthyClient.GetAsync("/healthy", cancellationToken);
+        healthy.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebApplicationServerIntegrationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebApplicationServerIntegrationTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Hosting.Tests;
+
+/// <summary>
+/// Full-pipeline integration coverage for the <c>WebApplicationServer</c> dispatch and stop
+/// semantics (issue #762), driven end to end over the in-memory transport through
+/// <see cref="WebApplicationTestFactory"/>. The unit suite pins the same properties against
+/// instrumented doubles; this suite proves them with a real client, real HTTP/1.1 exchanges,
+/// and the real accept loop.
+/// </summary>
+public class WebApplicationServerIntegrationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Server: A parked connection should not starve other connections (per-connection dispatch)")]
+    public async Task Server_ParkedConnection_ShouldNotStarveOtherConnections()
+    {
+        // Arrange — request /slow parks in the pipeline on a test-owned gate; /fast must be
+        // served from a second connection while the first is parked. Pre-#762 this deadlocked:
+        // the accept loop served connections inline, so the parked connection blocked all
+        // others.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        TaskCompletionSource slowEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use(async (context, next) =>
+        {
+            if (context.Request.Path.ToString() == "/slow")
+            {
+                slowEntered.TrySetResult();
+                await release.Task.WaitAsync(context.RequestCancelled);
+            }
+
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+
+            byte[] payload = Encoding.UTF8.GetBytes(context.Request.Path.ToString());
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        // Distinct clients own distinct connection pools, so the two requests are guaranteed
+        // to ride two distinct in-memory connections.
+        using HttpClient slowClient = factory.CreateClient();
+        using HttpClient fastClient = factory.CreateClient();
+
+        // Act — park /slow in the pipeline, then serve /fast on another connection.
+        Task<HttpResponseMessage> slowResponse = slowClient.GetAsync("/slow", cancellationToken);
+        await slowEntered.Task.WaitAsync(cancellationToken);
+
+        using HttpResponseMessage fastResponse = await fastClient.GetAsync("/fast", cancellationToken);
+
+        // Assert — the fast connection completed while the slow one was still parked.
+        fastResponse.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        slowResponse.IsCompleted.ShouldBeFalse();
+
+        // Release the parked request; its connection finishes normally.
+        release.TrySetResult();
+        using HttpResponseMessage completedSlow = await slowResponse.WaitAsync(cancellationToken);
+        completedSlow.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await completedSlow.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("/slow");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Server: StopAsync should wait for an in-flight request to unwind (graceful drain)")]
+    public async Task StopAsync_WithInFlightRequest_ShouldWaitForItToUnwind()
+    {
+        // Arrange — an exchange parked in the pipeline on a test-owned gate that deliberately
+        // ignores cancellation, so the only way StopAsync can complete is by draining it.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use(async (context, next) =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        Task<HttpResponseMessage> requestTask = client.GetAsync("/parked", cancellationToken);
+        await entered.Task.WaitAsync(cancellationToken);
+
+        // Act — begin the stop while the exchange is parked. The drain must not complete
+        // until the in-flight pipeline invocation returns.
+        Task stopTask = factory.StopAsync(CancellationToken.None);
+
+        await Task.Delay(100, cancellationToken);
+        stopTask.IsCompleted.ShouldBeFalse();
+
+        release.TrySetResult();
+        await stopTask.WaitAsync(cancellationToken);
+
+        // Assert — the client's request completes rather than hanging. Whether it observes a
+        // response or a torn-down connection is transport detail: the shutdown token governs
+        // the post-pipeline send, so the connection may close before the response head is
+        // written (cancellation-as-drain — see Web.Hosting docs/DESIGN.md "Stop semantics").
+        try
+        {
+            (await requestTask.WaitAsync(cancellationToken)).Dispose();
+        }
+        catch (HttpRequestException)
+        {
+            // The drained connection closed before a response was delivered — acceptable.
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Server: StopAsync should complete promptly with an idle keep-alive connection parked")]
+    public async Task StopAsync_WithIdleKeepAliveConnection_ShouldCompletePromptly()
+    {
+        // Arrange — a completed request leaves its pooled connection parked in the server's
+        // receive loop; the drain must unblock it rather than hang on the idle client.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+        (await client.GetAsync("/warmup", cancellationToken)).Dispose();
+
+        // Act & Assert — bounded by the test timeout; a drain hung on the idle keep-alive
+        // connection fails the test.
+        await factory.StopAsync(CancellationToken.None).WaitAsync(cancellationToken);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - Server: After StopAsync new connections should be refused")]
+    public async Task StopAsync_AfterStop_ShouldRefuseNewConnections()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+        (await client.GetAsync("/before", cancellationToken)).Dispose();
+
+        // Act — stopping the server disposes the listener chain down to the in-memory
+        // transport listener.
+        await factory.StopAsync(CancellationToken.None).WaitAsync(cancellationToken);
+
+        // Assert — a new request cannot dial the disposed listener.
+        await Should.ThrowAsync<HttpRequestException>(() => client.GetAsync("/after", cancellationToken));
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/README.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/README.md
@@ -1,0 +1,32 @@
+# Assimalign.Cohesion.Web.Testing
+
+Socketless integration testing for Cohesion web applications. `WebApplicationTestFactory`
+composes a `WebApplication` against the in-memory connection driver
+(`Assimalign.Cohesion.Connections.InMemory`) — **no sockets, no ports** — manages its
+lifecycle per test, and hands out `System.Net.Http.HttpClient` instances wired through
+`SocketsHttpHandler.ConnectCallback`, so every request flows the application's full pipeline
+(middleware, routing, features) end to end. This is how Cohesion consumers integration-test
+their services, and how Cohesion itself gets deterministic h1/h2 pipeline tests in CI.
+
+```csharp
+await using WebApplicationTestFactory factory = new();
+
+factory.Builder.AddRouting();
+factory.Application.UseRouting().Map(new Route(HttpMethod.Get, "/widgets", new RouterRouteHandler(async context =>
+{
+    context.Response.StatusCode = HttpStatusCode.Ok;
+    await context.Response.Body.WriteAsync("[]"u8.ToArray(), context.RequestCancelled);
+})));
+
+using HttpClient client = factory.CreateClient(); // starts the server on first use
+
+HttpResponseMessage response = await client.GetAsync("/widgets");
+```
+
+- HTTP/1.1 by default; prior-knowledge HTTP/2 via
+  `new WebApplicationTestFactoryOptions { Protocol = WebApplicationTestProtocol.Http2 }`.
+  HTTP/3 is out of scope (QUIC-bound — see `docs/DESIGN.md`).
+- Factories are fully isolated: run as many as you like in parallel in one process.
+- AOT/trim-safe: pure builder-time delegate wiring over BCL client types, zero reflection.
+
+See [`docs/OVERVIEW.md`](docs/OVERVIEW.md) and [`docs/DESIGN.md`](docs/DESIGN.md).

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/docs/DESIGN.md
@@ -1,0 +1,160 @@
+# Assimalign.Cohesion.Web.Testing — Design
+
+## Design intent
+
+A code-first multi-service framework whose flagship resource is a web server cannot ship
+without socketless full-pipeline testing: it is how every consumer will integration-test
+their services, and how Cohesion itself tests h1/h2 pipeline semantics deterministically in
+CI across three operating systems. `WebApplicationTestFactory` is that surface — the Cohesion
+analogue of ASP.NET's `WebApplicationFactory` / `TestServer`, built instead from two seams
+the framework already ships:
+
+- **Server side** — the builder-time listener registration seam:
+  `builder.Server.UseServer(options => options.UseHttp1(listener))` accepts any
+  `IConnectionListener`, so the in-memory driver's `InMemoryConnectionListener`
+  (`Assimalign.Cohesion.Connections.InMemory`, #772) plugs in with no contract changes.
+- **Client side** — `SocketsHttpHandler.ConnectCallback`: the real .NET HTTP client dials the
+  in-memory listener's bound `InMemoryConnectionFactory` and speaks over the returned
+  duplex-pipe stream.
+
+Nothing in the middle is faked. A test request crosses the real HTTP/1.1 or HTTP/2 wire
+format, the real `HttpConnectionListener` receive loop, the real `WebApplicationServer`
+per-connection dispatch (#762), and the application's real pipeline. What the factory removes
+is only the operating-system socket — and with it, port allocation, loopback flakiness, and
+cross-OS nondeterminism.
+
+## Why the real `SocketsHttpHandler`, not a synthetic message handler
+
+The alternative — a custom `HttpMessageHandler` that invokes the pipeline in process, the
+`TestServer` model — is cheaper per request but skips the transport entirely: no request
+serialization, no header wire casing, no keep-alive/pooling behaviour, no h2 framing or
+stream multiplexing, no connection lifecycle. Those layers are exactly where Cohesion's own
+bugs would live (the transport and server are first-party code here, unlike ASP.NET's
+battle-tested Kestrel), so the factory deliberately buys wire fidelity: the bytes a test
+exercises are the bytes production exercises. The trade-off accepted is a real client
+connection pool in each test — which the isolation model below turns into a feature.
+
+## Composition and drive model
+
+```
+WebApplicationTestFactory
+ ├─ owns InMemoryConnectionListener + its bound InMemoryConnectionFactory
+ ├─ Builder  (WebApplication.CreateBuilder(); ctor registers UseServer → UseHttp1/UseHttp2(listener))
+ ├─ Application  (built lazily on first access; pipeline configured here)
+ └─ CreateClient()
+      └─ SocketsHttpHandler.ConnectCallback ──dials──► factory ──► ClientConnectionStream
+                                                                        (owns the Connection)
+```
+
+**Two-phase configuration, snapshot at start.** Services and features are configured on
+`Builder` before the application is built; the pipeline (`Use`, `UseRouting`, `Map`) is
+configured on `Application` after. When the factory starts it resolves the default
+`IWebApplicationServer` from the application's service provider, which materializes the
+pipeline snapshot — pipeline mutations after start are not observed. This mirrors the
+production composition order rather than inventing a test-only one.
+
+**The factory drives the server, not the host.** Starting resolves and starts the default
+`IWebApplicationServer` directly — the same documented drive path the Web.Hosting test suite
+uses — rather than running the whole `Host` lifecycle. The default server's registration is
+`IWebApplicationServer`-keyed (it is not among the host's `IHostService`s today), and host
+lifecycle orchestration is the hosting epic's concern (#26); the factory stays scoped to
+"serve requests against the pipeline". User-registered `IHostService`s are not started by
+the factory — a deliberate non-goal below.
+
+**Start-on-first-client.** `CreateClient()` starts the factory when it has not been started
+yet (ASP.NET `WebApplicationFactory.CreateClient` parity). The blocking wait inside is safe
+by construction: the default server's `StartAsync` only schedules its accept loop and
+completes synchronously. `StartAsync`/`StopAsync` remain public for tests that assert
+lifecycle behaviour itself.
+
+## Client connection ownership
+
+`ConnectCallback` returns a `ClientConnectionStream` — the connection's duplex-pipe stream
+adapter plus one added responsibility: disposing the stream disposes the dialed
+`Connection`. `SocketsHttpHandler` disposes a pooled connection's stream when it evicts or
+tears down the connection; without the ownership hook the client end's pipes would never
+complete and the server end would stay parked in its receive loop until server shutdown.
+With it, client-side teardown propagates as end-of-stream to the server exactly as a closed
+socket would.
+
+## Protocol scope
+
+- **HTTP/1.1** (default) — `UseHttp1(listener)`; clients speak plain 1.1 with keep-alive and
+  pooling.
+- **HTTP/2, prior knowledge (h2c)** — `UseHttp2(listener)` server-side; clients pin
+  `DefaultRequestVersion = 2.0` with `HttpVersionPolicy.RequestVersionExact`, which makes
+  `SocketsHttpHandler` speak h2 from the first byte over the plaintext stream — no TLS, no
+  ALPN, no Upgrade dance. Streams multiplex over the single in-memory duplex pair; the test
+  suite pins that concurrent requests share one connection.
+- **HTTP/3 — out of scope.** h3 is QUIC-bound end to end: `UseHttp3` takes an
+  `IMultiplexedConnectionListener` (the driver's multiplexed variant could serve it), but
+  `SocketsHttpHandler` offers no client seam to substitute an in-memory multiplexed
+  transport — `ConnectCallback` is a stream seam, and the client's h3 stack rides real QUIC.
+  A meaningful h3 test surface therefore needs a QUIC-over-memory story (and likely a
+  Cohesion-native h3 test client), tracked alongside the HTTP/3 registration surface (#767).
+  Until then, h3 wire behaviour stays covered by the transport's own protocol tests.
+
+TLS-over-memory is likewise not modeled: the security library's `UseTls` layer can compose
+over an in-memory pair as over any transport, but certificate-trusting client plumbing adds
+ceremony the socketless factory exists to remove. Scheme-dependent behaviour is better
+tested at the unit level or over the loopback TLS integration tests that already exist in
+Web.Hosting.
+
+## Lifecycle contract
+
+| Phase | What happens |
+| --- | --- |
+| Construct | Listener + dial factory created; `Builder` prepared with the in-memory `UseServer` registration. Nothing runs. |
+| `Application` access | `Builder.Build()` (once, thread-safe). |
+| `StartAsync` / first `CreateClient` | Default server resolved (pipeline snapshot) and started; accept loop live. Idempotent. |
+| `StopAsync` | Server's graceful stop: stop accepting, drain in-flight connections, dispose the listener chain. New dials are refused (`ConnectionAbortedException` → client `HttpRequestException`). Idempotent; no-op before start. |
+| `DisposeAsync` | `StopAsync`, then application disposal, then defensive in-memory listener teardown (idempotent for the never-started factory). Safe to call twice. |
+
+Stop semantics — including cancellation-as-drain for in-flight exchanges — are owned and
+documented by Web.Hosting (`docs/DESIGN.md`, "Stop semantics"); the factory adds no policy of
+its own on top.
+
+## Parallel test isolation
+
+Each factory owns a private listener, dial factory, and application. Because the router
+builder is per-application state (#789 — `AddRouting` registers a per-application
+`IRouterFeature`, and `UseRouting` resolves that same feature), two factories in one process
+share no route tables, middleware, or connections. The test suite guards this end to end:
+two live factories with disjoint route maps serve their own routes and 404 each other's,
+sequentially and concurrently. This is what makes the factory safe under parallel xUnit
+execution — the intended usage, not an edge case.
+
+## AOT posture
+
+`IsAotCompatible=true` holds with no special handling and **zero reflection**: composition is
+plain delegate wiring over the builder seams, the client is BCL `SocketsHttpHandler` +
+`HttpClient`, and the connection stream is a pipe adapter. No runtime code generation, no
+`Assembly.LoadFrom`, no reflection-based serialization — unlike ASP.NET's
+`WebApplicationFactory<TEntryPoint>`, there is no entry-point discovery via reflection;
+composition is explicit on the factory's `Builder`/`Application`.
+
+## Non-goals
+
+- **HTTP/3 / QUIC-over-memory** — see "Protocol scope" above; tracked with #767.
+- **Full host lifecycle orchestration.** The factory starts the default web server only; it
+  does not run `IHost.StartAsync` or user-registered `IHostService`s. When the hosting
+  integration epic (#26) lands a canonical "run the whole host" path, the factory can grow
+  an opt-in for it.
+- **TLS composition over the in-memory pair** — compose `Connections.Security` directly in a
+  dedicated test if ever needed; the factory stays plaintext.
+- **Assertion/fixture surface.** No response-assertion helpers, no xUnit fixtures — hosting
+  only, so the package stays framework-neutral.
+- **Client tracking.** The caller owns clients from `CreateClient` and disposes them;
+  factory disposal tears down the server side regardless, so a leaked client cannot leak a
+  server-side connection past the drain.
+
+## Relationships
+
+- **`Assimalign.Cohesion.Connections.InMemory`** — the transport this factory rides; its
+  `docs/DESIGN.md` records the pair wiring, teardown semantics, and dial/accept model.
+- **`Assimalign.Cohesion.Web.Hosting`** — the composition root and server whose lifecycle the
+  factory manages; its `docs/DESIGN.md` owns the dispatch and stop semantics the factory's
+  drain relies on. Web.Hosting's integration test suite consumes this package for its
+  middleware-ordering, per-connection-concurrency, and graceful-shutdown coverage.
+- **`Assimalign.Cohesion.Web.Routing`** — per-application router state (#789) is what makes
+  the parallel-isolation guarantee hold; the isolation regression tests live here.

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/docs/OVERVIEW.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/docs/OVERVIEW.md
@@ -1,0 +1,71 @@
+# Assimalign.Cohesion.Web.Testing — Overview
+
+## Purpose
+
+Full-pipeline integration testing for Cohesion web applications without an operating-system
+socket. The package's one entry point, `WebApplicationTestFactory`, composes a
+`WebApplication` whose default server listens on the in-memory connection driver, manages the
+server's lifecycle per test (start on first use, graceful drain on dispose), and creates
+`System.Net.Http.HttpClient` instances that dial the in-memory listener through
+`SocketsHttpHandler.ConnectCallback`. A request sent through such a client crosses the real
+HTTP wire format, the real transport receive loop, the real server dispatch, and the
+application's real middleware pipeline — deterministically, on every CI operating system,
+with no ports to allocate or collide on.
+
+## Scope
+
+- `IWebApplicationTestFactory` / `WebApplicationTestFactory` — the per-test application host.
+- `WebApplicationTestFactoryOptions` — protocol selection and client base address.
+- `WebApplicationTestProtocol` — `Http1` (default) or prior-knowledge `Http2`. HTTP/3 is a
+  documented non-goal (see `DESIGN.md`).
+
+The factory intentionally has no assertion helpers, no fixture base classes, and no test
+framework coupling — it composes and hosts; the test framework and assertion library are the
+caller's business.
+
+## Usage
+
+```csharp
+await using WebApplicationTestFactory factory = new();
+
+// 1. Builder-time configuration (services, features, extra listener options).
+factory.Builder.AddRouting();
+
+// 2. Pipeline configuration on the built application.
+factory.Application.Use(async (context, next) =>
+{
+    context.Response.StatusCode = HttpStatusCode.Ok;
+    await context.Response.Body.WriteAsync("hello"u8.ToArray(), context.RequestCancelled);
+});
+
+// 3. Send requests; the server starts on the first client.
+using HttpClient client = factory.CreateClient();
+string payload = await client.GetStringAsync("/");
+```
+
+Prior-knowledge HTTP/2 over the same in-memory pair:
+
+```csharp
+await using WebApplicationTestFactory factory = new(new WebApplicationTestFactoryOptions
+{
+    Protocol = WebApplicationTestProtocol.Http2,
+});
+```
+
+## Dependencies
+
+- `Assimalign.Cohesion.Web.Hosting` — the `WebApplicationBuilder` / `WebApplication`
+  composition root the factory drives.
+- `Assimalign.Cohesion.Http.Connections` — the `UseHttp1` / `UseHttp2` listener registration
+  seams.
+- `Assimalign.Cohesion.Connections.InMemory` — the in-memory transport driver (listener +
+  dialing factory).
+- `Assimalign.Cohesion.Connections` — the `Connection` contract and duplex-pipe stream
+  adapter the client side rides.
+
+The client side is otherwise pure BCL (`SocketsHttpHandler`, `HttpClient`).
+
+## Design
+
+See [`DESIGN.md`](DESIGN.md) for the composition model, lifecycle contract, protocol scope
+(including why HTTP/3 is out), parallel-isolation guarantees, and AOT posture.

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/Abstractions/IWebApplicationTestFactory.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/Abstractions/IWebApplicationTestFactory.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Testing;
+
+/// <summary>
+/// A per-test host for a Cohesion web application: it boots the application against an
+/// in-memory connection listener — no sockets, no ports — manages the server's lifecycle,
+/// and hands out <see cref="HttpClient"/> instances whose requests flow the application's
+/// full pipeline (middleware, routing, features) end to end.
+/// </summary>
+/// <remarks>
+/// Factories are independent: multiple factories in one process share no listener, router,
+/// or pipeline state, so tests can run in parallel. Dispose the factory when the test
+/// completes; disposal stops the server (draining in-flight connections) and tears down the
+/// in-memory transport.
+/// </remarks>
+public interface IWebApplicationTestFactory : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the web application under test. Accessing this member builds the application if
+    /// it has not been built yet; configure the request pipeline on it before the factory
+    /// starts serving.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the factory has been disposed.</exception>
+    IWebApplication Application { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the factory's server has been started.
+    /// </summary>
+    bool IsStarted { get; }
+
+    /// <summary>
+    /// Builds the application if needed and starts its server against the in-memory
+    /// listener. Starting an already-started factory is a no-op.
+    /// </summary>
+    /// <param name="cancellationToken">Aborts the start if signaled.</param>
+    /// <returns>A task that completes when the server is accepting in-memory connections.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the factory has been disposed.</exception>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the factory's server: no further connections are accepted and in-flight
+    /// connections are drained. Stopping a never-started or already-stopped factory is a
+    /// no-op.
+    /// </summary>
+    /// <param name="cancellationToken">The caller's shutdown budget.</param>
+    /// <returns>A task that completes when the server has fully drained.</returns>
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> that dials the factory's in-memory listener,
+    /// starting the factory first when it is not started yet. The caller owns the returned
+    /// client and should dispose it.
+    /// </summary>
+    /// <returns>A client whose requests are served by the application under test.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the factory has been disposed.</exception>
+    HttpClient CreateClient();
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/Assimalign.Cohesion.Web.Testing.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/Assimalign.Cohesion.Web.Testing.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>Socketless integration testing for Cohesion web applications. WebApplicationTestFactory composes a WebApplication against the in-memory connection driver (no sockets, no ports), manages its lifecycle per test, and hands out System.Net.Http.HttpClient instances wired through SocketsHttpHandler.ConnectCallback so requests flow the full pipeline (middleware, routing, features) end to end. Supports HTTP/1.1 and prior-knowledge HTTP/2; AOT-safe, zero reflection.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Hosting" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Connections" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.InMemory" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.DependencyInjection" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/Internal/ClientConnectionStream.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/Internal/ClientConnectionStream.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections;
+
+namespace Assimalign.Cohesion.Web.Testing.Internal;
+
+/// <summary>
+/// The client-side stream handed to <see cref="System.Net.Http.SocketsHttpHandler"/>'s
+/// <c>ConnectCallback</c>: adapts a dialed in-memory connection's duplex pipe as a
+/// <see cref="Stream"/> and takes ownership of the connection, so the HTTP client pool
+/// releasing the stream gracefully closes the connection — the server end observes
+/// end-of-stream and unwinds its receive loop instead of parking until server shutdown.
+/// </summary>
+internal sealed class ClientConnectionStream : Stream
+{
+    private readonly Connection _connection;
+    private readonly Stream _inner;
+
+    public ClientConnectionStream(Connection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        _connection = connection;
+        _inner = connection.AsStream();
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanWrite => true;
+
+    public override bool CanSeek => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => _inner.Read(buffer, offset, count);
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.ReadAsync(buffer, cancellationToken);
+
+    public override void Write(byte[] buffer, int offset, int count)
+        => _inner.Write(buffer, offset, count);
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.WriteAsync(buffer, cancellationToken);
+
+    public override void Flush() => _inner.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+        => _inner.FlushAsync(cancellationToken);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // The in-memory connection's disposal completes synchronously (it only completes
+            // pipe ends), so blocking on it here cannot deadlock.
+            _connection.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestFactory.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestFactory.cs
@@ -1,0 +1,271 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections;
+using Assimalign.Cohesion.Connections.InMemory;
+using Assimalign.Cohesion.DependencyInjection;
+using Assimalign.Cohesion.Web.Hosting;
+using Assimalign.Cohesion.Web.Testing.Internal;
+
+namespace Assimalign.Cohesion.Web.Testing;
+
+/// <summary>
+/// Composes a <see cref="WebApplication"/> whose default server listens on the in-memory
+/// connection driver — no sockets, no ports — and creates <see cref="HttpClient"/> instances
+/// wired through <see cref="SocketsHttpHandler.ConnectCallback"/> to dial that listener, so
+/// every request flows the application's full pipeline (middleware, routing, features) end
+/// to end.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The intended flow is: construct the factory, configure services on <see cref="Builder"/>,
+/// configure the request pipeline on <see cref="Application"/>, then call
+/// <see cref="CreateClient"/> (which starts the server on first use) and send requests.
+/// The pipeline snapshot is taken when the server starts, so all
+/// <c>Use</c>/<c>UseRouting</c>/<c>Map</c> calls must happen before the factory starts
+/// serving.
+/// </para>
+/// <para>
+/// Each factory owns a private <see cref="InMemoryConnectionListener"/> and a private
+/// application instance (including per-application router state), so multiple factories in
+/// one process are fully isolated and safe to run in parallel. Disposal stops the server —
+/// draining in-flight connections per the Web.Hosting stop semantics — and tears down the
+/// in-memory transport.
+/// </para>
+/// <para>
+/// The factory is AOT/trim-safe: composition is plain delegate wiring over the builder
+/// seams, and the client side rides BCL types (<see cref="SocketsHttpHandler"/> over a
+/// duplex-pipe stream). No reflection anywhere.
+/// </para>
+/// </remarks>
+public sealed class WebApplicationTestFactory : IWebApplicationTestFactory
+{
+    private readonly WebApplicationTestFactoryOptions _options;
+    private readonly InMemoryConnectionListener _listener;
+    private readonly InMemoryConnectionFactory _connectionFactory;
+    private readonly Lock _gate = new();
+
+    private WebApplication? _application;
+    private IWebApplicationServer? _server;
+    private bool _isStarted;
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Initializes a new factory serving HTTP/1.1 over the in-memory transport.
+    /// </summary>
+    public WebApplicationTestFactory() : this(new WebApplicationTestFactoryOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new factory with the supplied options.
+    /// </summary>
+    /// <param name="options">The factory options (protocol, base address).</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="options"/> or its <see cref="WebApplicationTestFactoryOptions.BaseAddress"/>
+    /// is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <see cref="WebApplicationTestFactoryOptions.Protocol"/> is not a defined
+    /// <see cref="WebApplicationTestProtocol"/> value.
+    /// </exception>
+    public WebApplicationTestFactory(WebApplicationTestFactoryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.BaseAddress);
+
+        if (options.Protocol is not (WebApplicationTestProtocol.Http1 or WebApplicationTestProtocol.Http2))
+        {
+            throw new ArgumentException(
+                $"'{options.Protocol}' is not a supported test protocol. HTTP/3 is out of scope for the in-memory factory (see docs/DESIGN.md).",
+                nameof(options));
+        }
+
+        _options = options;
+        _listener = new InMemoryConnectionListener();
+        _connectionFactory = _listener.CreateFactory();
+
+        Builder = WebApplication.CreateBuilder();
+        Builder.Server.UseServer(listenerOptions =>
+        {
+            if (_options.Protocol == WebApplicationTestProtocol.Http2)
+            {
+                listenerOptions.UseHttp2(_listener);
+            }
+            else
+            {
+                listenerOptions.UseHttp1(_listener);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Gets the application builder, for service/configuration registration before the
+    /// application is built (for example <c>Builder.AddRouting()</c> or additional
+    /// <c>Builder.Server.UseServer(...)</c> listener configuration).
+    /// </summary>
+    public WebApplicationBuilder Builder { get; }
+
+    /// <summary>
+    /// Gets the web application under test, building it on first access. Configure the
+    /// request pipeline (<c>Use</c>, <c>UseRouting</c>, <c>Map</c>) through this member
+    /// before the factory starts serving — the pipeline snapshot is taken at server start.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the factory has been disposed.</exception>
+    public WebApplication Application
+    {
+        get
+        {
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+                return _application ??= Builder.Build();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsStarted
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _isStarted;
+            }
+        }
+    }
+
+    IWebApplication IWebApplicationTestFactory.Application => Application;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        IWebApplicationServer server;
+
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+            _application ??= Builder.Build();
+
+            // Resolving the server materializes the pipeline snapshot; the resolved instance
+            // is the default server the constructor wired onto the in-memory listener. The
+            // server's own start is idempotent, so a concurrent double-start is safe.
+            _server ??= _application.Context.ServiceProvider.GetRequiredService<IWebApplicationServer>();
+            _isStarted = true;
+
+            server = _server;
+        }
+
+        return server.StartAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        IWebApplicationServer? server;
+
+        lock (_gate)
+        {
+            server = _isStarted ? _server : null;
+        }
+
+        return server?.StopAsync(cancellationToken) ?? Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// When the factory has not started yet, this member starts it first. The default
+    /// server's start only schedules its accept loop and completes synchronously, so the
+    /// blocking wait here cannot deadlock; it keeps <see cref="CreateClient"/> a one-call
+    /// entry point.
+    /// </remarks>
+    public HttpClient CreateClient()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+        }
+
+        if (!IsStarted)
+        {
+            StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        SocketsHttpHandler handler = new()
+        {
+            ConnectCallback = (_, cancellationToken) => DialAsync(cancellationToken),
+        };
+
+        HttpClient client = new(handler, disposeHandler: true)
+        {
+            BaseAddress = _options.BaseAddress,
+        };
+
+        if (_options.Protocol == WebApplicationTestProtocol.Http2)
+        {
+            // Prior-knowledge HTTP/2 over the plaintext in-memory stream: an exact 2.0
+            // version policy makes SocketsHttpHandler speak h2 from the first byte with no
+            // TLS/ALPN negotiation and no Upgrade dance.
+            client.DefaultRequestVersion = HttpVersion.Version20;
+            client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// Stops the server when started (draining in-flight connections), disposes the
+    /// application, and tears down the in-memory listener. Disposal is idempotent.
+    /// </summary>
+    /// <returns>A task that completes when the factory has fully torn down.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        IWebApplicationServer? server;
+        WebApplication? application;
+
+        lock (_gate)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            server = _isStarted ? _server : null;
+            application = _application;
+        }
+
+        if (server is not null)
+        {
+            // Graceful stop: stops accepting, drains in-flight connections, and disposes
+            // the HTTP connection listener (which releases the transport listener).
+            await server.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        if (application is not null)
+        {
+            // Stops any user-registered host services; a never-started host no-ops.
+            await ((IAsyncDisposable)application).DisposeAsync().ConfigureAwait(false);
+        }
+
+        // Defensive teardown for the never-started path; the in-memory listener's disposal
+        // is idempotent when the server already released it.
+        await _listener.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async ValueTask<Stream> DialAsync(CancellationToken cancellationToken)
+    {
+        Connection connection = await _connectionFactory
+            .ConnectAsync(_listener.EndPoint, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ClientConnectionStream(connection);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestFactoryOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestFactoryOptions.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Testing;
+
+/// <summary>
+/// Options controlling how a <see cref="WebApplicationTestFactory"/> composes and serves the
+/// application under test.
+/// </summary>
+public sealed class WebApplicationTestFactoryOptions
+{
+    /// <summary>
+    /// Gets or sets the HTTP protocol served over the in-memory transport. Defaults to
+    /// <see cref="WebApplicationTestProtocol.Http1"/>.
+    /// </summary>
+    public WebApplicationTestProtocol Protocol { get; set; } = WebApplicationTestProtocol.Http1;
+
+    /// <summary>
+    /// Gets or sets the base address stamped on clients the factory creates. Defaults to
+    /// <c>http://localhost/</c>.
+    /// </summary>
+    /// <remarks>
+    /// The authority is nominal: it shapes the request URI (and therefore the <c>Host</c>
+    /// header the application observes) but is never resolved — every connection dials the
+    /// factory's in-memory listener regardless of host or port.
+    /// </remarks>
+    public Uri BaseAddress { get; set; } = new Uri("http://localhost/");
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestProtocol.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/src/WebApplicationTestProtocol.cs
@@ -1,0 +1,26 @@
+namespace Assimalign.Cohesion.Web.Testing;
+
+/// <summary>
+/// The HTTP protocol a <see cref="WebApplicationTestFactory"/> serves over the in-memory
+/// transport.
+/// </summary>
+/// <remarks>
+/// HTTP/3 is deliberately absent: it is QUIC-bound (transport security and stream lifecycle
+/// are inherent to the protocol), so an HTTP/3 test surface stays out of scope until
+/// QUIC-over-memory is meaningful — see the project's <c>docs/DESIGN.md</c> and the HTTP/3
+/// registration surface tracked under issue #767.
+/// </remarks>
+public enum WebApplicationTestProtocol
+{
+    /// <summary>
+    /// HTTP/1.1 over the in-memory duplex pair. The default.
+    /// </summary>
+    Http1 = 0,
+
+    /// <summary>
+    /// Prior-knowledge HTTP/2 (h2c) over the in-memory duplex pair: the client speaks
+    /// HTTP/2 from the first byte with no TLS/ALPN negotiation and no Upgrade dance,
+    /// multiplexing request streams over the single in-memory connection.
+    /// </summary>
+    Http2 = 1,
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/tests/Assimalign.Cohesion.Web.Testing.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/tests/Assimalign.Cohesion.Web.Testing.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Hosting" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Routing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryHttp2Tests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryHttp2Tests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Hosting;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Web.Testing.Tests;
+
+/// <summary>
+/// Prior-knowledge HTTP/2 (h2c) coverage for <see cref="WebApplicationTestFactory"/>: the
+/// factory registers the in-memory listener through <c>UseHttp2</c> and its clients pin an
+/// exact 2.0 version policy, so the exchange is HTTP/2 from the first byte over the plaintext
+/// in-memory duplex pair — no TLS, no ALPN, no Upgrade dance. HTTP/3 is out of scope for the
+/// factory (QUIC-bound; see docs/DESIGN.md).
+/// </summary>
+public class WebApplicationTestFactoryHttp2Tests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - Http2: Should serve a prior-knowledge HTTP/2 request over the in-memory pair")]
+    public async Task CreateClient_Http2Factory_ShouldServePriorKnowledgeHttp2()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new(new WebApplicationTestFactoryOptions
+        {
+            Protocol = WebApplicationTestProtocol.Http2,
+        });
+
+        factory.Application.Use(async (context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+
+            byte[] payload = Encoding.UTF8.GetBytes("served over h2");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/h2", cancellationToken);
+
+        // Assert — the negotiated client version proves prior-knowledge h2 end to end.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        response.Version.ShouldBe(NetHttpVersion.Version20);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("served over h2");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - Http2: Concurrent requests should multiplex streams over one in-memory connection")]
+    public async Task CreateClient_Http2ConcurrentRequests_ShouldMultiplexOverOneConnection()
+    {
+        // Arrange — the in-memory driver mints a distinct ephemeral endpoint per dialed
+        // connection, so a single observed remote endpoint across concurrent exchanges proves
+        // the client multiplexed them as streams of one HTTP/2 connection.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new(new WebApplicationTestFactoryOptions
+        {
+            Protocol = WebApplicationTestProtocol.Http2,
+        });
+
+        ConcurrentQueue<string?> observedConnections = new();
+        factory.Application.Use((context, next) =>
+        {
+            observedConnections.Enqueue(context.ConnectionInfo.RemoteEndPoint?.ToString());
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        Task<HttpResponseMessage> first = client.GetAsync("/one", cancellationToken);
+        Task<HttpResponseMessage> second = client.GetAsync("/two", cancellationToken);
+
+        HttpResponseMessage[] responses = await Task.WhenAll(first, second);
+
+        // Assert
+        foreach (HttpResponseMessage response in responses)
+        {
+            response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+            response.Version.ShouldBe(NetHttpVersion.Version20);
+            response.Dispose();
+        }
+
+        observedConnections.Count.ShouldBe(2);
+        observedConnections.Distinct().Count().ShouldBe(1);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryIsolationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryIsolationTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Hosting;
+using Assimalign.Cohesion.Web.Routing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Testing.Tests;
+
+/// <summary>
+/// Parallel test isolation: multiple factories in one process must not share state. This is
+/// the end-to-end regression guard for the per-application router state fix (#789) — before
+/// that fix, <c>UseRouting</c> returned a process-wide shared <c>RouterBuilder</c>, so routes
+/// mapped through one application leaked into every other application in the process. Here two
+/// live factories each map their own route and serve real requests over their own in-memory
+/// listeners; neither observes the other's routes, middleware, or connections.
+/// </summary>
+public class WebApplicationTestFactoryIsolationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - Isolation: Two factories in one process keep isolated router state (#789 regression)")]
+    public async Task TwoFactories_InOneProcess_ShouldKeepIsolatedRouterState()
+    {
+        // Arrange — factory A knows only /alpha; factory B knows only /beta. Each terminates
+        // unmatched requests with 404 (the pre-#881 application-authored terminal).
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factoryA = CreateRoutedFactory("/alpha", "alpha payload");
+        await using WebApplicationTestFactory factoryB = CreateRoutedFactory("/beta", "beta payload");
+
+        using HttpClient clientA = factoryA.CreateClient();
+        using HttpClient clientB = factoryB.CreateClient();
+
+        // Act & Assert — each application serves its own route...
+        using (HttpResponseMessage response = await clientA.GetAsync("/alpha", cancellationToken))
+        {
+            response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+            (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("alpha payload");
+        }
+
+        using (HttpResponseMessage response = await clientB.GetAsync("/beta", cancellationToken))
+        {
+            response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+            (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("beta payload");
+        }
+
+        // ...and the other application's route never leaked into its table.
+        using (HttpResponseMessage response = await clientA.GetAsync("/beta", cancellationToken))
+        {
+            response.StatusCode.ShouldBe(NetHttpStatusCode.NotFound);
+        }
+
+        using (HttpResponseMessage response = await clientB.GetAsync("/alpha", cancellationToken))
+        {
+            response.StatusCode.ShouldBe(NetHttpStatusCode.NotFound);
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - Isolation: Concurrent requests against two factories do not cross-talk")]
+    public async Task TwoFactories_ConcurrentRequests_ShouldNotCrossTalk()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factoryA = CreateRoutedFactory("/alpha", "alpha payload");
+        await using WebApplicationTestFactory factoryB = CreateRoutedFactory("/beta", "beta payload");
+
+        using HttpClient clientA = factoryA.CreateClient();
+        using HttpClient clientB = factoryB.CreateClient();
+
+        // Act — interleave both applications from one process concurrently.
+        Task<string> alpha = clientA.GetStringAsync("/alpha", cancellationToken);
+        Task<string> beta = clientB.GetStringAsync("/beta", cancellationToken);
+
+        string[] payloads = await Task.WhenAll(alpha, beta);
+
+        // Assert
+        payloads[0].ShouldBe("alpha payload");
+        payloads[1].ShouldBe("beta payload");
+    }
+
+    /// <summary>
+    /// Composes a factory whose application maps exactly one GET route writing
+    /// <paramref name="payload"/>, with a trailing 404 terminal for unmatched requests.
+    /// </summary>
+    private static WebApplicationTestFactory CreateRoutedFactory(string pattern, string payload)
+    {
+        WebApplicationTestFactory factory = new();
+
+        factory.Builder.AddRouting();
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(CohesionHttpMethod.Get, pattern, new RouterRouteHandler(async context =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(payload), context.RequestCancelled);
+        })));
+
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.NotFound;
+            return next.Invoke(context);
+        });
+
+        return factory;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Testing/tests/WebApplicationTestFactoryTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Hosting;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Web.Testing.Tests;
+
+/// <summary>
+/// End-to-end coverage for <see cref="WebApplicationTestFactory"/> over HTTP/1.1: requests from
+/// the factory's <see cref="HttpClient"/> dial the in-memory listener — no sockets, no ports —
+/// and flow the composed application's full pipeline.
+/// </summary>
+public class WebApplicationTestFactoryTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - CreateClient: Should flow a request through the full pipeline end to end")]
+    public async Task CreateClient_GetRequest_ShouldFlowFullPipelineEndToEnd()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        string? observedPath = null;
+        factory.Application.Use(async (context, next) =>
+        {
+            observedPath = context.Request.Path.ToString();
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+
+            byte[] payload = Encoding.UTF8.GetBytes("hello from the pipeline");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/probe", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        response.Version.ShouldBe(NetHttpVersion.Version11);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("hello from the pipeline");
+        observedPath.ShouldBe("/probe");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - CreateClient: Should stream the request body through the pipeline (echo)")]
+    public async Task CreateClient_PostRequest_ShouldEchoRequestBody()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.Use(async (context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            await context.Request.Body.CopyToAsync(context.Response.Body, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+        using StringContent content = new("echo me through the in-memory transport", Encoding.UTF8);
+
+        // Act
+        using HttpResponseMessage response = await client.PostAsync("/echo", content, cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("echo me through the in-memory transport");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - CreateClient: Sequential requests should reuse one keep-alive connection")]
+    public async Task CreateClient_SequentialRequests_ShouldReuseKeepAliveConnection()
+    {
+        // Arrange — the in-memory driver mints a distinct ephemeral client endpoint per dialed
+        // connection, so the remote endpoint the server observes identifies the connection.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        ConcurrentQueue<string?> observedConnections = new();
+        factory.Application.Use((context, next) =>
+        {
+            observedConnections.Enqueue(context.ConnectionInfo.RemoteEndPoint?.ToString());
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act — sequential requests on one client ride the pooled keep-alive connection.
+        (await client.GetAsync("/first", cancellationToken)).Dispose();
+        (await client.GetAsync("/second", cancellationToken)).Dispose();
+
+        // Assert
+        observedConnections.Count.ShouldBe(2);
+        observedConnections.Distinct().Count().ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - CreateClient: Should start the factory when it has not been started yet")]
+    public async Task CreateClient_BeforeStart_ShouldStartTheFactory()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        factory.IsStarted.ShouldBeFalse();
+
+        // Act
+        using HttpClient client = factory.CreateClient();
+
+        // Assert
+        factory.IsStarted.ShouldBeTrue();
+        using HttpResponseMessage response = await client.GetAsync("/", cancellationToken);
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - StartAsync: Repeated starts should be idempotent")]
+    public async Task StartAsync_CalledTwice_ShouldBeIdempotent()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        // Act
+        await factory.StartAsync(cancellationToken);
+        await factory.StartAsync(cancellationToken);
+
+        // Assert — the factory still serves normally.
+        using HttpClient client = factory.CreateClient();
+        using HttpResponseMessage response = await client.GetAsync("/", cancellationToken);
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - DisposeAsync: Should stop serving and refuse new dials")]
+    public async Task DisposeAsync_AfterServing_ShouldRefuseNewDials()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        WebApplicationTestFactory factory = new();
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+        (await client.GetAsync("/before", cancellationToken)).Dispose();
+
+        // Act
+        await factory.DisposeAsync();
+        await factory.DisposeAsync(); // double dispose is safe
+
+        // Assert — the listener is torn down, so a new request cannot connect.
+        await Should.ThrowAsync<HttpRequestException>(() => client.GetAsync("/after", cancellationToken));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - DisposeAsync: Should drain promptly with an idle keep-alive connection parked")]
+    public async Task DisposeAsync_WithIdleKeepAliveConnection_ShouldCompletePromptly()
+    {
+        // Arrange — after a completed request the pooled connection parks idle in the server's
+        // receive loop; disposal must unblock it rather than hang the drain on it.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        WebApplicationTestFactory factory = new();
+        factory.Application.Use((context, next) =>
+        {
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            return Task.CompletedTask;
+        });
+
+        using HttpClient client = factory.CreateClient();
+        (await client.GetAsync("/", cancellationToken)).Dispose();
+
+        // Act & Assert — bounded by the test timeout; a hung drain fails the test.
+        await factory.DisposeAsync().AsTask().WaitAsync(cancellationToken);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Testing] - Options: An out-of-range protocol should be rejected at construction")]
+    public void Constructor_UndefinedProtocol_ShouldThrowArgumentException()
+    {
+        // Arrange
+        WebApplicationTestFactoryOptions options = new()
+        {
+            Protocol = (WebApplicationTestProtocol)42,
+        };
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => new WebApplicationTestFactory(options));
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.slnx
+++ b/resources/Web/Assimalign.Cohesion.Web.slnx
@@ -170,6 +170,19 @@
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Sessions/tests/">
 		<Project Path="Assimalign.Cohesion.Web.Sessions/tests/Assimalign.Cohesion.Web.Sessions.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Testing/">
+		<File Path="Assimalign.Cohesion.Web.Testing/README.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Testing/docs/">
+		<File Path="Assimalign.Cohesion.Web.Testing/docs/DESIGN.md" />
+		<File Path="Assimalign.Cohesion.Web.Testing/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Testing/src/">
+		<Project Path="Assimalign.Cohesion.Web.Testing/src/Assimalign.Cohesion.Web.Testing.csproj" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Testing/tests/">
+		<Project Path="Assimalign.Cohesion.Web.Testing/tests/Assimalign.Cohesion.Web.Testing.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Web/refs/" >
 		<Project Path="../../libraries/Http/Assimalign.Cohesion.Http/src/Assimalign.Cohesion.Http.csproj" />
 		<Project Path="../../libraries/Core/Assimalign.Cohesion.Core/src/Assimalign.Cohesion.Core.csproj" />


### PR DESCRIPTION
## Summary

Builds `resources/Web/Assimalign.Cohesion.Web.Testing` (#793, Stage 2 · Lane E): socketless full-pipeline integration testing over the merged Connections.InMemory driver (#772) and the #762 server rewrite.

- **`WebApplicationTestFactory`** (+ `IWebApplicationTestFactory`, `WebApplicationTestFactoryOptions`, `WebApplicationTestProtocol`) composes a `WebApplication` at builder time via `builder.Server.UseServer(options => options.UseHttp1/UseHttp2(inMemoryListener))` — no sockets, no ports — and manages lifecycle per test: build-on-access, start-on-first-client (the default server's start completes synchronously), graceful drain on stop/dispose, idempotent throughout.
- **Client side rides BCL types**: `CreateClient()` returns a real `HttpClient` over `SocketsHttpHandler.ConnectCallback` dialing the listener's bound `InMemoryConnectionFactory`; an internal connection-owning stream propagates client pool teardown to the server as end-of-stream. AOT/trim-safe, **zero reflection** (explicitly contrasted with ASP.NET's reflective entry-point discovery in `docs/DESIGN.md`).
- **Protocols**: HTTP/1.1 default; **prior-knowledge h2** via exact-2.0 version policy, with a test pinning that concurrent requests multiplex streams over one in-memory duplex pair. **h3 documented out of scope** in `docs/DESIGN.md` (QUIC-bound; no client seam via `ConnectCallback`; tracked alongside #767).
- **Parallel test isolation** is regression-guarded end to end: two live factories with disjoint route maps serve their own routes and 404 each other's, sequentially and concurrently — the e2e guard for the per-application router state fix (#789).
- **Web.Hosting/tests** gains the full-pipeline integration suite the issue called for, driven through the factory: middleware onion ordering + short-circuiting + application-fault isolation (one connection, not the server), per-connection dispatch (a parked connection starves nobody — the #762 property), and graceful shutdown draining (in-flight unwind, idle keep-alive unblock, post-stop connection refusal per the documented cancellation-as-drain semantics).

### Enabling fix in Web.Hosting (called out for review)

The first true full-pipeline tests exposed that `WebApplication.Init()` — the middleware copying DI-registered `IHttpFeature`s onto request contexts — was dead code (never invoked), so `AddRouting`'s per-application `IRouterFeature` never reached any exchange and `UseRouting` would throw at request time in the real composition root. `#793`'s acceptance criteria (middleware, **routing, features** flow end-to-end) require it, so this PR replaces the dead path: the pipeline `Build()` now snapshots registered features **once at builder time** and stamps them per exchange (no request-time service location, per the hosting philosophy). Documented in Web.Hosting `docs/DESIGN.md` ("Application feature seeding").

## Verification

| Suite | Result |
| --- | --- |
| Web.Testing tests (new) | 12/12 |
| Web.Hosting tests (43 existing + 7 new integration) | 50/50 |
| Web.Routing tests | 109/109 |
| Web.Health / Web.Forms / Connections.InMemory | 37 + 2 + 23, all pass |
| `resources/Web/Assimalign.Cohesion.Web.slnx` full build | 0 errors |

New project registered in `Assimalign.Cohesion.Web.slnx` + root `Assimalign.Cohesion.slnx`; ships `README.md`, `docs/OVERVIEW.md`, `docs/DESIGN.md`. No framework-manifest change needed (App.Web currently ships only the umbrella + `Assimalign.Cohesion.Web`, same as every other Web feature project).

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)