### PR TITLE
[L01.01.11.29.01] Make Content-Digest verification safe for HTTP/2 streamed request bodies (lazy verify-on-read)

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
@@ -13,6 +13,9 @@
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.InterimResponses" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.ProtocolUpgrade" />
+		<!-- Test-only: proves the Content-Digest verifier's lazy verify-on-read path against the real
+		     h2 frame pump and flow-controlled body pipe (#876). -->
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.DigestFields" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.InMemory" />
 		<CohesionPackageReference Include="coverlet.collector" />

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http2ContentDigestVerificationTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http2ContentDigestVerificationTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Internal.Http2;
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+/// <summary>
+/// Proves the Content-Digest verifier's lazy verify-on-read path (#876) against the real HTTP/2
+/// frame pump and flow-controlled body pipe: a request whose body exceeds what is buffered at
+/// dispatch verifies without stalling the pump (the peer sends the remaining DATA only after the
+/// exchange has dispatched), a mid-stream mismatch surfaces as the typed failure on the terminal
+/// body read and the exchange aborts with <c>RST_STREAM(CANCEL)</c> through the app-owned abort
+/// path, and the HTTP/1.1 eager pre-dispatch <c>400</c> is regression-locked end to end.
+/// </summary>
+public class Http2ContentDigestVerificationTests
+{
+    private const int MaxFrame = 16384;
+    // The octets on the wire before dispatch; the remainder is written only after the application
+    // has observed the dispatched exchange, so it provably was not buffered at dispatch.
+    private const int DispatchedChunk = 8192;
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http2 ContentDigest: A flow-controlled streamed body verifies without stalling the frame pump")]
+    public async Task Http2_OnStreamedBodyWithMatchingDigest_ShouldDispatchVerifyAndComplete()
+    {
+        // Body: 40,000 deterministic octets; only the first 8,192 are on the wire at dispatch.
+        byte[] content = CreateContent(40_000);
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        byte[] opening = Combine(
+            Http2TestSettings.Preface(),
+            Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>()),
+            HeadersFrame(streamId: 1, digest),
+            DataFrames(streamId: 1, content.AsSpan(0, DispatchedChunk), endStreamOnLast: false));
+
+        // completeInput: false — the peer's write side stays open; the rest of the body does not
+        // exist yet as far as the server can observe.
+        TestConnection connection = new(opening, completeInput: false);
+        HttpConnectionListenerOptions options = new();
+        options.Interceptors.Add(HttpDigestFields.CreateContentDigestVerifier());
+        options.UseHttp2(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        // The dispatch itself is the deadlock regression guard: the eager verifier read the body
+        // to completion inside the parse-path hook, on the very pump that delivers the missing
+        // DATA — this MoveNextAsync would never complete. The timeout turns a regression into a
+        // clean failure instead of a hung test run.
+        (await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        IHttpContext context = enumerator.Current;
+
+        // The application consumes what has arrived so far...
+        byte[] first = await ReadExactAsync(context.Request.Body, DispatchedChunk);
+        first.ShouldBe(content.AsSpan(0, DispatchedChunk).ToArray());
+
+        // ...and only now does the peer send the remainder — data the parse-path hook could never
+        // have read. Consumption-driven WINDOW_UPDATEs (issue #750) keep flowing because the pump
+        // was never blocked.
+        await connection.WriteInputAsync(DataFrames(streamId: 1, content.AsSpan(DispatchedChunk), endStreamOnLast: true));
+        connection.CompleteInput();
+
+        byte[] rest = await ReadExactAsync(context.Request.Body, content.Length - DispatchedChunk);
+        rest.ShouldBe(content.AsSpan(DispatchedChunk).ToArray());
+
+        // The terminal read observes end-of-body and resolves the verdict: a match, so a clean EOF.
+        (await ReadTerminalAsync(context.Request.Body)).ShouldBe(0);
+
+        // The exchange completes normally.
+        context.Response.StatusCode = HttpStatusCode.Ok;
+        await httpConnectionContext.SendAsync(context);
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames =
+            HttpProtocolPayloadFactory.ParseHttp2Frames(await connection.ReadOutputAsync());
+        (long FrameType, byte[] Payload) responseHead = frames.First(f => f.FrameType == 1);
+        HttpProtocolPayloadFactory.DecodeLiteralHttp2Headers(responseHead.Payload)[":status"].ShouldBe("200");
+        frames.ShouldNotContain(f => f.FrameType == 3, "a verified exchange must not be reset");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http2 ContentDigest: A streamed-body mismatch surfaces on the terminal read and aborts with RST_STREAM(CANCEL)")]
+    public async Task Http2_OnStreamedBodyWithMismatchedDigest_ShouldThrowTypedFailureAndResetStream()
+    {
+        // The declared digest covers different content than what the peer actually sends.
+        byte[] content = CreateContent(20_000);
+        byte[] declared = CreateContent(20_000);
+        declared[^1] ^= 0xFF;
+        string digest = HttpDigestField.ForContent(declared, HttpDigestAlgorithm.Sha256).Serialize();
+        byte[] opening = Combine(
+            Http2TestSettings.Preface(),
+            Http2TestSettings.RawFrame(0x4, 0, 0, Array.Empty<byte>()),
+            HeadersFrame(streamId: 1, digest),
+            DataFrames(streamId: 1, content.AsSpan(0, DispatchedChunk), endStreamOnLast: false));
+
+        TestConnection connection = new(opening, completeInput: false);
+        HttpConnectionListenerOptions options = new();
+        options.Interceptors.Add(HttpDigestFields.CreateContentDigestVerifier());
+        options.UseHttp2(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        IHttpContext context = enumerator.Current;
+
+        await ReadExactAsync(context.Request.Body, DispatchedChunk);
+        await connection.WriteInputAsync(DataFrames(streamId: 1, content.AsSpan(DispatchedChunk), endStreamOnLast: true));
+        connection.CompleteInput();
+
+        // Every content octet still flows to the application — the verdict cannot exist earlier —
+        // and the terminal read surfaces the typed failure.
+        await ReadExactAsync(context.Request.Body, content.Length - DispatchedChunk);
+        HttpContentDigestMismatchException ex = await Should.ThrowAsync<HttpContentDigestMismatchException>(
+            () => ReadTerminalAsync(context.Request.Body));
+        ex.Algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+
+        // Mid-stream rejection semantics: the body was already consumed, so there is no clean 400
+        // left — the application aborts the exchange, and the transport resets the single stream.
+        context.Cancel();
+        await httpConnectionContext.SendAsync(context);
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+
+        AssertFirstResetStream(
+            HttpProtocolPayloadFactory.ParseHttp2Frames(await connection.ReadOutputAsync()),
+            Http2ErrorCode.Cancel);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http1 ContentDigest: The eager pre-dispatch 400 rejection is preserved end to end")]
+    public async Task Http1_OnMismatchedDigest_ShouldRejectWith400BeforeDispatch()
+    {
+        // HTTP/1.1 keeps the eager buffer-and-replay: the parse path is its own body reader, so
+        // the in-hook full read is free and the mismatch stays a deterministic pre-dispatch 400.
+        byte[] body = Encoding.ASCII.GetBytes("the tampered payload");
+        string digest = HttpDigestField.ForContent(Encoding.ASCII.GetBytes("the original payload"), HttpDigestAlgorithm.Sha256).Serialize();
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            $"POST /upload HTTP/1.1\r\nHost: api.test\r\nContent-Length: {body.Length}\r\nContent-Digest: {digest}\r\n\r\n{Encoding.ASCII.GetString(body)}");
+
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.Interceptors.Add(HttpDigestFields.CreateContentDigestVerifier());
+        options.UseHttp1(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+
+        bool yielded;
+        await using (IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator())
+        {
+            yielded = await enumerator.MoveNextAsync();
+        }
+
+        // No exchange is dispatched; the transport answers the rejection itself.
+        yielded.ShouldBeFalse();
+        string response = Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+        response.ShouldStartWith("HTTP/1.1 400");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http1 ContentDigest: A matching digest replays the body to the application end to end")]
+    public async Task Http1_OnMatchingDigest_ShouldReplayBodyAndComplete()
+    {
+        byte[] body = Encoding.ASCII.GetBytes("payload that matches its digest");
+        string digest = HttpDigestField.ForContent(body, HttpDigestAlgorithm.Sha256).Serialize();
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(
+            $"POST /upload HTTP/1.1\r\nHost: api.test\r\nContent-Length: {body.Length}\r\nContent-Digest: {digest}\r\n\r\n{Encoding.ASCII.GetString(body)}");
+
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.Interceptors.Add(HttpDigestFields.CreateContentDigestVerifier());
+        options.UseHttp1(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext httpConnectionContext = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        await using IAsyncEnumerator<IHttpContext> enumerator = httpConnectionContext.ReceiveAsync().GetAsyncEnumerator();
+
+        (await enumerator.MoveNextAsync()).ShouldBeTrue();
+        IHttpContext context = enumerator.Current;
+
+        // The hook consumed the wire body to hash it; the application observes the replay.
+        byte[] observed = await ReadExactAsync(context.Request.Body, body.Length);
+        observed.ShouldBe(body);
+
+        context.Response.StatusCode = HttpStatusCode.Ok;
+        await httpConnectionContext.SendAsync(context);
+        (await enumerator.MoveNextAsync()).ShouldBeFalse();
+
+        string response = Encoding.ASCII.GetString(await connection.ReadOutputAsync());
+        response.ShouldStartWith("HTTP/1.1 200");
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static byte[] CreateContent(int length)
+    {
+        byte[] content = new byte[length];
+        for (int i = 0; i < content.Length; i++)
+        {
+            content[i] = (byte)(i % 251);
+        }
+        return content;
+    }
+
+    private static byte[] HeadersFrame(int streamId, string contentDigest)
+        => HttpProtocolPayloadFactory.CreateHttp2HeadersFrame(
+            streamId,
+            0x4, // END_HEADERS only — the body follows in DATA frames
+            (":method", "POST"),
+            (":scheme", "https"),
+            (":path", "/upload"),
+            (":authority", "api.test"),
+            ("content-digest", contentDigest));
+
+    /// <summary>
+    /// Builds one or more DATA frames on <paramref name="streamId"/> carrying
+    /// <paramref name="content"/>, each frame no larger than the advertised max frame size, with
+    /// END_STREAM set on the final frame when <paramref name="endStreamOnLast"/> is
+    /// <see langword="true"/>.
+    /// </summary>
+    private static byte[] DataFrames(int streamId, ReadOnlySpan<byte> content, bool endStreamOnLast)
+    {
+        using MemoryStream stream = new();
+        int offset = 0;
+
+        do
+        {
+            int chunk = Math.Min(MaxFrame, content.Length - offset);
+            bool last = offset + chunk == content.Length;
+            byte flags = last && endStreamOnLast ? (byte)0x1 : (byte)0x0;
+            byte[] frame = Http2TestSettings.RawFrame(0x0, flags, streamId, content.Slice(offset, chunk).ToArray());
+            stream.Write(frame, 0, frame.Length);
+            offset += chunk;
+        }
+        while (offset < content.Length);
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Asserts the first <c>RST_STREAM</c> on the wire carries <paramref name="expectedErrorCode"/>.
+    /// Only the first is asserted because the reset removes the stream, so any DATA already in
+    /// flight afterward legitimately draws a follow-up <c>RST_STREAM(STREAM_CLOSED)</c>
+    /// (RFC 9113 §5.1).
+    /// </summary>
+    private static void AssertFirstResetStream(
+        IReadOnlyList<(long FrameType, byte[] Payload)> frames,
+        Http2ErrorCode expectedErrorCode)
+    {
+        foreach ((long frameType, byte[] framePayload) in frames)
+        {
+            if (frameType == 3) // RST_STREAM
+            {
+                framePayload.Length.ShouldBe(4);
+                uint code = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(framePayload);
+                code.ShouldBe((uint)expectedErrorCode);
+                return;
+            }
+        }
+
+        throw new ShouldAssertException("Expected an RST_STREAM frame on the wire, but none was found.");
+    }
+
+    private static async Task<byte[]> ReadExactAsync(Stream stream, int count)
+    {
+        byte[] buffer = new byte[count];
+        int offset = 0;
+
+        while (offset < count)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset));
+            read.ShouldBeGreaterThan(0, $"the body stream ended after {offset} of {count} expected octets");
+            offset += read;
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Issues one read against a body expected to be at end-of-body, returning the transferred
+    /// count — the read on which the lazy verifier resolves its verdict.
+    /// </summary>
+    private static Task<int> ReadTerminalAsync(Stream stream) => stream.ReadAsync(new byte[8], 0, 8);
+
+    private static byte[] Combine(params byte[][] buffers)
+    {
+        using MemoryStream stream = new();
+
+        foreach (byte[] buffer in buffers)
+        {
+            stream.Write(buffer, 0, buffer.Length);
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/README.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/README.md
@@ -3,8 +3,9 @@
 RFC 9530 integrity digest fields for the Cohesion HTTP stack — `Content-Digest`, `Repr-Digest`,
 `Want-Content-Digest`, `Want-Repr-Digest` — as structured-fields value objects with `sha-256` /
 `sha-512` computation and verification (BCL incremental hashing, no reflection), plus an opt-in
-server-side request verifier that rejects a `Content-Digest` mismatch with `400` at parse time
-through the core `IHttpExchangeInterceptor` seam.
+server-side request verifier through the core `IHttpExchangeInterceptor` seam: a `Content-Digest`
+mismatch is a pre-dispatch `400` on HTTP/1.1 and HTTP/3, and on HTTP/2 — whose body streams in
+under flow control — a lazy verify-on-read failure surfaced on the terminal body read.
 
 - `docs/OVERVIEW.md` — purpose, dependencies, usage
 - `docs/DESIGN.md` — value-model placement, algorithm registry, verification model, and scope

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/DESIGN.md
@@ -97,40 +97,74 @@ reflection" mandate literally:
    untouched (nothing this library can verify).
 2. A malformed `Content-Digest` → **fail closed**: throw `HttpRequestRejectedException(400)`. RFC
    9530 §2 lets a recipient either ignore or reject; an *operator-installed verifier* should not
-   silently accept a field it cannot parse.
-3. Otherwise read the (already-materialized) body in full, verify it against every supported digest
-   with constant-time comparison (`CryptographicOperations.FixedTimeEquals`), and either reject a
-   mismatch with `HttpRequestRejectedException(400)` or return a replay stream so the application
-   still observes the body.
+   silently accept a field it cannot parse. Parsing is CPU-only, so this pre-dispatch rejection
+   holds on **every** protocol.
+3. Otherwise verify — in one of two modes, chosen by `context.Version`.
 
-Why **eager buffer-and-replay** rather than a lazy verify-on-read wrapper: on HTTP/1.1 the transport
-already materializes the request body into a `MemoryStream` **before** `AfterRequestBody` runs (and
-catches `HttpRequestRejectedException` on its parse path, ahead of dispatch). Reading it there is
-therefore CPU-only — it adds no wire wait — and lets the rejection happen **before the application
-runs**, so the transport answers a real, deterministic `400` and closes the connection. A lazy
-wrapper would only discover the mismatch mid-application-read, after dispatch, where there is no
-transport-answered status today. The cost is one transient extra copy of the body, bounded by the
-`HttpConnectionListenerLimits.MaxRequestBodySize` cap the request-limits package enforces.
+### Two verification modes, chosen by where the verdict is affordable
 
-Two ordering/coverage notes:
+**Eager buffer-and-replay (HTTP/1.1, HTTP/3).** The hook reads the body in full, verifies against
+every supported digest with constant-time comparison (`CryptographicOperations.FixedTimeEquals`),
+and either rejects a mismatch with `HttpRequestRejectedException(400)` or returns a replay stream
+(`HttpDigestReplayStream`) so the application still observes the body. The rejection happens
+**before the application runs**, so the transport answers a real, deterministic `400` (h1) or
+resets the request stream (h3) with no application involvement. The in-hook full read is free
+exactly there: h3 hands the hook a fully received body (drained before header decode), and the h1
+parse path is its own body reader — the post-#810 streamed body is pulled from the wire by the
+same logical flow that runs the hook, and the peer needs nothing from the server to keep sending
+(the `Expect: 100-continue` solicitation is emitted by the body stream's own first read). The cost
+is one transient extra copy of the body, bounded by the request-limits cap on h1.
 
-- **Register the verifier first**, before any content-decoding interceptor. `Content-Digest` is
-  taken over the message content *as received* (post-content-coding, on the wire), so it must be
-  verified against the raw body before a decompression wrapper transforms it.
-- **All three protocols run the seam, but the eager full read is only safe where the body is
-  already received.** As of #819 the h1 parser and the h2/h3 context-construction sites all
-  invoke the request-parse hooks. h1 and h3 hand `AfterRequestBody` a fully received body, so the
-  verifier's in-hook full read is CPU-only there. On h2, however, the hooks run on the
-  connection's single frame pump and the body may still be **arriving** under flow-control
-  backpressure — an in-hook blocking read of a still-incomplete body would stall the very pump
-  that feeds it (the hook contract's CPU-only rule exists for exactly this). The eager
-  buffer-and-replay verifier is therefore correct for h1/h3 today; verifying h2 streamed bodies
-  needs a lazy verify-on-read wrapper (or verification at body completion) and is tracked as
-  follow-up work rather than papered over here.
+**Lazy verify-on-read (HTTP/2 — and, defensively, any version not proven eager-safe).** On h2 the
+parse hooks run on the connection's **single frame pump** and the body is a live
+`Http2RequestBodyStream` that may still be arriving under flow-control backpressure (#750): an
+in-hook read would wait for DATA frames only the blocked pump can deliver, deadlocking every
+multiplexed stream on the connection. So the hook stays CPU-only — it wraps the body in
+`HttpDigestVerifyingStream` and reads nothing. The wrapper feeds every octet the application reads
+into one BCL `IncrementalHash` per supported digest entry (zero double-buffering; the only copy of
+the body is the flow-control-bounded pipe the transport already owns) and resolves the verdict on
+the **terminal read** — the read that observes end-of-body:
 
-The replay stream (`HttpDigestReplayStream`) owns the original body it replaced and disposes it when
-the exchange disposes the stream chain, honoring the seam's "a wrapper owns the stream it wraps"
-contract.
+- **Match** → the terminal read returns `0`; the application saw a normal body end-to-end.
+- **Mismatch** → the terminal read throws `HttpContentDigestMismatchException` (naming the first
+  failing algorithm in field order), and every subsequent read rethrows it — the failure is
+  sticky, so a consumer that swallows it once cannot go on treating the stream as verified.
+
+The mode switch is deliberately an allow-list (`Http11`/`Http30` eager, everything else lazy):
+eager is an *optimization* that must be proven safe per protocol, while lazy is safe everywhere
+because the hook performs no I/O. An unknown future version therefore degrades to correctness,
+not to a deadlock.
+
+### Mid-stream rejection semantics (the lazy path's contract)
+
+Once the application has begun consuming a streamed body, a digest mismatch can no longer become
+a clean pre-dispatch `400` — the content was already observed and the exchange is running. The
+contract, per the seam's layering rule (interceptors are wiring; aborting is an application-layer
+act):
+
+- The typed failure surfaces **on the terminal body read** (`HttpContentDigestMismatchException`,
+  `HttpErrorCode.ReadingError`), never earlier — the verdict does not exist until every content
+  octet has been hashed.
+- The application (or the hosting layer that installed the verifier) must treat the body as
+  corrupt, discard anything derived from it, and abort the exchange via `IHttpContext.Cancel`.
+  The transport answers the abort with its per-exchange reset — on h2, `RST_STREAM(CANCEL)` from
+  the exchange abort path — instead of writing a response. There is deliberately no
+  transport-automatic abort: the seam has no abort verb, and the application may prefer to answer
+  (e.g. `422`) rather than reset.
+- **A body the application never drains is never verified.** Lazy verification can only cover
+  what is consumed; a handler that responds without reading to end-of-body has waived
+  verification for the unread remainder. Operators who need an unconditional verdict must drain
+  the body (h2) or rely on the eager protocols.
+
+Both wrapper streams own the body they replace and dispose it when the exchange disposes the
+stream chain, honoring the seam's "a wrapper owns the stream it wraps" contract
+(`HttpDigestVerifyingStream` also disposes its running hashes at verdict or disposal, whichever
+comes first).
+
+One ordering note applies to both modes: **register the verifier first**, before any
+content-decoding interceptor. `Content-Digest` is taken over the message content *as received*
+(post-content-coding, on the wire), so it must be verified against the raw body before a
+decompression wrapper transforms it.
 
 ## Response stamping and Want-* honoring
 
@@ -158,8 +192,9 @@ When those land, `Repr-Digest` verification is a drop-in on the same value model
 No reflection, no runtime codegen. Hashing is BCL `IncrementalHash` over fixed `HashAlgorithmName`
 values; comparison is `CryptographicOperations.FixedTimeEquals`; parsing reuses core's span-based
 structured-fields parser. The value objects are readonly structs over a single array; the
-interceptor is one small allocation per verified request (only when a `Content-Digest` is present
-and verifiable).
+interceptor allocates only for a verified request (a `Content-Digest` present and verifiable):
+one transient body copy plus the replay stream on the eager path, or the verifying wrapper plus
+one `IncrementalHash` per supported entry — and **no body copy at all** — on the lazy path.
 
 ## Non-goals and honest gaps
 

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/OVERVIEW.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/docs/OVERVIEW.md
@@ -17,8 +17,12 @@ request verifier.
   parse but never used (RFC 9530 §5).
 - **Server verification:** `HttpDigestFields.CreateContentDigestVerifier()` returns an
   `IHttpExchangeInterceptor` the composition root registers on its listener; it verifies an inbound
-  `Content-Digest` against the request body and rejects a mismatch (or a malformed field) with
-  `400 Bad Request` before dispatch.
+  `Content-Digest` against the request body. On HTTP/1.1 and HTTP/3 verification is eager and a
+  mismatch is rejected with `400 Bad Request` before dispatch; on HTTP/2 (whose body streams in
+  under flow control after dispatch) it is lazy — the body is hashed incrementally as the
+  application reads, and a mismatch surfaces as `HttpContentDigestMismatchException` on the
+  terminal body read, after which the application aborts the exchange (`IHttpContext.Cancel` →
+  `RST_STREAM`). A malformed field is a pre-dispatch `400` on every protocol.
 - **Response stamping:** `IHttpResponse.SetContentDigest(...)` computes and stamps `Content-Digest`,
   honoring the request's `Want-Content-Digest` preference ordering; `HttpContentDigester` is the
   incremental "hash as you write" primitive for the trailer-borne streamed case.
@@ -38,4 +42,5 @@ if (HttpDigestField.TryParse(headerValue, out var field) &&
 ```
 
 See `docs/DESIGN.md` for the placement rationale (consumer of the structured-fields toolkit), the
-eager buffer-and-replay verification model, and the Content-Digest vs Repr-Digest scope.
+two verification modes (eager buffer-and-replay vs. lazy verify-on-read) and the mid-stream
+rejection semantics, and the Content-Digest vs Repr-Digest scope.

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpContentDigestMismatchException.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpContentDigestMismatchException.cs
@@ -1,0 +1,41 @@
+namespace Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Thrown when the received message content does not match a digest carried by its
+/// <c>Content-Digest</c> field (RFC 9530 &#167; 2). On a streamed request body verified lazily
+/// (HTTP/2), this surfaces on the <em>terminal</em> body read — the read that observes
+/// end-of-body — because the verdict cannot exist until every content octet has been hashed.
+/// Inherits the HTTP area exception root <see cref="HttpException"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// By the time this exception is thrown the application has already consumed the (tampered or
+/// corrupt) content, so it cannot become a clean pre-dispatch <c>400 Bad Request</c> the way an
+/// eagerly verified mismatch does. The application must discard whatever it derived from the body
+/// and abort the exchange (<see cref="IHttpContext.Cancel"/>), which the transport answers with
+/// its per-exchange reset (HTTP/2 <c>RST_STREAM(CANCEL)</c>) instead of a response.
+/// </para>
+/// <para>
+/// The exception is sticky: every subsequent read of the verified body stream rethrows it, so a
+/// consumer that swallows the first failure cannot accidentally treat the body as verified.
+/// </para>
+/// </remarks>
+public sealed class HttpContentDigestMismatchException : HttpException
+{
+    /// <summary>
+    /// Initializes a new <see cref="HttpContentDigestMismatchException"/>.
+    /// </summary>
+    /// <param name="algorithm">The digest algorithm whose declared digest the content failed.</param>
+    public HttpContentDigestMismatchException(HttpDigestAlgorithm algorithm)
+        : base($"The request body does not match its Content-Digest ('{algorithm}').")
+    {
+        Algorithm = algorithm;
+        Code = HttpErrorCode.ReadingError;
+    }
+
+    /// <summary>
+    /// Gets the digest algorithm whose declared digest the content failed. When the field carried
+    /// several supported digests, this is the first mismatching one in field order.
+    /// </summary>
+    public HttpDigestAlgorithm Algorithm { get; }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestFields.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/HttpDigestFields.cs
@@ -9,14 +9,21 @@ namespace Assimalign.Cohesion.Http;
 public static class HttpDigestFields
 {
     /// <summary>
-    /// Creates the stateless <see cref="IHttpRequestInterceptor"/> that verifies an inbound
-    /// <c>Content-Digest</c> against the request body and rejects a mismatch (or a malformed field)
-    /// with <c>400 Bad Request</c> before the request is dispatched.
+    /// Creates the stateless <see cref="IHttpExchangeInterceptor"/> that verifies an inbound
+    /// <c>Content-Digest</c> against the request body. On HTTP/1.1 and HTTP/3 verification is
+    /// eager and a mismatch (or a malformed field) is rejected with <c>400 Bad Request</c> before
+    /// the request is dispatched; on HTTP/2 the body is verified lazily as the application reads
+    /// it, and a mismatch surfaces as <see cref="HttpContentDigestMismatchException"/> from the
+    /// terminal body read (the malformed-field <c>400</c> stays pre-dispatch there too).
     /// </summary>
     /// <remarks>
     /// Register it <em>before</em> any content-decoding interceptor, because <c>Content-Digest</c>
     /// is taken over the message content as received. A request with no <c>Content-Digest</c>, or
-    /// one offering only deprecated/unregistered algorithms, is passed through unverified.
+    /// one offering only deprecated/unregistered algorithms, is passed through unverified — as is
+    /// (on the lazy path) any part of a body the application never reads: verification can only
+    /// cover what is consumed. An application that catches
+    /// <see cref="HttpContentDigestMismatchException"/> must treat the body as corrupt and abort
+    /// the exchange (<see cref="IHttpContext.Cancel"/>).
     /// </remarks>
     /// <returns>The content-digest verification interceptor.</returns>
     public static IHttpExchangeInterceptor CreateContentDigestVerifier() => new HttpContentDigestInterceptor();

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpContentDigestInterceptor.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpContentDigestInterceptor.cs
@@ -4,24 +4,40 @@ namespace Assimalign.Cohesion.Http.Internal;
 
 /// <summary>
 /// A request-parse interceptor that verifies an inbound <c>Content-Digest</c> against the request
-/// body and rejects a mismatch with <c>400 Bad Request</c>. Opt-in: the composition root installs
-/// it via <see cref="HttpDigestFields.CreateContentDigestVerifier"/>.
+/// body. Opt-in: the composition root installs it via
+/// <see cref="HttpDigestFields.CreateContentDigestVerifier"/>.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Stateless — one instance serves every connection and request on the listener. It hooks
-/// <c>AfterRequestBody</c>: by the time that hook runs the transport has materialized the request
-/// body, so the verifier reads it in full (to hash it), compares against every supported digest the
-/// field carries, and returns a replay stream so the application still observes the body. A
-/// mismatch, or a malformed <c>Content-Digest</c> field, throws
-/// <see cref="HttpRequestRejectedException"/> before dispatch, which the transport answers with the
-/// carried status and then closes the connection.
+/// <c>AfterRequestBody</c> and verifies in one of two modes, chosen per protocol by where the
+/// verdict can be produced without violating the hook's CPU-only contract:
 /// </para>
 /// <para>
-/// Verification is over the message content <em>as received</em> (RFC 9530 <c>Content-Digest</c>
-/// semantics), so this interceptor must run before any content-decoding interceptor. A request
-/// carrying no <c>Content-Digest</c>, or only deprecated/unknown algorithms, passes through
-/// untouched.
+/// <b>Eager buffer-and-replay (HTTP/1.1, HTTP/3):</b> the hook reads the body in full, compares
+/// against every supported digest the field carries, and returns a replay stream so the
+/// application still observes the body. A mismatch throws
+/// <see cref="HttpRequestRejectedException"/> (<c>400</c>) before dispatch. Safe on these
+/// protocols because the in-hook read cannot wait on work the hook itself is blocking: HTTP/3
+/// hands the hook a fully received body, and the HTTP/1.1 parse path is its own body reader (the
+/// peer needs nothing from the server to keep sending).
+/// </para>
+/// <para>
+/// <b>Lazy verify-on-read (HTTP/2, and any version not known to be eager-safe):</b> the hook is
+/// CPU-only — it wraps the body in a <see cref="HttpDigestVerifyingStream"/> that hashes
+/// incrementally as the application reads and resolves the verdict on the terminal read. The h2
+/// hook runs on the connection's single frame pump while the body may still be arriving under
+/// flow-control backpressure; an in-hook read would stall the pump that delivers the very DATA it
+/// waits for, deadlocking every stream on the connection. A mismatch therefore surfaces as
+/// <see cref="HttpContentDigestMismatchException"/> from the application's end-of-body read, and
+/// the application aborts the exchange (<see cref="IHttpContext.Cancel"/> → <c>RST_STREAM</c>).
+/// </para>
+/// <para>
+/// A malformed <c>Content-Digest</c> field is rejected with <c>400</c> in-hook on every protocol —
+/// parsing is CPU-only, so the fail-closed pre-dispatch rejection needs no body octet. Verification
+/// is over the message content <em>as received</em> (RFC 9530 <c>Content-Digest</c> semantics), so
+/// this interceptor must run before any content-decoding interceptor. A request carrying no
+/// <c>Content-Digest</c>, or only deprecated/unknown algorithms, passes through untouched.
 /// </para>
 /// </remarks>
 internal sealed class HttpContentDigestInterceptor : HttpExchangeInterceptor
@@ -47,6 +63,15 @@ internal sealed class HttpContentDigestInterceptor : HttpExchangeInterceptor
         {
             // Only deprecated/unregistered algorithms were offered — nothing this library verifies.
             return body;
+        }
+
+        // Eager reading is an optimization (it buys the clean pre-dispatch 400), never assumed:
+        // only the protocols whose parse paths make an in-hook full read free take it. Everything
+        // else — HTTP/2 today, any future version until proven — gets the lazy wrapper, which is
+        // safe everywhere because the hook itself reads nothing.
+        if (context.Version is not (HttpVersion.Http11 or HttpVersion.Http30))
+        {
+            return new HttpDigestVerifyingStream(field, body);
         }
 
         byte[] content = ReadToEnd(body);

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpDigestVerifyingStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/src/Internal/HttpDigestVerifyingStream.cs
@@ -1,0 +1,242 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Internal;
+
+/// <summary>
+/// A read-only wrapper that verifies a request body against its <c>Content-Digest</c> lazily, as
+/// the application reads it: every octet read is fed to one BCL <see cref="IncrementalHash"/> per
+/// supported digest entry, and the computed digests are compared on the <em>terminal</em> read —
+/// the read that observes end-of-body. A mismatch throws
+/// <see cref="HttpContentDigestMismatchException"/> from that read (and, stickily, from every read
+/// after it); a match lets the end-of-body surface as a normal zero-length read.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the verification shape for transports whose request body may still be arriving when
+/// <c>AfterRequestBody</c> runs (HTTP/2, where the hook executes on the connection's single frame
+/// pump and an in-hook read of the flow-controlled body would stall the very pump that feeds it).
+/// Construction is CPU-only — no octet is read here — so the hook honors its contract; the wire
+/// wait moves to the application's own reads, where waiting is safe and where flow-control
+/// backpressure keeps buffering bounded. The cost is that the verdict arrives only at end-of-body:
+/// content is necessarily observed by the application before it is proven authentic, and a body
+/// the application never drains is never verified.
+/// </para>
+/// <para>
+/// The wrapper owns the stream it wraps (the seam's disposal contract): disposing it disposes the
+/// wrapped body and the running hashes. Reads are single-consumer, like the transport body streams
+/// it wraps.
+/// </para>
+/// </remarks>
+internal sealed class HttpDigestVerifyingStream : Stream
+{
+    private readonly Stream _inner;
+    // The supported digest entries under verification and one running hash per entry, index-paired.
+    private readonly HttpDigestEntry[] _entries;
+    private readonly IncrementalHash[] _hashes;
+
+    private bool _verified;
+    private HttpDigestAlgorithm? _failedAlgorithm;
+    private bool _disposed;
+
+    public HttpDigestVerifyingStream(HttpDigestField field, Stream inner)
+    {
+        _inner = inner;
+
+        int supported = 0;
+        foreach (HttpDigestEntry entry in field.Entries)
+        {
+            if (entry.Algorithm.IsSupported)
+            {
+                supported++;
+            }
+        }
+
+        _entries = new HttpDigestEntry[supported];
+        _hashes = new IncrementalHash[supported];
+
+        int index = 0;
+        foreach (HttpDigestEntry entry in field.Entries)
+        {
+            if (entry.Algorithm.IsSupported)
+            {
+                _entries[index] = entry;
+                _hashes[index] = entry.Algorithm.CreateIncrementalHash();
+                index++;
+            }
+        }
+
+        // Nothing verifiable (the interceptor never constructs the wrapper this way): the empty
+        // verdict is a pass, so reads degrade to pure pass-through.
+        _verified = supported == 0;
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException("The digest-verified request body length is not known in advance.");
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException("The digest-verified request body stream is not seekable.");
+        set => throw new NotSupportedException("The digest-verified request body stream is not seekable.");
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        // A zero-length read returns zero by definition; it must not be observed as end-of-body.
+        if (buffer.IsEmpty)
+        {
+            return 0;
+        }
+
+        ThrowIfFailed();
+
+        if (_verified)
+        {
+            // End-of-body was already observed and verified; the stream stays at EOF.
+            return 0;
+        }
+
+        int read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        Observe(buffer.Span, read);
+        return read;
+    }
+
+    /// <inheritdoc />
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
+    /// <inheritdoc />
+    public override int Read(Span<byte> buffer)
+    {
+        if (buffer.IsEmpty)
+        {
+            return 0;
+        }
+
+        ThrowIfFailed();
+
+        if (_verified)
+        {
+            return 0;
+        }
+
+        int read = _inner.Read(buffer);
+        Observe(buffer, read);
+        return read;
+    }
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ValidateBufferArguments(buffer, offset, count);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+        // A request body is read-only; there is nothing to flush.
+    }
+
+    /// <inheritdoc />
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException("The digest-verified request body stream is not seekable.");
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException("The digest-verified request body stream is read-only.");
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException("The digest-verified request body stream is read-only.");
+
+    /// <summary>
+    /// Feeds octets that flowed to the application into the running hashes, or — on the terminal
+    /// read — resolves the verdict.
+    /// </summary>
+    /// <param name="buffer">The read destination.</param>
+    /// <param name="read">The octet count the wrapped stream returned.</param>
+    /// <exception cref="HttpContentDigestMismatchException">The content failed a declared digest.</exception>
+    private void Observe(ReadOnlySpan<byte> buffer, int read)
+    {
+        if (read > 0)
+        {
+            foreach (IncrementalHash hash in _hashes)
+            {
+                hash.AppendData(buffer[..read]);
+            }
+            return;
+        }
+
+        // End-of-body: every content octet has been hashed, so the verdict exists now. Resolve it
+        // exactly once; the hashes are no longer needed either way.
+        Span<byte> computed = stackalloc byte[64]; // large enough for SHA-512
+        for (int i = 0; i < _entries.Length; i++)
+        {
+            int written = _hashes[i].GetHashAndReset(computed);
+
+            // FixedTimeEquals is length-checked, so a truncated or oversized digest value is a
+            // mismatch rather than an exception — same rule as the eager verifier.
+            if (!CryptographicOperations.FixedTimeEquals(computed[..written], _entries[i].Digest.Span))
+            {
+                _failedAlgorithm = _entries[i].Algorithm;
+                DisposeHashes();
+                ThrowIfFailed();
+            }
+        }
+
+        _verified = true;
+        DisposeHashes();
+    }
+
+    private void ThrowIfFailed()
+    {
+        if (_failedAlgorithm is { } algorithm)
+        {
+            // Sticky: the content is proven corrupt/tampered, so no later read may present the
+            // stream as healthy. Each throw is a fresh instance to keep stack traces honest.
+            throw new HttpContentDigestMismatchException(algorithm);
+        }
+    }
+
+    private void DisposeHashes()
+    {
+        foreach (IncrementalHash hash in _hashes)
+        {
+            hash.Dispose();
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
+        {
+            _disposed = true;
+            if (!_verified && _failedAlgorithm is null)
+            {
+                // Disposed before end-of-body was observed — no verdict was ever resolved, so the
+                // hashes are still live.
+                DisposeHashes();
+            }
+            _inner.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigestInterceptorTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.DigestFields/tests/HttpContentDigestInterceptorTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Shouldly;
 
@@ -12,44 +14,45 @@ using Assimalign.Cohesion.Http;
 
 public class HttpContentDigestInterceptorTests
 {
-    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A matching Content-Digest passes and replays the body")]
-    public void AfterRequestBody_Match_ReplaysBody()
+    // ------------------------------------------------------------ eager path (HTTP/1.1, HTTP/3)
+
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A matching Content-Digest passes and replays the body (eager protocols)")]
+    [InlineData(HttpVersion.Http11)]
+    [InlineData(HttpVersion.Http30)]
+    public void AfterRequestBody_EagerMatch_ReplaysBody(HttpVersion version)
     {
         byte[] content = Encoding.UTF8.GetBytes("payload that matches its digest");
         string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
-        HttpExchangeInterceptorRequestContext context = CreateContext(digest);
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, version);
         IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+        using var body = new MemoryStream(content);
 
-        Stream result = verifier.AfterRequestBody(context, new MemoryStream(content));
+        Stream result = verifier.AfterRequestBody(context, body);
 
+        // The eager path hashes in-hook and hands the application a replay of the buffered body:
+        // the original was consumed to end inside the hook, and the replay is independently
+        // seekable (the lazy wrapper is not).
+        result.ShouldNotBeSameAs(body);
+        body.Position.ShouldBe(body.Length);
+        result.CanSeek.ShouldBeTrue();
         using var read = new MemoryStream();
         result.CopyTo(read);
         read.ToArray().ShouldBe(content);
     }
 
-    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A mismatched Content-Digest is rejected with 400")]
-    public void AfterRequestBody_Mismatch_Rejects400()
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A mismatched Content-Digest is rejected with 400 before dispatch (eager protocols)")]
+    [InlineData(HttpVersion.Http11)]
+    [InlineData(HttpVersion.Http30)]
+    public void AfterRequestBody_EagerMismatch_Rejects400(HttpVersion version)
     {
         byte[] declared = Encoding.UTF8.GetBytes("the original payload");
         byte[] actual = Encoding.UTF8.GetBytes("the tampered payload");
         string digest = HttpDigestField.ForContent(declared, HttpDigestAlgorithm.Sha256).Serialize();
-        HttpExchangeInterceptorRequestContext context = CreateContext(digest);
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, version);
         IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
 
         HttpRequestRejectedException ex = Should.Throw<HttpRequestRejectedException>(
             () => verifier.AfterRequestBody(context, new MemoryStream(actual)));
-
-        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-    }
-
-    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A malformed Content-Digest is rejected with 400")]
-    public void AfterRequestBody_Malformed_Rejects400()
-    {
-        HttpExchangeInterceptorRequestContext context = CreateContext("sha-256=12345");
-        IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
-
-        HttpRequestRejectedException ex = Should.Throw<HttpRequestRejectedException>(
-            () => verifier.AfterRequestBody(context, new MemoryStream(new byte[] { 1, 2, 3 })));
 
         ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
@@ -92,7 +95,228 @@ public class HttpContentDigestInterceptorTests
         original.IsDisposed.ShouldBeTrue();
     }
 
-    private static HttpExchangeInterceptorRequestContext CreateContext(string? contentDigest)
+    // ------------------------------------------------------------ lazy path (HTTP/2)
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: The HTTP/2 hook is CPU-only — it wraps without reading a single body octet")]
+    public void AfterRequestBody_OnHttp2_DoesNotReadBodyInHook()
+    {
+        // On h2 the hook runs on the connection's frame pump while the body may still be arriving;
+        // reading it in-hook is the deadlock this rework removes. A body that throws on any read
+        // proves the hook never touches it.
+        byte[] content = Encoding.UTF8.GetBytes("still arriving");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+
+        // The eager path would throw from ReadForbiddenStream here; returning at all proves the
+        // hook stayed CPU-only.
+        Stream result = verifier.AfterRequestBody(context, new ReadForbiddenStream());
+
+        result.ShouldNotBeNull();
+        result.ShouldNotBeOfType<ReadForbiddenStream>();
+        result.CanSeek.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 body matching its digest streams through and verifies at end-of-body")]
+    public async Task AfterRequestBody_OnHttp2Match_StreamsAndVerifiesAtEof()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("a streamed h2 body verified as the application reads");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(content, maxChunk: 7));
+
+        byte[] observed = await ReadToEndAsync(wrapped);
+
+        observed.ShouldBe(content);
+        // End-of-body was verified; the stream stays at a clean EOF afterward.
+        (await wrapped.ReadAsync(new byte[8])).ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 digest mismatch surfaces as the typed failure on the terminal read")]
+    public async Task AfterRequestBody_OnHttp2Mismatch_ThrowsTypedFailureOnTerminalRead()
+    {
+        byte[] declared = Encoding.UTF8.GetBytes("the original payload");
+        byte[] actual = Encoding.UTF8.GetBytes("the tampered payload");
+        string digest = HttpDigestField.ForContent(declared, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(actual, maxChunk: 5));
+
+        // Every content octet flows to the application unimpeded — the verdict cannot exist until
+        // end-of-body, so the reads that carry data must succeed.
+        byte[] observed = await ReadExactAsync(wrapped, actual.Length);
+        observed.ShouldBe(actual);
+
+        HttpContentDigestMismatchException ex = await Should.ThrowAsync<HttpContentDigestMismatchException>(
+            () => ReadTerminalAsync(wrapped));
+        ex.Algorithm.ShouldBe(HttpDigestAlgorithm.Sha256);
+        ex.Code.ShouldBe(HttpErrorCode.ReadingError);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 multi-digest field verifies every supported algorithm")]
+    public async Task AfterRequestBody_OnHttp2MultiDigestMatch_VerifiesAllAlgorithms()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("content hashed with two algorithms");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256, HttpDigestAlgorithm.Sha512).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(content, maxChunk: 11));
+
+        byte[] observed = await ReadToEndAsync(wrapped);
+
+        observed.ShouldBe(content);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 multi-digest field fails when any one algorithm mismatches, naming it")]
+    public async Task AfterRequestBody_OnHttp2MultiDigestOneWrong_ThrowsNamingTheAlgorithm()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("content whose sha-512 digest is wrong");
+        // sha-256 is computed over the real content; sha-512 over different content.
+        HttpDigestField sha256 = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256);
+        HttpDigestField sha512 = HttpDigestField.ForContent(Encoding.UTF8.GetBytes("other"), HttpDigestAlgorithm.Sha512);
+        string digest = $"{sha256.Serialize()}, {sha512.Serialize()}";
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(content, maxChunk: 9));
+
+        await ReadExactAsync(wrapped, content.Length);
+
+        HttpContentDigestMismatchException ex = await Should.ThrowAsync<HttpContentDigestMismatchException>(
+            () => ReadTerminalAsync(wrapped));
+        ex.Algorithm.ShouldBe(HttpDigestAlgorithm.Sha512);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 mismatch is sticky — every later read rethrows")]
+    public async Task AfterRequestBody_OnHttp2MismatchThenReadAgain_RethrowsSticky()
+    {
+        byte[] actual = Encoding.UTF8.GetBytes("tampered");
+        string digest = HttpDigestField.ForContent(Encoding.UTF8.GetBytes("original"), HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(actual, maxChunk: 3));
+        await ReadExactAsync(wrapped, actual.Length);
+        await Should.ThrowAsync<HttpContentDigestMismatchException>(() => ReadTerminalAsync(wrapped));
+
+        // A consumer that swallows the first failure must not be able to observe a healthy stream.
+        await Should.ThrowAsync<HttpContentDigestMismatchException>(() => ReadTerminalAsync(wrapped));
+        Should.Throw<HttpContentDigestMismatchException>(() => wrapped.Read(new byte[8], 0, 8));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 malformed Content-Digest is still rejected 400 in-hook without touching the body")]
+    public void AfterRequestBody_OnHttp2Malformed_StillRejects400InHook()
+    {
+        // Parsing is CPU-only, so the fail-closed pre-dispatch rejection survives on h2 — only the
+        // body-dependent verdict moves to the application's reads.
+        HttpExchangeInterceptorRequestContext context = CreateContext("sha-256=12345", HttpVersion.Http20);
+        IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+
+        HttpRequestRejectedException ex = Should.Throw<HttpRequestRejectedException>(
+            () => verifier.AfterRequestBody(context, new ReadForbiddenStream()));
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An HTTP/2 request with nothing verifiable passes the body through untouched")]
+    [InlineData(null)]
+    [InlineData("md5=:1B2M2Y8AsgTpgAmY7PhCfg==:")]
+    public void AfterRequestBody_OnHttp2NothingVerifiable_PassesThroughSameStream(string? contentDigest)
+    {
+        HttpExchangeInterceptorRequestContext context = CreateContext(contentDigest, HttpVersion.Http20);
+        IHttpExchangeInterceptor verifier = HttpDigestFields.CreateContentDigestVerifier();
+        using var body = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        Stream result = verifier.AfterRequestBody(context, body);
+
+        result.ShouldBeSameAs(body);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An empty HTTP/2 body verifies against the digest of empty content")]
+    public async Task AfterRequestBody_OnHttp2EmptyBodyMatch_Verifies()
+    {
+        string digest = HttpDigestField.ForContent(ReadOnlySpan<byte>.Empty, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(Array.Empty<byte>(), maxChunk: 4));
+
+        (await wrapped.ReadAsync(new byte[8])).ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: An empty HTTP/2 body fails a digest declared over non-empty content")]
+    public async Task AfterRequestBody_OnHttp2EmptyBodyMismatch_Throws()
+    {
+        string digest = HttpDigestField.ForContent(Encoding.UTF8.GetBytes("expected content"), HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(Array.Empty<byte>(), maxChunk: 4));
+
+        await Should.ThrowAsync<HttpContentDigestMismatchException>(() => ReadTerminalAsync(wrapped));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: A zero-length read is not mistaken for end-of-body")]
+    public async Task AfterRequestBody_OnHttp2ZeroLengthRead_DoesNotResolveVerdict()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("body");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(content, maxChunk: 64));
+
+        // A zero-length read returns 0 by definition; the verdict must wait for real end-of-body.
+        (await wrapped.ReadAsync(Memory<byte>.Empty)).ShouldBe(0);
+
+        byte[] observed = await ReadToEndAsync(wrapped);
+        observed.ShouldBe(content);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: The HTTP/2 lazy path verifies over synchronous reads too")]
+    public void AfterRequestBody_OnHttp2SyncReads_VerifyAtEof()
+    {
+        byte[] declared = Encoding.UTF8.GetBytes("the original payload");
+        byte[] actual = Encoding.UTF8.GetBytes("the tampered payload");
+        string digest = HttpDigestField.ForContent(declared, HttpDigestAlgorithm.Sha256).Serialize();
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier()
+            .AfterRequestBody(context, new ChunkedReadStream(actual, maxChunk: 6));
+
+        byte[] buffer = new byte[actual.Length];
+        int offset = 0;
+        while (offset < buffer.Length)
+        {
+            offset += wrapped.Read(buffer, offset, buffer.Length - offset);
+        }
+
+        buffer.ShouldBe(actual);
+        Should.Throw<HttpContentDigestMismatchException>(() => wrapped.Read(new byte[8], 0, 8));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.DigestFields] - Verifier: Disposing the HTTP/2 wrapper disposes the wrapped body, verified or not")]
+    public async Task AfterRequestBody_OnHttp2WrapperDisposal_DisposesWrappedBody()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("owned body");
+        string digest = HttpDigestField.ForContent(content, HttpDigestAlgorithm.Sha256).Serialize();
+
+        // Disposed mid-body — no verdict was ever resolved.
+        HttpExchangeInterceptorRequestContext context = CreateContext(digest, HttpVersion.Http20);
+        var unread = new TrackingStream(content);
+        Stream wrapped = HttpDigestFields.CreateContentDigestVerifier().AfterRequestBody(context, unread);
+        wrapped.Dispose();
+        unread.IsDisposed.ShouldBeTrue();
+
+        // Disposed after a verified end-of-body.
+        context = CreateContext(digest, HttpVersion.Http20);
+        var drained = new TrackingStream(content);
+        wrapped = HttpDigestFields.CreateContentDigestVerifier().AfterRequestBody(context, drained);
+        await ReadToEndAsync(wrapped);
+        wrapped.Dispose();
+        drained.IsDisposed.ShouldBeTrue();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static HttpExchangeInterceptorRequestContext CreateContext(
+        string? contentDigest,
+        HttpVersion version = HttpVersion.Http11)
     {
         var headers = new HttpHeaderCollection();
         if (contentDigest is not null)
@@ -102,7 +326,7 @@ public class HttpContentDigestInterceptorTests
 
         return new HttpExchangeInterceptorRequestContext
         {
-            Version = HttpVersion.Http11,
+            Version = version,
             Method = HttpMethod.Post,
             Path = new HttpPath("/upload"),
             Scheme = HttpScheme.Http,
@@ -112,6 +336,37 @@ public class HttpContentDigestInterceptorTests
             ConnectionInfo = HttpConnectionInfo.Empty,
             MaxRequestBodySize = null,
         };
+    }
+
+    /// <summary>
+    /// Issues one read against a stream expected to be at end-of-body, returning the transferred
+    /// count — the read on which the lazy verifier resolves its verdict.
+    /// </summary>
+    private static Task<int> ReadTerminalAsync(Stream stream) => stream.ReadAsync(new byte[8], 0, 8);
+
+    private static async Task<byte[]> ReadToEndAsync(Stream stream)
+    {
+        using var copy = new MemoryStream();
+        byte[] buffer = new byte[16];
+        int read;
+        while ((read = await stream.ReadAsync(buffer)) > 0)
+        {
+            copy.Write(buffer, 0, read);
+        }
+        return copy.ToArray();
+    }
+
+    private static async Task<byte[]> ReadExactAsync(Stream stream, int count)
+    {
+        byte[] buffer = new byte[count];
+        int offset = 0;
+        while (offset < count)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset));
+            read.ShouldBeGreaterThan(0, $"the stream ended after {offset} of {count} expected octets");
+            offset += read;
+        }
+        return buffer;
     }
 
     private sealed class TrackingStream : MemoryStream
@@ -127,5 +382,77 @@ public class HttpContentDigestInterceptorTests
             IsDisposed = true;
             base.Dispose(disposing);
         }
+    }
+
+    /// <summary>
+    /// A body double proving the hook never reads: any read attempt fails the test. This is the
+    /// package-level stand-in for the h2 frame pump, where an in-hook read deadlocks.
+    /// </summary>
+    private sealed class ReadForbiddenStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new InvalidOperationException("The parse-path hook must not read the request body.");
+        public override int Read(Span<byte> buffer)
+            => throw new InvalidOperationException("The parse-path hook must not read the request body.");
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("The parse-path hook must not read the request body.");
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("The parse-path hook must not read the request body.");
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A forward-only stream that serves at most <c>maxChunk</c> octets per read, so tests prove
+    /// the wrapper hashes incrementally across many partial reads — the shape of a
+    /// flow-controlled h2 body.
+    /// </summary>
+    private sealed class ChunkedReadStream : Stream
+    {
+        private readonly byte[] _content;
+        private readonly int _maxChunk;
+        private int _position;
+
+        public ChunkedReadStream(byte[] content, int maxChunk)
+        {
+            _content = content;
+            _maxChunk = maxChunk;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(Span<byte> buffer)
+        {
+            int take = Math.Min(Math.Min(buffer.Length, _maxChunk), _content.Length - _position);
+            _content.AsSpan(_position, take).CopyTo(buffer);
+            _position += take;
+            return take;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => new(Read(buffer.Span));
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => Task.FromResult(Read(buffer.AsSpan(offset, count)));
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary

The Content-Digest verifier (`HttpDigestFields.CreateContentDigestVerifier`) eagerly read the request body to completion inside its `AfterRequestBody` hook. On HTTP/2 that hook runs on the connection's **single frame pump** while the body is a live, flow-controlled `Http2RequestBodyStream` (#750): the in-hook read waits for DATA frames only the blocked pump can deliver, deadlocking every multiplexed stream on the connection. This was a live defect for any h2 listener with the verifier installed receiving a body larger than what was buffered at dispatch.

The verifier now chooses its mode per protocol, by where the verdict is affordable:

- **HTTP/1.1 / HTTP/3 — eager buffer-and-replay (unchanged, regression-locked).** The in-hook full read is free there (h3 hands a fully received body; the h1 parse path is its own body reader), and it buys the clean, deterministic pre-dispatch `400`.
- **HTTP/2 (and, defensively, any version not proven eager-safe) — lazy verify-on-read.** The hook stays CPU-only per the `IHttpExchangeInterceptor` contract: it wraps the body in the new internal `HttpDigestVerifyingStream`, which feeds every octet the application reads into one BCL `IncrementalHash` per supported digest entry (**zero double-buffering** — the only copy of the body remains the transport's flow-control-bounded pipe) and resolves the verdict on the **terminal read**. A mismatch surfaces as the new typed `HttpContentDigestMismatchException` (sticky on every later read); the application aborts the exchange via `IHttpContext.Cancel`, which the transport answers with `RST_STREAM(CANCEL)` through the existing exchange abort path — the seam's app-owned abort model (#818/#875). The malformed-field `400` stays pre-dispatch on **every** protocol, since parsing needs no body octet.

The mode switch is an allow-list (`Http11`/`Http30` eager, everything else lazy): eager is an optimization that must be proven safe per protocol, so an unknown future version degrades to correctness, not to a deadlock.

## Acceptance criteria → evidence

- **h2 streamed body verifies without stalling the pump (wire-level, body exceeds dispatch buffer):** `Http2ContentDigestVerificationTests.Http2_OnStreamedBodyWithMatchingDigest_ShouldDispatchVerifyAndComplete` — the peer sends the remaining 31,808 of 40,000 octets only **after** the exchange has dispatched and the app has consumed the first chunk; the exchange completes with a `200` and no `RST_STREAM`. The dispatch step carries a 10s timeout guard, **verified to trip against the old eager path** (temporarily forcing eager made the test fail at exactly the guard).
- **Hook stays CPU-only / hashes incrementally:** package test drives the hook with a body double that throws on any read; wire test proves end-to-end. The wrapper hashes across many partial reads (chunked-read doubles).
- **Mismatch → typed failure on terminal read + RST_STREAM:** `Http2_OnStreamedBodyWithMismatchedDigest_ShouldThrowTypedFailureAndResetStream` asserts `HttpContentDigestMismatchException` on the end-of-body read, then `Cancel()` → first `RST_STREAM` on the wire carries `CANCEL`. Mid-stream rejection semantics documented in `docs/DESIGN.md`.
- **h1/h3 keep eager + pre-dispatch 400:** package `Theory` over `Http11`/`Http30` (match → replay, mismatch → `HttpRequestRejectedException(400)`) plus h1 end-to-end wire tests (`400` pre-dispatch on mismatch, replay + `200` on match).
- **DESIGN.md hazard note replaced by the shipped design; Shouldly match/mismatch/multi-digest coverage on the h2 lazy path:** `docs/DESIGN.md` now documents the two modes, the allow-list rationale, and the mid-stream contract (including the *unread body is never verified* caveat); OVERVIEW/README updated. New lazy-path tests cover match, mismatch, multi-digest (both-match and one-wrong, naming the failing algorithm), sticky failure, sync reads, empty bodies, the zero-length-buffer guard, and disposal ownership.

## Notes

- New public API: `HttpContentDigestMismatchException` (sealed, `: HttpException`, `Code = ReadingError`, carries the failing `HttpDigestAlgorithm`). No transport code changed.
- `Assimalign.Cohesion.Http.Connections.Tests` gains a **test-only** `CohesionProjectReference` to `Assimalign.Cohesion.Http.DigestFields` (mirrors the existing Streaming/InterimResponses/ProtocolUpgrade precedent); the transport library still never references the package.
- Tests: DigestFields 65/65, Http.Connections 417/417 (4 new wire tests included).
- No scope creep filed; the plan doc is untouched per §1.

## Work items resolved by this PR
Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)