### PR TITLE
feat(web): request-timeout policies over the request-lifetime abort feature — Web.RequestTimeouts [L03.01.01.13]

### DIFF
--- a/.github/workflows/resource-web.yml
+++ b/.github/workflows/resource-web.yml
@@ -36,6 +36,7 @@ jobs:
             'Assimalign.Cohesion.Web.Hosting',
             'Assimalign.Cohesion.Web.ProblemDetails',
             'Assimalign.Cohesion.Web.Query',
+            'Assimalign.Cohesion.Web.RequestTimeouts',
             'Assimalign.Cohesion.Web.Routing',
             'Assimalign.Cohesion.Web.Sessions',
             'Assimalign.Cohesion.Web.StaticFiles',

--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -2171,6 +2171,17 @@
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Query/tests/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/" />
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/DESIGN.md" />
+		<File Path="resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Assimalign.Cohesion.Web.RequestTimeouts.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/Assimalign.Cohesion.Web.RequestTimeouts.Tests.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Routing/">
 		<File Path="resources/Web/Assimalign.Cohesion.Web.Routing/README.md" />
 	</Folder>

--- a/frameworks/Assimalign.Cohesion.App.props
+++ b/frameworks/Assimalign.Cohesion.App.props
@@ -168,6 +168,7 @@
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Hosting" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.ProblemDetails" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Query" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.RequestTimeouts" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Routing" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Sessions" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.StaticFiles" />

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/DESIGN.md
@@ -1,0 +1,175 @@
+# Assimalign.Cohesion.Web.RequestTimeouts — Design
+
+## Design intent
+
+Arm the per-exchange abort primitive the protocol core already ships (#703:
+`IHttpContext.RequestCancelled` + `Cancel`/`CancelAsync`) with a *policy layer*: a builder-time
+global default, per-endpoint overrides on the #150 endpoint-metadata seam, and an
+ASP.NET-parity translation of expiry into a 504 (or a clean protocol-level abort once the
+response has started). The package is a plain Web feature library under the middleware-first
+composition model: one `UseRequestTimeouts` verb, values captured at builder time, no service
+container, no request-time service location, no transport changes.
+
+## Why expiry does NOT trip the transport cancel while the response is writable
+
+The issue that motivated this package sketched "on expiry call `IHttpContext.CancelAsync()`
+… write the configured status if the response has not started." Those two halves are mutually
+exclusive on the wire, which is the load-bearing discovery of this design:
+
+- `Cancel`/`CancelAsync` set the transport's `CancelRequested` flag, and **every transport's
+  send path answers that flag by resetting the exchange instead of writing a response** —
+  HTTP/1.1 writes nothing and ends the connection after the exchange
+  (`Http1ConnectionContext.SendAsync`), HTTP/2 sends `RST_STREAM`, HTTP/3 resets the request
+  stream. A 504 written after `CancelAsync()` is silently discarded.
+- The transport token cannot be re-armed, and `IHttpContext.RequestCancelled` is get-only and
+  transport-owned — there is no supported way to trip it *without* the reset semantics, and
+  adding one would be a transport change (an explicit non-goal).
+
+So the two intents are split by response state:
+
+| State at expiry | Action |
+| --- | --- |
+| Response not started | Cancel downstream *work* via the linked token; write the policy's status/payload imperatively on the still-writable exchange; the transport sends it normally. `CancelRequested` is deliberately **not** set. |
+| Response started (streamed head committed) | The status is already on the wire — `CancelAsync()` is the only clean answer: h2/h3 reset the stream, h1 truncates and closes. This is exactly what the #703 primitive is for. |
+
+"Response started" is probed through `IHttpResponseStreamingFeature.HasStarted` when the
+streaming feature package is composed; on the default buffered path the response cannot start
+while the handler is still running, so the probe's absence correctly means "writable."
+
+## Cancellation delivery: a decorated context, not a token swap
+
+ASP.NET's middleware swaps `HttpContext.RequestAborted` through its request-lifetime feature.
+Cohesion deleted its request-lifetime feature library (the #703 context members are its
+successor), and `RequestCancelled` has no setter. The equivalent seam here is **decoration at
+the middleware boundary**: `UseRequestTimeouts` passes downstream a pass-through `IHttpContext`
+whose `RequestCancelled` is `linked(transport token, timeout token)`.
+
+That single decoration makes every existing consumer timeout-aware with no contract changes:
+
+- Handlers reading `context.RequestCancelled` observe the linked token.
+- The router creates its per-dispatch handler token by linking off
+  `context.RequestCancelled` — of the *decorated* context — so `IRouterRouteHandler`
+  cancellation tokens trip too.
+- `Cancel`/`CancelAsync`/`Features`/`Items` forward to the real context, so shared state
+  never forks. The middleware retained the original context and writes the timeout response
+  on it.
+
+The linked token also trips on a genuine client abort, preserving the primitive's original
+meaning downstream.
+
+## Timeout attribution (client aborts are never mislabeled)
+
+A downstream `OperationCanceledException` is converted to a timeout response only when
+`timeout source fired && !transport token cancelled`. A client abort therefore propagates
+unchanged — the server loop already treats an escaping OCE as a clean per-connection drain —
+and when both race, the client abort wins (nothing can be delivered anyway). A handler that
+swallows the cancellation and completes keeps the response it produced, matching ASP.NET. The
+filter deliberately keys off the middleware's own state, not
+`OperationCanceledException.CancellationToken`, because the throwing token is usually a
+*further-linked* token (e.g. the router's per-dispatch source), not ours.
+
+## Per-endpoint policy: observing the route-match publication
+
+Cohesion's router **matches and dispatches in one middleware** — on a match it invokes the
+handler and never calls `next`. There is no pipeline position "between match and dispatch" for
+a policy consumer to occupy (the position ASP.NET's timeout middleware occupies between
+`UseRouting` and endpoint execution). The documented routing contract fills the gap: *the
+router installs `IRouteMatchFeature` on `IHttpContext.Features` before invoking the handler*.
+The decorated context's feature collection forwards everything and reacts to that one
+installation, applying the endpoint's `RequestTimeoutMetadata` (last-wins over the bag) at
+exactly the match→dispatch boundary.
+
+Alternatives rejected:
+
+- **Match again inside the timeout middleware** (`IRouter.Match` is public): correct but pays
+  the full route-matching cost twice per request.
+- **Resolve the endpoint policy only when the global timer fires:** cannot honor an endpoint
+  policy *shorter* than the global default (the global timer fires too late), and cannot arm
+  anything when no global default exists.
+- **Teach the router about timeouts** (arm around `Handler.InvokeAsync`): routing routes; a
+  cross-cutting policy inside the router is the wrong ownership and would splinter the policy
+  surface across two packages.
+
+When routing eventually splits match from dispatch (the #28 evolution), the observation
+collapses into a plain read of the match feature between the phases; the public surface is
+unaffected.
+
+The endpoint timer is measured **from the match**, not from request start — the endpoint's
+budget belongs to its handler, not to route-table evaluation. `SetTimeout` re-arms from the
+moment of the call, like `CancellationTokenSource.CancelAfter`.
+
+## The timer: one unarmed CTS per exchange, TimeProvider-bound
+
+Each governed exchange owns two sources: a timeout source constructed
+`new CancellationTokenSource(Timeout.InfiniteTimeSpan, options.TimeProvider)` and the linked
+source described above. Creating the timeout source *unarmed but with the provider* is
+deliberate:
+
+- the `(delay, TimeProvider)` constructor is what binds `CancelAfter` to the provider — a
+  bare CTS re-armed later would silently fall back to system timing;
+- the source must exist before a deadline is known, because a per-endpoint policy or a
+  handler's `SetTimeout` can arm it when there is no global default;
+- disable is `CancelAfter(InfiniteTimeSpan)` — the same one-timer re-arm as every other
+  transition, so there is no timer allocation churn per policy change.
+
+`CancelAfter` after the source has fired is inherently a no-op, which yields the documented
+race semantic of `Disable`/`SetTimeout` (effective only before expiry) — the same race ASP.NET
+documents for `DisableRequestTimeout`. Cost when the middleware is registered but nothing arms:
+two small allocations per request, comparable to the linked source the router itself creates
+per dispatch.
+
+## Policy and metadata shape
+
+- `RequestTimeoutPolicy` is an immutable init-only value object; a `null` `Timeout` *is* the
+  disabled spelling (`RequestTimeoutPolicy.Disabled` is the shared instance). Disable is policy
+  **data**, not an attribute — attributes would need reflection or a translation layer under
+  AOT, and the metadata bag already gives last-wins override composition for free.
+- `RequestTimeoutMetadata` is a **sealed concrete carrier with no interface** per the repo's
+  metadata-carrier discipline (`RouteNameMetadata`/`RouteHostMetadata` precedent): the sealed
+  type is the contract, guaranteeing the validated, immutable policy consumers read.
+- An endpoint policy **replaces** the effective policy outright (timeout *and* response
+  members); policies do not merge member-by-member — merging invites "where did this status
+  come from" archaeology.
+- The timeout response: `WriteResponse` (imperative, owns everything) beats
+  `WriteProblemDetails` (RFC 9457 payload via `Web.ProblemDetails`) beats the bare status.
+  Before writing, staged response state is reset (headers cleared, buffered body truncated) —
+  the imperative analog of ASP.NET's `Response.Clear()`.
+
+## Feature lifecycle
+
+`IHttpRequestTimeoutFeature` is installed on the *real* feature collection for the duration of
+the middleware scope and removed before its cancellation sources are disposed, so later
+pipeline stages can never resolve a feature with disposed state. When the middleware is not
+registered — or is suspended for an attached debugger — no feature exists and
+`Features.Get<IHttpRequestTimeoutFeature>()` returns `null`, which is the discoverable
+"no timeout governance" signal.
+
+## Ordering and composition constraints
+
+- `UseRequestTimeouts` must be registered **before** `UseRouting` (and before anything
+  long-running it should govern): the middleware wraps its downstream, and endpoint policies
+  are observed only when routing runs inside the timeout scope.
+- Registration is expected once per pipeline. Nesting is not harmful (the innermost scope's
+  token is what downstream observes) but has no defined use.
+- Debugger suspension (`Debugger.IsAttached`, checked per request) skips the entire scope —
+  no timer, no decoration, no feature — mirroring ASP.NET.
+
+## AOT posture
+
+No reflection anywhere: policy resolution is an `is`-test scan over the metadata bag, the
+problem payload rides `Web.ProblemDetails`' `Utf8JsonWriter`-based writer, timers are
+`TimeProvider`/`CancellationTokenSource` plumbing, and the feature is resolved by type test.
+Nothing in the package (or its tests) needs dynamic code.
+
+## Non-goals
+
+- **No connection/parse-phase timeouts.** Keep-alive, request-head, and body data-rate
+  enforcement are transport limits (#791/#810, `HttpServerLimits`) — this package governs
+  *application execution time* only, from the moment the exchange enters the middleware.
+- **No attribute surface.** Policies attach as metadata objects at map time; an attribute
+  translation belongs to whatever source-generated mapping layer arrives later (#796).
+- **No per-route timer wheel or shared scheduler.** One CTS per governed exchange is the
+  simplest correct thing; optimize only with evidence.
+- **No 504 after the response has started** — physically impossible; the started path aborts.
+- **No Microsoft.Extensions dependencies, no separate hosting wiring.** The package composes
+  purely against the Web root's builder seams and ships to applications via `App.Web`.

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/OVERVIEW.md
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/OVERVIEW.md
@@ -1,0 +1,74 @@
+# Assimalign.Cohesion.Web.RequestTimeouts — Overview
+
+Request-timeout policies for the Cohesion Web pipeline. Cohesion's protocol core already ships
+the right primitive — the per-exchange, transport-aware cancel (`IHttpContext.RequestCancelled` +
+`Cancel`/`CancelAsync`, from #703) — but nothing armed it: a slow handler ran forever. This
+package is the policy layer that arms it.
+
+## What it does
+
+- **Global default policy** — configured at builder time on `UseRequestTimeouts`, applied to
+  every request the middleware sees.
+- **Per-endpoint policies** — a sealed `RequestTimeoutMetadata` carrier attached to a route's
+  endpoint-metadata bag (the #150 seam) overrides the default, resolved last-wins. An endpoint
+  can also opt out entirely via `RequestTimeoutMetadata.Disabled`.
+- **Expiry → cancellation** — the middleware hands downstream a context whose
+  `RequestCancelled` is a linked token that trips on expiry, so handlers, the router's
+  per-dispatch token, and anything else awaiting the request token unwind cooperatively.
+- **Expiry → response** — when the response has not started, the timed-out request is answered
+  imperatively with the policy's status (504 `Gateway Timeout` by default), optionally an
+  RFC 9457 `application/problem+json` payload (via `Web.ProblemDetails`), or a fully custom
+  `WriteResponse` handler. When the response *has* started (streamed head already committed),
+  the exchange is aborted cleanly at the protocol layer instead (`IHttpContext.CancelAsync`).
+- **Per-exchange control** — an `IHttpRequestTimeoutFeature` on the feature collection lets a
+  handler `Disable()` or re-arm (`SetTimeout`) its own exchange, mirroring ASP.NET's
+  `DisableRequestTimeout`.
+- **Debugger suspension** — enforcement is suspended while a debugger is attached (mirrors
+  ASP.NET; opt out via `RequestTimeoutOptions.SuspendWhenDebuggerAttached`).
+- **TimeProvider-based** — timers measure against `RequestTimeoutOptions.TimeProvider`
+  (`TimeProvider.System` by default), so expiry is deterministic under a test clock.
+
+## Usage
+
+```csharp
+// Global default: every request gets 30 seconds.
+application.UseRequestTimeouts(TimeSpan.FromSeconds(30));
+
+// Or configured: 504 with a problem+json payload.
+application.UseRequestTimeouts(options => options.DefaultPolicy = new RequestTimeoutPolicy
+{
+    Timeout = TimeSpan.FromSeconds(30),
+    WriteProblemDetails = true,
+});
+
+// Register BEFORE UseRouting so routed endpoints are governed and per-endpoint
+// metadata is observed.
+IRouterBuilder routes = application.UseRouting();
+
+// Per-endpoint override / disable via the endpoint metadata bag.
+routes.Map(new Route(HttpMethod.Get, "/report", handler,
+    new RouterRouteMetadataCollection(new RequestTimeoutMetadata(TimeSpan.FromMinutes(2)))));
+routes.Map(new Route(HttpMethod.Get, "/stream", streamHandler,
+    new RouterRouteMetadataCollection(RequestTimeoutMetadata.Disabled)));
+```
+
+## Public surface
+
+| Type | Role |
+| --- | --- |
+| `RequestTimeoutPolicy` | The policy value: `Timeout` (null = disabled), `StatusCode` (default 504), `WriteProblemDetails`, `WriteResponse` |
+| `RequestTimeoutMetadata` | Sealed endpoint-metadata carrier for a policy; `Disabled` opts an endpoint out |
+| `RequestTimeoutOptions` | Middleware options: `DefaultPolicy`, `TimeProvider`, `SuspendWhenDebuggerAttached` |
+| `IHttpRequestTimeoutFeature` | Per-exchange feature: `Token`, `Disable()`, `SetTimeout(TimeSpan)` |
+| `WebApplicationExtensions` | `UseRequestTimeouts(...)` pipeline verbs |
+
+## Dependencies
+
+`Assimalign.Cohesion.Web` (pipeline seams) · `Assimalign.Cohesion.Web.Routing` (route-match
+feature + endpoint metadata) · `Assimalign.Cohesion.Web.ProblemDetails` (timeout payload) ·
+`Assimalign.Cohesion.Http.Streaming` (response-started probe). Per the Web-area dependency rule
+it references no hosting module, holds no DI/configuration/logging state, and is delivered to
+applications through the `App.Web` shared framework.
+
+Design rationale — including why expiry does **not** trip the transport cancel while the
+response is writable — lives in [DESIGN.md](DESIGN.md).

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Abstractions/IHttpRequestTimeoutFeature.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Abstractions/IHttpRequestTimeoutFeature.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts;
+
+/// <summary>
+/// The per-exchange feature the request-timeout middleware installs on
+/// <see cref="IHttpContext.Features"/>, through which a handler can observe, disable, or re-arm
+/// the timeout governing its exchange (parity with ASP.NET's <c>IHttpRequestTimeoutFeature</c> /
+/// <c>DisableRequestTimeout</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extensibility stays on the feature-collection seam rather than attributes or reflection: the
+/// middleware attaches this feature to every exchange it governs, and downstream code resolves it
+/// with <c>context.Features.Get&lt;IHttpRequestTimeoutFeature&gt;()</c>. When the middleware is
+/// not registered (or is suspended for a debugger), no feature is present and the lookup returns
+/// <see langword="null"/>.
+/// </para>
+/// <para>
+/// <see cref="Disable"/> and <see cref="SetTimeout"/> take effect only while the timeout has not
+/// fired yet — once <see cref="Token"/> is cancelled the exchange is already being timed out and
+/// both are no-ops. This is the same inherent race ASP.NET documents for
+/// <c>DisableRequestTimeout</c>; call them early in the handler.
+/// </para>
+/// </remarks>
+public interface IHttpRequestTimeoutFeature : IHttpFeature
+{
+    /// <summary>
+    /// Gets the effective request-cancellation token for the exchange: it is cancelled when the
+    /// timeout expires <em>or</em> when the underlying request is cancelled (client abort,
+    /// connection teardown). Downstream of the middleware this is the same token
+    /// <see cref="IHttpContext.RequestCancelled"/> reports.
+    /// </summary>
+    CancellationToken Token { get; }
+
+    /// <summary>
+    /// Disables the timeout for this exchange, letting the handler run for as long as the
+    /// underlying request lives. A no-op when the timeout has already fired.
+    /// </summary>
+    void Disable();
+
+    /// <summary>
+    /// Re-arms the timeout to fire <paramref name="timeout"/> from now, replacing whatever
+    /// deadline the effective policy armed. A no-op when the timeout has already fired.
+    /// </summary>
+    /// <param name="timeout">The new interval, measured from the moment of the call.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is zero or negative.</exception>
+    void SetTimeout(TimeSpan timeout);
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Assimalign.Cohesion.Web.RequestTimeouts.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Assimalign.Cohesion.Web.RequestTimeouts.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>Request-timeout policies for the Cohesion Web pipeline: a builder-time global default plus per-endpoint policies carried as sealed endpoint metadata, enforced by a UseRequestTimeouts middleware that arms a TimeProvider-based timer per exchange and cancels downstream work on expiry. A timed-out request is answered with a configurable status (504 Gateway Timeout by default, optionally an RFC 9457 problem payload via Web.ProblemDetails) when the response has not started, or aborted cleanly at the protocol layer when it has. Suspends while a debugger is attached, mirroring ASP.NET.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Routing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.ProblemDetails" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Extensions/WebApplicationExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+
+using Assimalign.Cohesion.Web.RequestTimeouts.Internal;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts;
+
+/// <summary>
+/// Pipeline-builder members that add request-timeout enforcement to a web application.
+/// </summary>
+/// <remarks>
+/// Register <c>UseRequestTimeouts</c> <b>before</b> <c>UseRouting</c> (and before any other
+/// long-running middleware it should govern): the middleware wraps everything downstream of it,
+/// and it applies per-endpoint policies by observing the router publish its match — which only
+/// works when routing runs inside the timeout scope. Composition is dependency-free: the options
+/// are captured at builder time and no request-time service location occurs.
+/// </remarks>
+public static class WebApplicationExtensions
+{
+    extension(IWebApplicationPipelineBuilder builder)
+    {
+        /// <summary>
+        /// Adds the request-timeout middleware to the pipeline. With no configuration the
+        /// middleware applies no global timeout — only endpoints carrying
+        /// <see cref="RequestTimeoutMetadata"/> (or handlers arming
+        /// <see cref="IHttpRequestTimeoutFeature.SetTimeout"/>) are governed.
+        /// </summary>
+        /// <param name="configure">An optional callback to configure the middleware.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+        public IWebApplicationPipelineBuilder UseRequestTimeouts(Action<RequestTimeoutOptions>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            RequestTimeoutOptions options = new();
+            configure?.Invoke(options);
+
+            return builder.Use(new RequestTimeoutMiddleware(options));
+        }
+
+        /// <summary>
+        /// Adds the request-timeout middleware with a global default timeout, answered with the
+        /// default 504 status when it fires.
+        /// </summary>
+        /// <param name="defaultTimeout">The time any request may execute before it is timed out.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="defaultTimeout"/> is zero or negative.</exception>
+        public IWebApplicationPipelineBuilder UseRequestTimeouts(TimeSpan defaultTimeout)
+        {
+            return builder.UseRequestTimeouts(options =>
+                options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = defaultTimeout });
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/HttpRequestTimeoutFeature.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/HttpRequestTimeoutFeature.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Internal;
+
+/// <summary>
+/// The per-exchange timeout engine and the <see cref="IHttpRequestTimeoutFeature"/>
+/// implementation. Owns two cancellation sources: the timeout source (armed and re-armed against
+/// the composed <see cref="TimeProvider"/>) and a source linking it with the transport's
+/// <see cref="IHttpContext.RequestCancelled"/> — the linked token is what downstream work
+/// observes, so it trips on expiry <em>and</em> on a genuine request cancellation.
+/// </summary>
+/// <remarks>
+/// The timeout source is created unarmed (an infinite due time) so a per-endpoint policy or a
+/// handler's <see cref="SetTimeout"/> can arm it even when no global default exists. Re-arming
+/// after the source has fired is inherently a no-op (<see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/>
+/// cannot un-cancel), which is exactly the documented race semantic of <see cref="Disable"/>.
+/// </remarks>
+internal sealed class HttpRequestTimeoutFeature : IHttpRequestTimeoutFeature, IDisposable
+{
+    private readonly CancellationTokenSource _timeoutSource;
+    private readonly CancellationTokenSource _linkedSource;
+    private RequestTimeoutPolicy? _policy;
+
+    public HttpRequestTimeoutFeature(IHttpContext context, RequestTimeoutOptions options)
+    {
+        _timeoutSource = new CancellationTokenSource(Timeout.InfiniteTimeSpan, options.TimeProvider);
+        _linkedSource = CancellationTokenSource.CreateLinkedTokenSource(context.RequestCancelled, _timeoutSource.Token);
+        _policy = options.DefaultPolicy;
+
+        if (_policy?.Timeout is { } timeout)
+        {
+            _timeoutSource.CancelAfter(timeout);
+        }
+    }
+
+    public string Name => nameof(IHttpRequestTimeoutFeature);
+
+    public CancellationToken Token => _linkedSource.Token;
+
+    /// <summary>
+    /// The policy in effect for the exchange: the endpoint policy once one has been applied,
+    /// otherwise the global default; <see langword="null"/> when neither exists.
+    /// </summary>
+    public RequestTimeoutPolicy? EffectivePolicy => _policy;
+
+    /// <summary>
+    /// Whether the timeout timer has fired. Distinguishes an expiry from a genuine request
+    /// cancellation when both surface as an <see cref="OperationCanceledException"/> — the
+    /// middleware additionally checks that <see cref="IHttpContext.RequestCancelled"/> itself is
+    /// not cancelled before attributing the unwind to the timeout.
+    /// </summary>
+    public bool TimedOut => _timeoutSource.IsCancellationRequested;
+
+    public void Disable() => _timeoutSource.CancelAfter(Timeout.InfiniteTimeSpan);
+
+    public void SetTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                timeout,
+                "The request timeout must be a positive interval. Use Disable() to turn enforcement off.");
+        }
+
+        _timeoutSource.CancelAfter(timeout);
+    }
+
+    /// <summary>
+    /// Applies the matched endpoint's policy, replacing the global default: re-arms the timer to
+    /// the endpoint's interval (measured from the match) or disarms it for a disabled policy.
+    /// Invoked by the middleware's feature-collection decorator at the moment the router publishes
+    /// the route match — before the endpoint's handler runs.
+    /// </summary>
+    /// <param name="metadata">The endpoint's timeout metadata.</param>
+    public void ApplyEndpointPolicy(RequestTimeoutMetadata metadata)
+    {
+        _policy = metadata.Policy;
+
+        if (metadata.Policy.Timeout is { } timeout)
+        {
+            _timeoutSource.CancelAfter(timeout);
+        }
+        else
+        {
+            _timeoutSource.CancelAfter(Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    public void Dispose()
+    {
+        _linkedSource.Dispose();
+        _timeoutSource.Dispose();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutFeatureCollection.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutFeatureCollection.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Routing;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Internal;
+
+/// <summary>
+/// A pass-through <see cref="IHttpFeatureCollection"/> decorator that observes the router
+/// publishing its route match (<see cref="IRouteMatchFeature"/>) and applies the matched
+/// endpoint's <see cref="RequestTimeoutMetadata"/> to the exchange's timeout engine at that
+/// moment — after route selection, before the endpoint's handler runs.
+/// </summary>
+/// <remarks>
+/// Cohesion's router matches and dispatches in a single middleware, so there is no pipeline
+/// position "between match and handler" for a policy consumer to occupy. The documented routing
+/// contract — the router installs the match on <see cref="IHttpContext.Features"/> before
+/// invoking the handler — is therefore the seam: every installation funnels through the
+/// name-keyed <see cref="Set"/>, and the decorator reacts to the one feature type it cares about.
+/// All other members forward untouched.
+/// </remarks>
+internal sealed class RequestTimeoutFeatureCollection : IHttpFeatureCollection
+{
+    private readonly IHttpFeatureCollection _inner;
+    private readonly HttpRequestTimeoutFeature _feature;
+
+    public RequestTimeoutFeatureCollection(IHttpFeatureCollection inner, HttpRequestTimeoutFeature feature)
+    {
+        _inner = inner;
+        _feature = feature;
+    }
+
+    public int Version => _inner.Version;
+
+    public IHttpFeature? Get(string name) => _inner.Get(name);
+
+    public void Set(IHttpFeature? feature)
+    {
+        _inner.Set(feature);
+
+        if (feature is IRouteMatchFeature match &&
+            match.Metadata.GetMetadata<RequestTimeoutMetadata>() is { } metadata)
+        {
+            _feature.ApplyEndpointPolicy(metadata);
+        }
+    }
+
+    public bool Remove(string name) => _inner.Remove(name);
+
+    public IEnumerator<IHttpFeature> GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutHttpContext.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutHttpContext.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Internal;
+
+/// <summary>
+/// The <see cref="IHttpContext"/> the timeout middleware hands downstream: a pass-through
+/// decorator whose <see cref="RequestCancelled"/> is the timeout-linked token, so everything
+/// below the middleware — including the router's own per-dispatch linked token and any handler
+/// reading <c>context.RequestCancelled</c> — observes the timeout as a request cancellation.
+/// </summary>
+/// <remarks>
+/// The transport's real token cannot be swapped (<see cref="IHttpContext.RequestCancelled"/> is
+/// get-only and transport-owned), and tripping the transport's own cancel
+/// (<see cref="IHttpContext.Cancel"/>) makes every transport reset the exchange instead of
+/// sending a response — which would make the configured 504 undeliverable. Decorating the
+/// context keeps cancellation application-level while the exchange stays writable; the
+/// middleware still writes the timeout response on the <em>original</em> context it retained.
+/// <see cref="Features"/> is likewise decorated to observe the route-match publication for
+/// per-endpoint policy.
+/// </remarks>
+internal sealed class RequestTimeoutHttpContext : IHttpContext
+{
+    private readonly IHttpContext _inner;
+    private readonly HttpRequestTimeoutFeature _feature;
+    private readonly RequestTimeoutFeatureCollection _features;
+
+    public RequestTimeoutHttpContext(IHttpContext inner, HttpRequestTimeoutFeature feature)
+    {
+        _inner = inner;
+        _feature = feature;
+        _features = new RequestTimeoutFeatureCollection(inner.Features, feature);
+    }
+
+    public HttpVersion Version => _inner.Version;
+
+    public IHttpRequest Request => _inner.Request;
+
+    public IHttpResponse Response => _inner.Response;
+
+    public IHttpConnectionInfo ConnectionInfo => _inner.ConnectionInfo;
+
+    public IHttpFeatureCollection Features => _features;
+
+    public IDictionary<string, object?> Items => _inner.Items;
+
+    public CancellationToken RequestCancelled => _feature.Token;
+
+    public void Cancel() => _inner.Cancel();
+
+    public Task CancelAsync() => _inner.CancelAsync();
+
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/Internal/RequestTimeoutMiddleware.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Internal;
+
+/// <summary>
+/// The request-timeout middleware: arms a per-exchange timer (global default policy, overridden
+/// by the matched endpoint's <see cref="RequestTimeoutMetadata"/>), hands downstream a context
+/// whose <see cref="IHttpContext.RequestCancelled"/> is the timeout-linked token, and translates
+/// an expiry-attributable unwind into the configured timeout response — or a clean protocol-level
+/// abort when the response has already started.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Expiry attribution: a downstream <see cref="OperationCanceledException"/> is converted only
+/// when the timeout timer fired <em>and</em> the transport's own
+/// <see cref="IHttpContext.RequestCancelled"/> has not — a client-initiated abort therefore
+/// propagates unchanged (the server treats it as a clean drain) and is never mislabeled as a
+/// timeout. A handler that swallows the cancellation and completes keeps the response it
+/// produced, matching ASP.NET.
+/// </para>
+/// <para>
+/// The timeout path deliberately does <b>not</b> trip <see cref="IHttpContext.Cancel"/> while
+/// the response is still writable: every transport answers a cancel request by resetting the
+/// exchange instead of sending (HTTP/1.1 sends nothing and ends the connection; HTTP/2 and
+/// HTTP/3 reset the stream), so the 504 would never reach the client. Cancellation of downstream
+/// <em>work</em> rides the linked token instead, and <see cref="IHttpContext.CancelAsync"/> is
+/// reserved for the response-already-started path, where a wire reset is the only clean answer.
+/// </para>
+/// </remarks>
+internal sealed class RequestTimeoutMiddleware : IWebApplicationMiddleware
+{
+    // The status source when a timeout fires with no configured policy — possible only when a
+    // handler armed the timer itself through IHttpRequestTimeoutFeature.SetTimeout.
+    private static readonly RequestTimeoutPolicy FallbackPolicy = new();
+
+    private readonly RequestTimeoutOptions _options;
+
+    public RequestTimeoutMiddleware(RequestTimeoutOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task InvokeAsync(IHttpContext context, WebApplicationMiddleware next)
+    {
+        // Mirrors ASP.NET: a paused debug session must not cancel the request under inspection.
+        if (_options.SuspendWhenDebuggerAttached && Debugger.IsAttached)
+        {
+            await next.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        HttpRequestTimeoutFeature feature = new(context, _options);
+
+        try
+        {
+            context.Features.Set<IHttpRequestTimeoutFeature>(feature);
+
+            try
+            {
+                await next.Invoke(new RequestTimeoutHttpContext(context, feature)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (feature.TimedOut && !context.RequestCancelled.IsCancellationRequested)
+            {
+                await WriteTimeoutResponseAsync(context, feature.EffectivePolicy ?? FallbackPolicy).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            // Remove before disposing so later pipeline stages can never resolve a feature whose
+            // cancellation sources have been released.
+            context.Features.Set<IHttpRequestTimeoutFeature>(null);
+            feature.Dispose();
+        }
+    }
+
+    private static async Task WriteTimeoutResponseAsync(IHttpContext context, RequestTimeoutPolicy policy)
+    {
+        // Headers already committed to the wire (streamed responses): the status can no longer be
+        // changed, so the only clean answer is the protocol-level per-exchange abort — HTTP/2 and
+        // HTTP/3 reset the stream, HTTP/1.1 truncates and closes after the exchange.
+        if (context.Features.Get<IHttpResponseStreamingFeature>() is { HasStarted: true })
+        {
+            await context.CancelAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (policy.WriteResponse is { } writeResponse)
+        {
+            await writeResponse.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        ResetResponse(context.Response, policy.StatusCode);
+
+        if (policy.WriteProblemDetails)
+        {
+            // The request token is cancelled by definition here — the payload write must not
+            // observe it or the timeout response would cancel itself.
+            await context.Response
+                .WriteProblemDetailsAsync(ProblemDetails.FromStatus(policy.StatusCode), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static void ResetResponse(IHttpResponse response, HttpStatusCode statusCode)
+    {
+        // The handler may have staged headers and body bytes before it timed out; the timeout
+        // response replaces them (the imperative analog of ASP.NET's Response.Clear).
+        response.Headers.Clear();
+
+        if (response.Body.CanSeek)
+        {
+            response.Body.SetLength(0);
+        }
+        else
+        {
+            response.Body = new MemoryStream();
+        }
+
+        response.StatusCode = statusCode;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutMetadata.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutMetadata.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts;
+
+/// <summary>
+/// Endpoint metadata that attaches a <see cref="RequestTimeoutPolicy"/> to a route. Add an
+/// instance to a route's metadata collection to override the global default policy for that
+/// endpoint — including overriding it with <see cref="Disabled"/> to opt the endpoint out of
+/// timeout enforcement entirely.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The middleware resolves this metadata with last-wins semantics
+/// (<c>IRouterRouteMetadataCollection.GetMetadata&lt;TMetadata&gt;</c>), so an endpoint-level
+/// policy overrides a broader (for example group-level) one. The endpoint policy replaces the
+/// global default outright — policies do not merge member-by-member.
+/// </para>
+/// <para>
+/// This sealed carrier <em>is</em> the metadata contract — there is deliberately no
+/// <c>IRequestTimeoutMetadata</c> interface. Metadata items in the endpoint bag are immutable
+/// data carriers, and the sealed type guarantees the validated, immutable policy the middleware
+/// reads at request time.
+/// </para>
+/// </remarks>
+public sealed class RequestTimeoutMetadata
+{
+    /// <summary>
+    /// Creates request-timeout metadata carrying the supplied policy.
+    /// </summary>
+    /// <param name="policy">The timeout policy applied to requests matching the route.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="policy"/> is <see langword="null"/>.</exception>
+    public RequestTimeoutMetadata(RequestTimeoutPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        Policy = policy;
+    }
+
+    /// <summary>
+    /// Creates request-timeout metadata for a plain timeout interval, answered with the default
+    /// 504 status.
+    /// </summary>
+    /// <param name="timeout">The time a matching request may execute before it is timed out.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is zero or negative.</exception>
+    public RequestTimeoutMetadata(TimeSpan timeout)
+        : this(new RequestTimeoutPolicy { Timeout = timeout })
+    {
+    }
+
+    /// <summary>
+    /// Shared metadata that disables timeout enforcement for the endpoint it is attached to,
+    /// overriding any global default (parity with ASP.NET's <c>DisableRequestTimeoutAttribute</c>).
+    /// </summary>
+    public static RequestTimeoutMetadata Disabled { get; } = new(RequestTimeoutPolicy.Disabled);
+
+    /// <summary>
+    /// Gets the timeout policy applied to requests matching the route. Never <see langword="null"/>.
+    /// </summary>
+    public RequestTimeoutPolicy Policy { get; }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutOptions.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts;
+
+/// <summary>
+/// Builder-time options for the request-timeout middleware
+/// (<see cref="WebApplicationExtensions.UseRequestTimeouts(IWebApplicationPipelineBuilder, Action{RequestTimeoutOptions}?)"/>).
+/// </summary>
+public sealed class RequestTimeoutOptions
+{
+    private TimeProvider _timeProvider = TimeProvider.System;
+
+    /// <summary>
+    /// Gets or sets the global default timeout policy, applied to every request that reaches the
+    /// middleware unless the matched endpoint carries its own <see cref="RequestTimeoutMetadata"/>.
+    /// <see langword="null"/> (the default) applies no global timeout — only endpoints with
+    /// metadata are governed.
+    /// </summary>
+    public RequestTimeoutPolicy? DefaultPolicy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time source the per-request timers measure against. Defaults to
+    /// <see cref="TimeProvider.System"/>; inject a test provider to control expiry
+    /// deterministically.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value is set to <see langword="null"/>.</exception>
+    public TimeProvider TimeProvider
+    {
+        get => _timeProvider;
+        set => _timeProvider = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets whether timeout enforcement is suspended while a debugger is attached
+    /// (<see cref="System.Diagnostics.Debugger.IsAttached"/>), so a paused debug session does not
+    /// cancel the request under inspection. Defaults to <see langword="true"/>, mirroring
+    /// ASP.NET's request-timeouts middleware.
+    /// </summary>
+    public bool SuspendWhenDebuggerAttached { get; set; } = true;
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutPolicy.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/RequestTimeoutPolicy.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts;
+
+/// <summary>
+/// A request-timeout policy: how long a request may execute before it is timed out, and how the
+/// timeout is answered on the wire. The global default policy is configured at builder time
+/// through <see cref="RequestTimeoutOptions.DefaultPolicy"/>; per-endpoint policies are attached
+/// to routes as <see cref="RequestTimeoutMetadata"/> and override the default.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A policy with a <see langword="null"/> <see cref="Timeout"/> disables timeout enforcement for
+/// the requests it applies to — <see cref="Disabled"/> is the shared instance for that intent
+/// (parity with ASP.NET's <c>DisableRequestTimeoutAttribute</c>, expressed as policy data rather
+/// than an attribute). The response members are not used by a disabled policy.
+/// </para>
+/// <para>
+/// When a timeout fires and the response has not started, the middleware answers with
+/// <see cref="StatusCode"/> (504 by default). Set <see cref="WriteProblemDetails"/> to also write
+/// an RFC 9457 <c>application/problem+json</c> payload for the status, or supply
+/// <see cref="WriteResponse"/> to own the whole timeout response imperatively —
+/// <see cref="WriteResponse"/> wins over both.
+/// </para>
+/// </remarks>
+public sealed class RequestTimeoutPolicy
+{
+    private readonly TimeSpan? _timeout;
+
+    /// <summary>
+    /// A shared policy that disables timeout enforcement (its <see cref="Timeout"/> is
+    /// <see langword="null"/>). Attach it to a route via
+    /// <see cref="RequestTimeoutMetadata.Disabled"/> to opt an endpoint out of the global default.
+    /// </summary>
+    public static RequestTimeoutPolicy Disabled { get; } = new();
+
+    /// <summary>
+    /// Gets the time a request governed by this policy may execute before it is timed out, or
+    /// <see langword="null"/> to disable timeout enforcement.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value is set to a non-<see langword="null"/> interval that is zero or negative.
+    /// </exception>
+    public TimeSpan? Timeout
+    {
+        get => _timeout;
+        init
+        {
+            if (value is { } timeout && timeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    timeout,
+                    "The request timeout must be a positive interval. Use a null timeout to disable enforcement.");
+            }
+
+            _timeout = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the status code written when the timeout fires before the response has started.
+    /// Defaults to <see cref="HttpStatusCode.GatewayTimeout"/> (504).
+    /// </summary>
+    public HttpStatusCode StatusCode { get; init; } = HttpStatusCode.GatewayTimeout;
+
+    /// <summary>
+    /// Gets whether the timeout response carries an RFC 9457 <c>application/problem+json</c>
+    /// payload for <see cref="StatusCode"/> (written through the <c>Web.ProblemDetails</c>
+    /// writer). Defaults to <see langword="false"/> — a bare status response, matching ASP.NET's
+    /// request-timeouts middleware.
+    /// </summary>
+    public bool WriteProblemDetails { get; init; }
+
+    /// <summary>
+    /// Gets an optional handler that owns the whole timeout response. When set, the middleware
+    /// invokes it instead of writing <see cref="StatusCode"/> (and instead of the
+    /// <see cref="WriteProblemDetails"/> payload); the handler writes the response imperatively
+    /// on the supplied context. It is only invoked when the response has not started.
+    /// </summary>
+    public Func<IHttpContext, Task>? WriteResponse { get; init; }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/Assimalign.Cohesion.Web.RequestTimeouts.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/Assimalign.Cohesion.Web.RequestTimeouts.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.RequestTimeouts" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Hosting" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Routing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http.Streaming" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutEndToEndTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutEndToEndTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Routing;
+using Assimalign.Cohesion.Web.Routing.Metadata;
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Tests;
+
+/// <summary>
+/// Full-pipeline coverage over the <see cref="WebApplicationTestFactory"/> (in-memory HTTP/1.1):
+/// a slow handler is answered with 504 on the wire, per-endpoint metadata overrides the global
+/// default in both directions, and a disabled endpoint runs past the global timeout.
+/// </summary>
+public class RequestTimeoutEndToEndTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan GlobalTimeout = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan NeverInTestBudget = TimeSpan.FromSeconds(300);
+    private static readonly TimeSpan PastGlobalTimeout = TimeSpan.FromMilliseconds(600);
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: A slow handler should be answered with 504 on the wire")]
+    public async Task UseRequestTimeouts_SlowHandler_ShouldAnswer504()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.UseRequestTimeouts(GlobalTimeout);
+        factory.Application.Use(async (context, next) =>
+        {
+            await Task.Delay(NeverInTestBudget, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/slow", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: A problem-details policy should answer application/problem+json")]
+    public async Task UseRequestTimeouts_ProblemDetailsPolicy_ShouldAnswerProblemJson()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.UseRequestTimeouts(options => options.DefaultPolicy = new RequestTimeoutPolicy
+        {
+            Timeout = GlobalTimeout,
+            WriteProblemDetails = true,
+        });
+        factory.Application.Use(async (context, next) =>
+        {
+            await Task.Delay(NeverInTestBudget, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/slow", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.GatewayTimeout);
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("application/problem+json");
+
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        body.ShouldContain("\"status\":504", Case.Sensitive);
+        body.ShouldContain("Gateway Timeout", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: An endpoint policy shorter than the global default should win")]
+    public async Task UseRequestTimeouts_EndpointShorterThanGlobal_ShouldWinPrecedence()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Builder.AddRouting();
+
+        factory.Application.UseRequestTimeouts(NeverInTestBudget);
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/slow",
+            new RouterRouteHandler(async context =>
+            {
+                await Task.Delay(NeverInTestBudget, context.RequestCancelled);
+            }),
+            new RouterRouteMetadataCollection(new RequestTimeoutMetadata(GlobalTimeout))));
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act — only the 200ms endpoint policy can produce a response inside the test budget.
+        using HttpResponseMessage response = await client.GetAsync("/slow", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: An endpoint policy longer than the global default should extend past it")]
+    public async Task UseRequestTimeouts_EndpointLongerThanGlobal_ShouldExtendPastGlobal()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Builder.AddRouting();
+
+        factory.Application.UseRequestTimeouts(GlobalTimeout);
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/steady",
+            new RouterRouteHandler(async context =>
+            {
+                await Task.Delay(PastGlobalTimeout, context.RequestCancelled);
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("finished"), context.RequestCancelled);
+            }),
+            new RouterRouteMetadataCollection(new RequestTimeoutMetadata(NeverInTestBudget))));
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/steady", cancellationToken);
+
+        // Assert — the handler ran three times the global timeout and still completed.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("finished");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: A disabled endpoint should run past the global timeout")]
+    public async Task UseRequestTimeouts_EndpointDisabled_ShouldServePastGlobalTimeout()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Builder.AddRouting();
+
+        factory.Application.UseRequestTimeouts(GlobalTimeout);
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/unhurried",
+            new RouterRouteHandler(async context =>
+            {
+                await Task.Delay(PastGlobalTimeout, context.RequestCancelled);
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("unhurried"), context.RequestCancelled);
+            }),
+            new RouterRouteMetadataCollection(RequestTimeoutMetadata.Disabled)));
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/unhurried", cancellationToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldBe("unhurried");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - E2E: A client-cancelled request should surface as cancellation, not a timeout response")]
+    public async Task UseRequestTimeouts_ClientCancelsRequest_ShouldSurfaceAsCancellation()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using WebApplicationTestFactory factory = new();
+
+        factory.Application.UseRequestTimeouts(TimeSpan.FromSeconds(2));
+        factory.Application.Use(async (context, next) =>
+        {
+            await Task.Delay(NeverInTestBudget, context.RequestCancelled);
+        });
+
+        using HttpClient client = factory.CreateClient();
+        using CancellationTokenSource clientCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        clientCancellation.CancelAfter(TimeSpan.FromMilliseconds(150));
+
+        // Act / Assert — the client observes its own cancellation; no 504 arrives.
+        await Should.ThrowAsync<TaskCanceledException>(client.GetAsync("/abandoned", clientCancellation.Token));
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutMiddlewareTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutMiddlewareTests.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Tests;
+
+/// <summary>
+/// Middleware-level coverage for <c>UseRequestTimeouts</c> over the pipeline harness: expiry
+/// translation (504 / problem payload / custom writer / started-response abort), endpoint-policy
+/// precedence at the route-match seam, the per-exchange feature (disable / re-arm), timeout
+/// attribution against client aborts, and the injected <see cref="TimeProvider"/>.
+/// </summary>
+public class RequestTimeoutMiddlewareTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ArmedTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan NeverInTestBudget = TimeSpan.FromSeconds(300);
+    private static readonly TimeSpan PastArmedTimeout = TimeSpan.FromMilliseconds(450);
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - UseRequestTimeouts: Should throw on a null pipeline builder")]
+    public void UseRequestTimeouts_NullBuilder_ShouldThrow()
+    {
+        // Arrange
+        IWebApplicationPipelineBuilder builder = null!;
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => builder.UseRequestTimeouts());
+        Should.Throw<ArgumentNullException>(() => builder.UseRequestTimeouts(TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: Global policy expiry should write 504 and cancel downstream work")]
+    public async Task InvokeAsync_GlobalPolicyExpires_ShouldWrite504AndCancelDownstreamWork()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+        CancellationToken observedToken = default;
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            async ctx =>
+            {
+                observedToken = ctx.RequestCancelled;
+                await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+        observedToken.IsCancellationRequested.ShouldBeTrue();
+        context.CancelRequested.ShouldBeFalse();
+        context.RequestCancelled.IsCancellationRequested.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: Expiry should ride the injected TimeProvider, not wall time")]
+    public async Task InvokeAsync_InjectedTimeProvider_ShouldExpireOnlyWhenClockAdvances()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        ManualTimeProvider timeProvider = new();
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options =>
+            {
+                options.TimeProvider = timeProvider;
+                options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = NeverInTestBudget };
+            },
+            ctx => Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled));
+
+        // Act
+        Task execution = pipeline.ExecuteAsync(context, cancellationToken);
+
+        await Task.Delay(100, cancellationToken);
+        execution.IsCompleted.ShouldBeFalse();
+
+        timeProvider.Advance(NeverInTestBudget);
+        await execution.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: An endpoint policy shorter than the global default should win")]
+    public async Task InvokeAsync_EndpointPolicyShorterThanGlobal_ShouldTimeoutOnEndpointPolicy()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = NeverInTestBudget },
+            async ctx =>
+            {
+                // What UseRouting does between matching and dispatching: publish the match (with
+                // its endpoint metadata) on the context's feature collection, then run the handler.
+                ctx.Features.Set<Routing.IRouteMatchFeature>(new FakeRouteMatchFeature(new RequestTimeoutMetadata(ArmedTimeout)));
+                await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A disabled endpoint policy should run past the global timeout")]
+    public async Task InvokeAsync_EndpointPolicyDisabled_ShouldRunPastGlobalTimeout()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            async ctx =>
+            {
+                ctx.Features.Set<Routing.IRouteMatchFeature>(new FakeRouteMatchFeature(RequestTimeoutMetadata.Disabled));
+                await Task.Delay(PastArmedTimeout, ctx.RequestCancelled);
+                ctx.Response.StatusCode = HttpStatusCode.Ok;
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: An endpoint policy longer than the global default should replace its timer")]
+    public async Task InvokeAsync_EndpointPolicyLongerThanGlobal_ShouldReplaceGlobalTimer()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            async ctx =>
+            {
+                ctx.Features.Set<Routing.IRouteMatchFeature>(new FakeRouteMatchFeature(new RequestTimeoutMetadata(NeverInTestBudget)));
+                await Task.Delay(PastArmedTimeout, ctx.RequestCancelled);
+                ctx.Response.StatusCode = HttpStatusCode.Ok;
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert — had the global 100ms timer stayed armed, the 450ms handler would have been cancelled.
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Disable: The per-exchange feature should disarm the timeout")]
+    public async Task InvokeAsync_FeatureDisable_ShouldDisarmForTheExchange()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            async ctx =>
+            {
+                IHttpRequestTimeoutFeature feature = ctx.Features.Get<IHttpRequestTimeoutFeature>()!;
+                feature.Disable();
+
+                await Task.Delay(PastArmedTimeout, ctx.RequestCancelled);
+                ctx.Response.StatusCode = HttpStatusCode.Ok;
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - SetTimeout: A handler-armed timeout with no configured policy should answer 504")]
+    public async Task InvokeAsync_FeatureSetTimeout_WithoutConfiguredPolicy_ShouldArmAndAnswer504()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            configure: null,
+            async ctx =>
+            {
+                IHttpRequestTimeoutFeature feature = ctx.Features.Get<IHttpRequestTimeoutFeature>()!;
+                feature.SetTimeout(ArmedTimeout);
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A client abort should propagate and never be labeled a timeout")]
+    public async Task InvokeAsync_ClientAbort_ShouldPropagateCancellationWithout504()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = NeverInTestBudget },
+            async ctx =>
+            {
+                context.AbortClient();
+                await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+            });
+
+        // Act / Assert — the unwind reaches the server loop unchanged (its clean-drain path).
+        await Should.ThrowAsync<OperationCanceledException>(
+            pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
+
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.CancelRequested.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A started response should be aborted at the protocol layer instead of written")]
+    public async Task InvokeAsync_ResponseAlreadyStarted_ShouldAbortExchangeInsteadOfWriting504()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+        context.Features.Set<IHttpResponseStreamingFeature>(new FakeResponseStreamingFeature(hasStarted: true));
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            ctx => Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled));
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert — headers are on the wire, so the status must not be rewritten; the exchange is
+        // cancelled instead (transport reset: h2/h3 stream reset, h1 truncate-and-close).
+        context.CancelRequested.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A problem-details policy should write problem+json and reset the staged response")]
+    public async Task InvokeAsync_ProblemDetailsPolicy_ShouldWriteProblemPayloadAndResetStagedResponse()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy
+            {
+                Timeout = ArmedTimeout,
+                WriteProblemDetails = true,
+            },
+            async ctx =>
+            {
+                // Stage a partial response before timing out; the timeout answer must replace it.
+                ctx.Response.Headers[HttpHeaderKey.ContentType] = "text/plain";
+                await ctx.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("partial-body"), ctx.RequestCancelled);
+                await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+        context.Response.Headers[HttpHeaderKey.ContentType].ToString().ShouldBe("application/problem+json");
+
+        string body = context.ReadResponseBody();
+        body.ShouldContain("\"status\":504", Case.Sensitive);
+        body.ShouldContain("Gateway Timeout", Case.Sensitive);
+        body.ShouldNotContain("partial-body");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A custom WriteResponse handler should own the timeout response")]
+    public async Task InvokeAsync_CustomWriteResponse_ShouldOwnTheTimeoutResponse()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy
+            {
+                Timeout = ArmedTimeout,
+                WriteResponse = async ctx =>
+                {
+                    ctx.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+                    await ctx.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("custom-timeout"), CancellationToken.None);
+                },
+            },
+            ctx => Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled));
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        context.ReadResponseBody().ShouldBe("custom-timeout");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: A handler that completes despite the timeout should keep its response")]
+    public async Task InvokeAsync_HandlerCompletesDespiteTimeout_ShouldKeepHandlerResponse()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            options => options.DefaultPolicy = new RequestTimeoutPolicy { Timeout = ArmedTimeout },
+            async ctx =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ctx.RequestCancelled);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The handler owns the cancellation and still produces a response.
+                }
+
+                ctx.Response.StatusCode = HttpStatusCode.Ok;
+                await ctx.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("handled"), CancellationToken.None);
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert — only an expiry-attributable unwind is converted; a completed handler wins.
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("handled");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - InvokeAsync: With no policies the request should pass through and the feature should be cleaned up")]
+    public async Task InvokeAsync_NoPolicies_ShouldPassThroughAndCleanUpFeature()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using TimeoutTestContext context = new();
+        bool featurePresentDuringRequest = false;
+
+        IWebApplicationPipeline pipeline = BuildPipeline(
+            configure: null,
+            ctx =>
+            {
+                featurePresentDuringRequest = ctx.Features.Get<IHttpRequestTimeoutFeature>() is not null;
+                ctx.Response.StatusCode = HttpStatusCode.Ok;
+                return Task.CompletedTask;
+            });
+
+        // Act
+        await pipeline.ExecuteAsync(context, cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        featurePresentDuringRequest.ShouldBeTrue();
+        context.Features.Get<IHttpRequestTimeoutFeature>().ShouldBeNull();
+        context.RequestCancelled.IsCancellationRequested.ShouldBeFalse();
+    }
+
+    private static IWebApplicationPipeline BuildPipeline(
+        Action<RequestTimeoutOptions>? configure,
+        WebApplicationMiddleware terminal)
+    {
+        TestPipelineBuilder builder = new();
+        builder.UseRequestTimeouts(configure);
+        builder.Use(next => context => terminal.Invoke(context));
+
+        return builder.Build();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutPolicyTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/RequestTimeoutPolicyTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading;
+
+using Assimalign.Cohesion.Http;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Tests;
+
+/// <summary>
+/// Model-level coverage for <see cref="RequestTimeoutPolicy"/>, <see cref="RequestTimeoutMetadata"/>,
+/// and <see cref="RequestTimeoutOptions"/>: defaults, validation, and the disabled spellings.
+/// </summary>
+public class RequestTimeoutPolicyTests
+{
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Policy: Defaults should be a bare 504 with no timeout")]
+    public void Policy_Defaults_ShouldBeBare504WithNoTimeout()
+    {
+        // Arrange / Act
+        RequestTimeoutPolicy policy = new();
+
+        // Assert
+        policy.Timeout.ShouldBeNull();
+        policy.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+        policy.WriteProblemDetails.ShouldBeFalse();
+        policy.WriteResponse.ShouldBeNull();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Policy: A zero or negative timeout should throw")]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Policy_ZeroOrNegativeTimeout_ShouldThrow(int milliseconds)
+    {
+        // Arrange
+        TimeSpan timeout = TimeSpan.FromMilliseconds(milliseconds);
+
+        // Act / Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => new RequestTimeoutPolicy { Timeout = timeout });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Policy: An infinite timeout should throw (null is the disable spelling)")]
+    public void Policy_InfiniteTimeout_ShouldThrow()
+    {
+        // Arrange / Act / Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => new RequestTimeoutPolicy { Timeout = Timeout.InfiniteTimeSpan });
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Policy: Disabled should carry a null timeout")]
+    public void Policy_Disabled_ShouldCarryNullTimeout()
+    {
+        // Arrange / Act / Assert
+        RequestTimeoutPolicy.Disabled.Timeout.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Metadata: A null policy should throw")]
+    public void Metadata_NullPolicy_ShouldThrow()
+    {
+        // Arrange / Act / Assert
+        Should.Throw<ArgumentNullException>(() => new RequestTimeoutMetadata((RequestTimeoutPolicy)null!));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Metadata: The timeout constructor should carry a default-504 policy")]
+    public void Metadata_TimeoutConstructor_ShouldCarryDefault504Policy()
+    {
+        // Arrange
+        TimeSpan timeout = TimeSpan.FromSeconds(3);
+
+        // Act
+        RequestTimeoutMetadata metadata = new(timeout);
+
+        // Assert
+        metadata.Policy.Timeout.ShouldBe(timeout);
+        metadata.Policy.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Metadata: A zero or negative timeout should throw")]
+    public void Metadata_ZeroOrNegativeTimeout_ShouldThrow()
+    {
+        // Arrange / Act / Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => new RequestTimeoutMetadata(TimeSpan.Zero));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Metadata: Disabled should carry the disabled policy")]
+    public void Metadata_Disabled_ShouldCarryDisabledPolicy()
+    {
+        // Arrange / Act / Assert
+        RequestTimeoutMetadata.Disabled.Policy.ShouldBeSameAs(RequestTimeoutPolicy.Disabled);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Options: Defaults should be no global policy, the system clock, and debugger suspension")]
+    public void Options_Defaults_ShouldBeNoPolicySystemClockAndDebuggerSuspension()
+    {
+        // Arrange / Act
+        RequestTimeoutOptions options = new();
+
+        // Assert
+        options.DefaultPolicy.ShouldBeNull();
+        options.TimeProvider.ShouldBeSameAs(TimeProvider.System);
+        options.SuspendWhenDebuggerAttached.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.RequestTimeouts] - Options: A null TimeProvider should throw")]
+    public void Options_NullTimeProvider_ShouldThrow()
+    {
+        // Arrange
+        RequestTimeoutOptions options = new();
+
+        // Act / Assert
+        Should.Throw<ArgumentNullException>(() => options.TimeProvider = null!);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/TestObjects/RequestTimeoutTestObjects.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/TestObjects/RequestTimeoutTestObjects.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+using Assimalign.Cohesion.Web.Routing;
+
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.RequestTimeouts.Tests;
+
+/// <summary>
+/// Minimal <see cref="IWebApplicationPipelineBuilder"/> that composes middleware in registration
+/// order — the same shape the real <c>WebApplication</c> builder produces — without pulling in
+/// the hosting/DI stack.
+/// </summary>
+internal sealed class TestPipelineBuilder : IWebApplicationPipelineBuilder
+{
+    private readonly List<Func<WebApplicationMiddleware, WebApplicationMiddleware>> _middleware = new();
+
+    public IWebApplicationPipelineBuilder Use(Func<WebApplicationMiddleware, WebApplicationMiddleware> middleware)
+    {
+        _middleware.Add(middleware);
+        return this;
+    }
+
+    public IWebApplicationPipelineBuilder Use(IWebApplicationMiddleware middleware)
+        => Use(next => context => middleware.InvokeAsync(context, next));
+
+    public IWebApplicationPipelineBuilder Use(Func<IWebApplicationContext, WebApplicationMiddleware, WebApplicationMiddleware> middleware)
+        => throw new NotSupportedException();
+
+    public IWebApplicationPipeline Build()
+    {
+        WebApplicationMiddleware pipeline = _ => Task.CompletedTask;
+        for (int i = _middleware.Count - 1; i >= 0; i--)
+        {
+            pipeline = _middleware[i].Invoke(pipeline);
+        }
+
+        return new TestPipeline(pipeline);
+    }
+
+    private sealed class TestPipeline : IWebApplicationPipeline
+    {
+        private readonly WebApplicationMiddleware _middleware;
+
+        public TestPipeline(WebApplicationMiddleware middleware) => _middleware = middleware;
+
+        public Task ExecuteAsync(IHttpContext context, CancellationToken cancellationToken = default)
+            => _middleware.Invoke(context);
+    }
+}
+
+/// <summary>
+/// A configurable <see cref="IHttpContext"/> test double whose request-cancellation token is
+/// backed by a real source, with the transport cancel-request flag recorded the way
+/// <c>TransportHttpContext</c> records it.
+/// </summary>
+internal sealed class TimeoutTestContext : IHttpContext
+{
+    private readonly CancellationTokenSource _requestAborted = new();
+
+    public TimeoutTestContext(string path = "/", HttpMethod? method = null)
+    {
+        Request = new TestHttpRequest(this, path, method ?? HttpMethod.Get);
+        Response = new TestHttpResponse(this);
+    }
+
+    public HttpVersion Version => HttpVersion.Http11;
+    public IHttpRequest Request { get; }
+    public IHttpResponse Response { get; }
+    public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
+    public IHttpFeatureCollection Features { get; } = new HttpFeatureCollection();
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+    public CancellationToken RequestCancelled => _requestAborted.Token;
+
+    /// <summary>Whether <see cref="Cancel"/>/<see cref="CancelAsync"/> was invoked (the transport reset path).</summary>
+    public bool CancelRequested { get; private set; }
+
+    public void Cancel()
+    {
+        CancelRequested = true;
+        _requestAborted.Cancel();
+    }
+
+    public Task CancelAsync()
+    {
+        Cancel();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Trips the underlying request token without the cancel-request flag — a client abort.</summary>
+    public void AbortClient() => _requestAborted.Cancel();
+
+    public ValueTask DisposeAsync()
+    {
+        _requestAborted.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    public string ReadResponseBody()
+    {
+        MemoryStream stream = (MemoryStream)Response.Body;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+}
+
+internal sealed class TestHttpRequest : IHttpRequest
+{
+    public TestHttpRequest(IHttpContext context, string path, HttpMethod method)
+    {
+        HttpContext = context;
+        Path = new HttpPath(path);
+        Method = method;
+    }
+
+    public HttpHost Host => HttpHost.Empty;
+    public HttpPath Path { get; }
+    public HttpMethod Method { get; }
+    public HttpScheme Scheme => HttpScheme.Http;
+    public IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body => Stream.Null;
+}
+
+internal sealed class TestHttpResponse : IHttpResponse
+{
+    public TestHttpResponse(IHttpContext context) => HttpContext = context;
+
+    public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body { get; set; } = new MemoryStream();
+}
+
+/// <summary>
+/// A stand-in for the router's route-match publication: installing it on the (decorated) feature
+/// collection is exactly what <c>UseRouting</c> does between matching and dispatching.
+/// </summary>
+internal sealed class FakeRouteMatchFeature : IRouteMatchFeature
+{
+    private readonly IRouterRouteMetadataCollection _metadata;
+
+    public FakeRouteMatchFeature(params object[] metadata)
+        => _metadata = new Routing.Metadata.RouterRouteMetadataCollection(metadata);
+
+    public string Name => nameof(IRouteMatchFeature);
+    public IRouterRoute? Route => null;
+    public RouteValueDictionary? Values => null;
+    public IRouterRouteMetadataCollection Metadata => _metadata;
+}
+
+/// <summary>
+/// A fake response-streaming feature reporting a started (head-committed) response, as the
+/// streaming feature package would after the handler's first streamed write.
+/// </summary>
+internal sealed class FakeResponseStreamingFeature : IHttpResponseStreamingFeature
+{
+    public FakeResponseStreamingFeature(bool hasStarted) => HasStarted = hasStarted;
+
+    public string Name => nameof(IHttpResponseStreamingFeature);
+    public bool HasStarted { get; }
+    public ValueTask StartAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public ValueTask CompleteAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// A hand-rolled <see cref="TimeProvider"/> whose timers fire only when the test advances the
+/// clock — proving the middleware measures against the composed provider rather than wall time.
+/// (The repo cannot use <c>Microsoft.Extensions.Time.Testing</c>.)
+/// </summary>
+internal sealed class ManualTimeProvider : TimeProvider
+{
+    private readonly Lock _gate = new();
+    private readonly List<ManualTimer> _timers = new();
+    private DateTimeOffset _utcNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        lock (_gate)
+        {
+            return _utcNow;
+        }
+    }
+
+    public override long GetTimestamp()
+    {
+        lock (_gate)
+        {
+            return _utcNow.UtcTicks;
+        }
+    }
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        ManualTimer timer = new(this, callback, state, dueTime);
+        lock (_gate)
+        {
+            _timers.Add(timer);
+        }
+
+        return timer;
+    }
+
+    /// <summary>Advances the clock, firing every timer whose due time elapses.</summary>
+    public void Advance(TimeSpan delta)
+    {
+        List<ManualTimer> due = new();
+
+        lock (_gate)
+        {
+            _utcNow += delta;
+
+            foreach (ManualTimer timer in _timers)
+            {
+                if (timer.AdvanceAndCheckDue(delta))
+                {
+                    due.Add(timer);
+                }
+            }
+        }
+
+        // Fire outside the gate: a callback cancels a CancellationTokenSource, which may run
+        // continuations inline and re-enter the provider (e.g. to re-arm or dispose a timer).
+        foreach (ManualTimer timer in due)
+        {
+            timer.Fire();
+        }
+    }
+
+    private void Remove(ManualTimer timer)
+    {
+        lock (_gate)
+        {
+            _timers.Remove(timer);
+        }
+    }
+
+    private sealed class ManualTimer : ITimer
+    {
+        private readonly ManualTimeProvider _owner;
+        private readonly TimerCallback _callback;
+        private readonly object? _state;
+        private TimeSpan? _remaining;
+
+        public ManualTimer(ManualTimeProvider owner, TimerCallback callback, object? state, TimeSpan dueTime)
+        {
+            _owner = owner;
+            _callback = callback;
+            _state = state;
+            _remaining = Normalize(dueTime);
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            lock (_owner._gate)
+            {
+                _remaining = Normalize(dueTime);
+            }
+
+            return true;
+        }
+
+        public bool AdvanceAndCheckDue(TimeSpan delta)
+        {
+            if (_remaining is not { } remaining)
+            {
+                return false;
+            }
+
+            remaining -= delta;
+            if (remaining <= TimeSpan.Zero)
+            {
+                _remaining = null;
+                return true;
+            }
+
+            _remaining = remaining;
+            return false;
+        }
+
+        public void Fire() => _callback.Invoke(_state);
+
+        public void Dispose() => _owner.Remove(this);
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        private static TimeSpan? Normalize(TimeSpan dueTime)
+            => dueTime == Timeout.InfiniteTimeSpan ? null : dueTime;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.slnx
+++ b/resources/Web/Assimalign.Cohesion.Web.slnx
@@ -190,6 +190,17 @@
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Query/tests/">
 		<Project Path="Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.RequestTimeouts/" />
+	<Folder Name="/Web/Assimalign.Cohesion.Web.RequestTimeouts/docs/">
+		<File Path="Assimalign.Cohesion.Web.RequestTimeouts/docs/DESIGN.md" />
+		<File Path="Assimalign.Cohesion.Web.RequestTimeouts/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.RequestTimeouts/src/">
+		<Project Path="Assimalign.Cohesion.Web.RequestTimeouts/src/Assimalign.Cohesion.Web.RequestTimeouts.csproj" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.RequestTimeouts/tests/">
+		<Project Path="Assimalign.Cohesion.Web.RequestTimeouts/tests/Assimalign.Cohesion.Web.RequestTimeouts.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Routing/">
 		<File Path="Assimalign.Cohesion.Web.Routing/README.md" />
 	</Folder>

--- a/resources/Web/README.md
+++ b/resources/Web/README.md
@@ -72,6 +72,7 @@ A new `Assimalign.Cohesion.Web.<Feature>` project is not done until all of these
 | `Assimalign.Cohesion.Web.ProblemDetails` | The RFC 9457 problem+json payload (model + AOT-safe writer + `WriteProblemDetailsAsync`) |
 | `Assimalign.Cohesion.Web.Query` | RFC 10008 QUERY server rules: request Content-Type validation / Accept-Query negotiation (400/415/406), method-preserving redirect helpers (307/308, 303), conditional QUERY (304/412) |
 | `Assimalign.Cohesion.Web.HostFiltering` | Allowed-hosts enforcement (`UseHostFiltering`, register first): 400s requests whose transport-resolved host misses the allowlist |
+| `Assimalign.Cohesion.Web.RequestTimeouts` | Request-timeout policies over the per-exchange abort primitive: global default + per-endpoint metadata, expiry → cancellation + configurable 504 |
 | `Assimalign.Cohesion.Web.Authentication` / `.Cookie` / `.Bearer` | Scheme model + builder surface, and the handler packages that graft their scheme verbs onto it |
 | `Assimalign.Cohesion.Web.Authorization` | Authorization contracts (in design) |
 | `Assimalign.Cohesion.Web.ForwardedHeaders` | First-position forwarded-headers middleware (`UseForwardedHeaders`): proxy trust model over the core `Http` parsing primitives, publishing the `Http.Forwarded` effective-identity feature |


### PR DESCRIPTION
## Summary

Implements **[L03.01.01.13] Request-timeout policies over the request-lifetime abort feature**: a new `resources/Web/Assimalign.Cohesion.Web.RequestTimeouts` feature library that arms the #703 per-exchange abort primitive with middleware-first timeout policies.

- **Global default policy** at builder time: `UseRequestTimeouts(TimeSpan)` / `UseRequestTimeouts(options => …)` on the pipeline builder (values captured at composition, no DI, no request-time service location).
- **Per-endpoint policies** on the merged #150 endpoint metadata bag via a **sealed `RequestTimeoutMetadata` carrier** (no interface-per-concept, per the metadata-carrier discipline; `RouteNameMetadata`/`RouteHostMetadata` precedent). Last-wins resolution; `RequestTimeoutMetadata.Disabled` opts an endpoint out of the global default.
- **Middleware** arms one `TimeProvider`-bound timer per exchange and hands downstream a decorated context whose `RequestCancelled` is the timeout-linked token — handlers, and the router's per-dispatch handler token (linked off the decorated context), all unwind cooperatively on expiry.
- **Expiry translation:** response not started → imperative, configurable **504** (`RequestTimeoutPolicy.StatusCode`), optionally an RFC 9457 `application/problem+json` payload via `Web.ProblemDetails` (`WriteProblemDetails`), or a fully custom `WriteResponse` handler; staged headers/body are reset first. Response already started (streamed head committed) → **clean protocol-level abort** via `IHttpContext.CancelAsync()` (h2/h3 stream reset, h1 truncate-and-close).
- **Attribution:** an unwind converts to a timeout response only when the timer fired *and* the transport token is untripped — a client abort propagates unchanged and is never mislabeled.
- **Per-exchange control:** `IHttpRequestTimeoutFeature` (`Token` / `Disable()` / `SetTimeout(TimeSpan)`) on the feature collection — ASP.NET `DisableRequestTimeout` parity without attributes/reflection.
- **Debugger suspension:** enforcement skipped while `Debugger.IsAttached` (opt-out via options), mirroring ASP.NET.
- AOT-safe throughout: no reflection; `is`-test metadata scans, `TimeProvider` + `CancellationTokenSource` plumbing, `Utf8JsonWriter`-based payload.

### Deviation from the issue's literal acceptance text (deliberate, documented)

The issue sketched "on expiry call `IHttpContext.CancelAsync()` … write the configured status if the response has not started." Those two halves are mutually exclusive on the wire: **every transport answers `CancelRequested` by resetting the exchange instead of sending** (`Http1ConnectionContext.SendAsync` writes nothing and ends keep-alive; h2 `RST_STREAM`; h3 stream reset), so a 504 written after `CancelAsync()` would never reach the client. The design therefore splits by response state — linked-token cancellation + deliverable 504 while writable, `CancelAsync()` once the head is on the wire. Full rationale in the package `docs/DESIGN.md`, verified end-to-end by the Web.Testing tests (the client actually receives the 504).

### Per-endpoint resolution seam

Cohesion's router matches **and** dispatches in one middleware, so there is no pipeline position between match and handler. The middleware observes the documented route-match publication (`IRouteMatchFeature` installed on `Features` before the handler runs) through its pass-through context/feature-collection decorators and applies the endpoint policy at exactly that boundary. Alternatives (double-matching, fire-time re-resolution, teaching the router about timeouts) and why they lose are recorded in `docs/DESIGN.md`.

## Wiring (new-Web-project checklist)

- `frameworks/Assimalign.Cohesion.App.props` — added to the `App.Web` ItemGroup (validated: `App.Web.Runtime` pack collects `Assimalign.Cohesion.Web.RequestTimeouts.dll`; no new outside-area transitives — `Http.Streaming` etc. already ship).
- `resources/Web/Assimalign.Cohesion.Web.slnx` + root `Assimalign.Cohesion.slnx`.
- `.github/workflows/resource-web.yml` matrix (hosting-isolation guard runs in CI; the package references no `Web.Hosting` — COHRES001/002 clean by construction).
- `resources/Web/README.md` project-map row; package `docs/OVERVIEW.md` + `docs/DESIGN.md`.

> Note for the orchestrator: sibling Batch-4a sessions also touch `App.props`/the CI matrix — both edits here are single alphabetized lines, rebases are trivial.

## Tests (31, all green)

- **Web.Testing end-to-end (in-memory h1, real wire):** slow handler → client receives **504**; problem+json payload + content-type; endpoint-shorter-than-global wins; endpoint-longer-than-global extends past the global timer; `Disabled` endpoint serves past the global timeout; client-cancelled request surfaces as cancellation (no 504).
- **Middleware-level:** expiry rides an injected manual `TimeProvider` (no wall-clock dependence); global expiry writes 504 + cancels the downstream token without tripping the transport; endpoint precedence both directions at the match seam; feature `Disable`/`SetTimeout` (including handler-armed timeout with no configured policy); client abort propagates un-mislabeled; started-response path aborts via `CancelAsync` without rewriting the status; handler that completes despite expiry keeps its response; staged partial response reset before the problem payload; no-policy passthrough + feature cleanup.
- **Model:** policy/metadata/options defaults and validation (positive-interval guard, null guards, `Disabled` spellings).

## Work items resolved by this PR

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
