### PR TITLE
feat(web.diagnostics): Web.Diagnostics — HTTP logging middleware + W3C access-log provider [L03.01.01.16]

### DIFF
--- a/.github/workflows/resource-web.yml
+++ b/.github/workflows/resource-web.yml
@@ -28,6 +28,7 @@ jobs:
             'Assimalign.Cohesion.Web.Authorization',
             'Assimalign.Cohesion.Web.CookiePolicy',
             'Assimalign.Cohesion.Web.Cors',
+            'Assimalign.Cohesion.Web.Diagnostics',
             'Assimalign.Cohesion.Web.Forms',
             'Assimalign.Cohesion.Web.ForwardedHeaders',
             'Assimalign.Cohesion.Web.Health',

--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -2088,6 +2088,17 @@
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Cors/tests/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.Cors/tests/Assimalign.Cohesion.Web.Cors.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Diagnostics/" />
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/DESIGN.md" />
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Assimalign.Cohesion.Web.Diagnostics.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/Assimalign.Cohesion.Web.Diagnostics.Tests.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Forms/" />
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Forms/src/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.Forms/src/Assimalign.Cohesion.Web.Forms.csproj" />

--- a/frameworks/Assimalign.Cohesion.App.props
+++ b/frameworks/Assimalign.Cohesion.App.props
@@ -160,6 +160,7 @@
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Authorization" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.CookiePolicy" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Cors" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Diagnostics" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Forms" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.ForwardedHeaders" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Health" />

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/DESIGN.md
@@ -1,0 +1,164 @@
+# Assimalign.Cohesion.Web.Diagnostics — Design
+
+## Design intent
+
+Access/request logging is table-stakes for a production web server: audit-grade request lines,
+header capture with redaction, duration/status, and W3C log files existing tooling can ingest.
+This package is the Web area's one diagnostics module (issue #794) — deliberately a single
+project holding both the HTTP logging middleware and the W3C access-log writer, not
+ASP.NET-style micro-packages.
+
+The load-bearing decision is that **emission rides Cohesion's own Logging model**. The
+middleware produces ordinary `LoggerEntry` values through the composed `ILogger`; the W3C
+writer is an ordinary `ILoggerProvider` registered on the same `LoggerFactoryBuilder` as
+console/debug sinks. Nothing here invents a second pipeline, and every existing logging
+facility — provider fan-out, factory filter rules, enrichers, scopes — applies to access-log
+entries for free.
+
+## The attribute contract
+
+The middleware and the provider are decoupled by the stable attribute names in
+`HttpLoggingAttributes` (`http.request.method`, `http.response.status`, `http.duration`, ...),
+aligned with OpenTelemetry HTTP semantic conventions where one exists but without any OTel
+dependency. The provider renders **only** entries stamped `http.event = "exchange"` and ignores
+everything else, so it is safe on a factory that also carries application logging. This is the
+same seam a future OTLP/OpenTelemetry adapter would consume (#583/#317): correlation concepts
+(trace/span ids as attributes) live here; OTel-specific behavior belongs in later adapters.
+
+Trace correlation is the inbound `traceparent` header, span-parsed (`Internal/TraceParent`)
+into `trace.id`/`span.id` attributes when valid. Optionally (`LogRequestStart`), a start entry
+seeds an `IScopedLogger` scope so the completion entry correlates via `ILoggerEntry.ParentId` —
+the Logging library's own correlation mechanism, not a bespoke one.
+
+## Why-this-not-that
+
+- **Explicit logger at composition time, not DI.** `UseHttpLogging(ILogger | ILoggerFactory, ...)`
+  takes its dependency the way `MapHealthChecks(IHealthCheckService)` does: handed in when the
+  pipeline is composed. The alternative — resolving `ILoggerFactory` from a container at request
+  time — violates the repo's `*.Hosting`-only DI rule and is exactly the request-time service
+  location the Web composition model forbids.
+- **Options frozen into a snapshot at `Use` time.** `HttpLoggingOptions` is scratch space;
+  `HttpLoggingSnapshot` (frozen sets, validated limits) is what the middleware holds. Mutating
+  options after composition has no effect — the same parse-once discipline as the routing
+  metadata carriers. There is no request-time configuration surface to misuse.
+- **Allowlist redaction, not a denylist.** A denylist fails open: every new sensitive header
+  leaks until someone remembers to add it. The allowlist fails closed — a header's value logs
+  only when explicitly allowed, and `Authorization`/`Proxy-Authorization`/`Cookie`/`Set-Cookie`
+  are simply never in the defaults. Header *names* still log, preserving diagnostic signal
+  (presence/absence) without the values. `RequestQuery` is likewise excluded from
+  `HttpLoggingFields.Default` — query strings carry tokens; ASP.NET made the same call.
+- **Tee-capture streams, never buffering.** Body capture wraps the body streams and copies the
+  first N bytes as they flow; the bytes themselves stream through untouched. h2 flow-control
+  backpressure (#750), h1 data-rate gates (#810), and the request-size limits (#764/#818) all
+  behave exactly as without the middleware. The alternative (buffer-then-log, ASP.NET's
+  `EnableBuffering`) would hold entire bodies in memory and fight the transport's
+  consumption-driven window updates.
+- **Request-body interposition via the `HttpRequest` base, degrading gracefully.**
+  `IHttpRequest.Body` is get-only, but the abstract `HttpRequest` base (which every transport
+  derives from) has a settable `Body`. The middleware type-tests for the base; a hypothetical
+  `IHttpRequest` that isn't an `HttpRequest` simply gets no request-body capture or count. The
+  response side needs no such test — `IHttpResponse.Body` is settable by contract.
+- **Response capture decided at first write.** The response `Content-Type` does not exist when
+  the middleware runs, so the content-type gate for response capture is a predicate the wrapper
+  evaluates once, at the application's first body write — by which point the response head is
+  set. Request capture is decided upfront from the request headers.
+- **Per-endpoint overrides read after `next`, not before.** The logging middleware sits ahead
+  of routing (it must see unrouted requests), so no endpoint is known when it starts. By the
+  time the downstream pipeline completes, routing has installed `IRouteMatchFeature`, and one
+  metadata lookup (`GetMetadata<HttpLoggingMetadata>`, last-wins) is effectively free. The
+  consequence is honest and documented: an override freely widens/narrows *emission-time*
+  fields (request line, headers, status, duration — all still readable post-pipeline), but the
+  *capture* fields (`RequestBody`/`ResponseBody`/`BytesTransferred`) can only narrow, because
+  the streams were armed (or not) before routing ran. `HttpLoggingFields.None` suppresses the
+  entry entirely — the health-probe case. `HttpLoggingMetadata` is a sealed concrete carrier
+  per the metadata-carrier discipline; there is no `IHttpLoggingMetadata`.
+- **Effective client address is a seam, not a guess.** The default logs the transport socket
+  peer (`IHttpConnectionInfo.RemoteIp`) — the only honest answer until a trust model exists.
+  The middleware never parses `X-Forwarded-For` itself; when the forwarded-headers middleware
+  (#778) merges, its trusted result plugs in through
+  `HttpLoggingOptions.ClientAddressResolver`. A faulting resolver falls back to the socket peer
+  rather than failing the exchange.
+- **One package, two halves.** The provider could live in `libraries/Logging.File`, but the W3C
+  format is defined by HTTP exchange semantics (`cs-method`, `sc-status`, `time-taken`), i.e. by
+  the attribute contract this package owns. Shipping them together keeps the contract and its
+  renderer in one place; a general-purpose file logging provider remains future Logging-area
+  work (see Non-goals).
+- **`Logger`/`LoggerProvider`/`ScopedLogger` base classes, not raw interfaces.** The provider
+  subclasses the Logging library's guided bases — the repo's interface-first-with-guided-base
+  pattern — inheriting category validation, idempotent disposal, and the single-virtual-call
+  hot path.
+
+## Emission model
+
+One entry per completed exchange, emitted in the middleware's `finally`:
+
+- **Level** — `Options.Level` (default `Information`); escalated to `Error` with the exception
+  attached when the downstream pipeline throws (the exception is rethrown — observing is this
+  package's job, the exception *boundary* is #881's).
+- **Message** — `"GET /orders -> 200 in 12.345 ms"`, composed only from enabled fields
+  (invariant culture, `string.Create`); `"(faulted)"` appended on exceptions.
+- **Attributes** — per the `HttpLoggingAttributes` contract, only for enabled fields.
+- **Never throws.** Attribute building is guarded; a logging failure cannot fail an exchange or
+  mask an application exception mid-unwind. Sink failures are already isolated by the logging
+  pipeline's own contract.
+- **Fast off-switch:** when the composed logger reports `Options.Level` disabled, the
+  middleware is a pure pass-through — no timestamps, no wrappers, no allocation.
+
+Duration comes from `TimeProvider.GetTimestamp()`/`GetElapsedTime` and entry timestamps from
+`TimeProvider.GetUtcNow()`, so tests can substitute a fake `TimeProvider` for deterministic
+output.
+
+## The W3C provider
+
+- **Formats.** `W3CExtended` (the W3C Extended Log File Format: `#Version`/`#Fields`
+  directives, fixed field list, `-` for absent, spaces `+`-encoded in string fields per the IIS
+  convention) plus NCSA `Common` and `Combined`. `cs-bytes`/`sc-bytes` are the body byte counts
+  observed at the application layer (headers are not included), and `time-taken` is seconds at
+  millisecond precision.
+- **Files.** `{prefix}-{yyyyMMdd}.log` per UTC day, rolling to `{prefix}-{yyyyMMdd}.{seq:000}.log`
+  when `FileSizeLimit` (approximate, char-counted) is exceeded; a restart appends to the day's
+  current file. Retention deletes oldest-first (by last-write time) beyond
+  `RetainedFileCountLimit`, never the active file. Rolling keys off the **entry's** timestamp,
+  which keeps the writer deterministic under a fake upstream `TimeProvider`.
+- **Buffering.** Writes are lock-serialized into a buffered `StreamWriter` and flushed on a
+  timer (`FlushInterval`, default 1 s; `TimeSpan.Zero` = flush every write), on `Flush()`, and
+  on disposal. Lines from concurrent exchanges never interleave.
+- **Log-injection defense.** Rendering strips control characters from every text field and
+  escapes quotes/backslashes inside NCSA quoted fields; a hostile `User-Agent` cannot forge log
+  lines. Sanitization happens at the text boundary — entry attributes keep the raw values for
+  structured consumers.
+- **Scoping fan-out.** The provider filters by the `http.event` attribute, so co-registration
+  with application logging is safe by default; a `LoggerFilterRule` scoped to
+  `typeof(W3CAccessLogProvider)` can additionally trim fan-out on high-volume factories.
+
+## Ordering guidance
+
+`UseHttpLogging` belongs **first** in the pipeline — before authentication, CORS, host
+filtering, and routing — so rejected and unrouted exchanges are still logged. Two consequences
+to be aware of:
+
+- Anything registered *before* it is invisible to the access log.
+- Captured bodies are whatever crosses the wire at its position: place it after a
+  decompression middleware to capture decoded payloads, before it to capture the raw ones.
+
+## AOT posture
+
+No reflection anywhere: field selection is a flags enum, per-endpoint discovery is the
+`is`-test-based metadata bag, header allowlists are `FrozenSet<HttpHeaderKey>`, and all
+numeric/date rendering goes through invariant `TryFormat` into stack buffers. Body capture
+decodes UTF-8 into a string only at emission. The package carries the repo-wide
+`IsAotCompatible=true` with nothing to suppress.
+
+## Non-goals
+
+- **No general-purpose file logging provider.** The W3C writer renders HTTP exchanges only. A
+  text/JSON file provider for application logging is Logging-area work; when it exists, the
+  rotation machinery here is the reference implementation to lift.
+- **No proxy trust model.** `X-Forwarded-For`/`Forwarded` parsing and trust decisions are #778's
+  middleware; this package only exposes the resolver seam.
+- **No error handling.** The middleware observes exceptions and rethrows; status-code pages and
+  the exception boundary are #881 (over the #864 `OnError` hook).
+- **No push/export telemetry.** OTLP export, metrics, and `EventSource` counters are the
+  OpenTelemetry epic (#317). The attribute contract is the handoff point.
+- **No per-request configuration surface.** Everything is builder-time; the only per-request
+  variance is the endpoint metadata override, itself attached at map time.

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/OVERVIEW.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/docs/OVERVIEW.md
@@ -1,0 +1,64 @@
+# Assimalign.Cohesion.Web.Diagnostics — Overview
+
+HTTP request/response logging and W3C access logs for Cohesion web applications, in one
+diagnostics package:
+
+- **`UseHttpLogging`** — an `IWebApplicationMiddleware` that captures request/response metadata
+  for each exchange and emits one structured `LoggerEntry` through the application's Cohesion
+  logging pipeline when the downstream pipeline completes (or faults).
+- **`W3CAccessLogProvider`** — an `ILoggerProvider` that renders those entries as W3C Extended
+  or NCSA common/combined access-log files with buffered, size- and day-rolled output.
+
+Emission deliberately **rides the repo's own Logging model** — providers, enrichers, and filter
+rules all apply — rather than a parallel logging pipeline. The two halves meet at the stable
+attribute-name contract in `HttpLoggingAttributes` (`http.request.method`,
+`http.response.status`, `http.duration`, ...), so any provider, filter, or enricher can consume
+access-log entries without referencing this package's middleware.
+
+## Composition
+
+```csharp
+// Providers register on the logging pipeline like any other sink.
+var accessLog = new W3CAccessLogProvider(new W3CAccessLogOptions
+{
+    Directory = "/var/log/myapp",
+    Format = AccessLogFormat.W3CExtended,
+});
+
+builder.Logging.AddProvider(new ConsoleLoggerProvider());
+builder.Logging.AddProvider(accessLog);
+
+// The middleware takes the composed logger explicitly - builder time only, no service location.
+application
+    .UseHttpLogging(loggerFactory, options =>
+    {
+        options.Fields = HttpLoggingFields.Default | HttpLoggingFields.RequestQuery;
+        options.AllowedRequestHeaders.Add("X-Correlation-Id");
+    })
+    .Use(...);
+```
+
+Register `UseHttpLogging` **first** — ahead of authentication, CORS, and routing — so rejected
+exchanges are logged too.
+
+## Field selection and redaction
+
+`HttpLoggingFields` selects what is captured. The default set carries the request line, headers,
+status, duration, client address, byte counts, and trace correlation; the **query string and
+bodies are opt-in** because they routinely carry secrets. Header redaction is
+**allowlist-based**: names always log, values log only for allowlisted headers, and
+`Authorization`, `Proxy-Authorization`, `Cookie`, and `Set-Cookie` are never in the default
+allowlists.
+
+Per-endpoint overrides attach an `HttpLoggingMetadata` to the route's metadata bag (last-wins);
+`HttpLoggingFields.None` silences an endpoint entirely — the usual choice for health probes.
+
+## Dependencies
+
+| Reference | Why |
+| --- | --- |
+| `Assimalign.Cohesion.Web` | the middleware/pipeline abstractions |
+| `Assimalign.Cohesion.Web.Routing` | reads the endpoint metadata bag for per-endpoint overrides |
+| `Assimalign.Cohesion.Logging` | the emission model (`ILogger`, `LoggerEntry`, `LoggerProvider`) |
+
+See [DESIGN.md](DESIGN.md) for the architecture and the decisions behind it.

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/AccessLogFormat.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/AccessLogFormat.cs
@@ -1,0 +1,29 @@
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+/// <summary>
+/// The on-disk line format the <see cref="W3CAccessLogProvider"/> writes.
+/// </summary>
+public enum AccessLogFormat
+{
+    /// <summary>
+    /// The W3C Extended Log File Format: <c>#Version</c>/<c>#Fields</c> directives at the top
+    /// of every file, space-separated fields, <c>-</c> for absent values, spaces inside string
+    /// fields encoded as <c>+</c>. The field list is fixed:
+    /// <c>date time c-ip cs-method cs-uri-stem cs-uri-query sc-status cs-bytes sc-bytes
+    /// time-taken cs-version cs-host cs(User-Agent) cs(Referer)</c>.
+    /// </summary>
+    W3CExtended = 0,
+
+    /// <summary>
+    /// The NCSA Common Log Format:
+    /// <c>host ident authuser [date] "request" status bytes</c>. Ident and authuser are always
+    /// <c>-</c>; timestamps are UTC (<c>+0000</c>).
+    /// </summary>
+    Common = 1,
+
+    /// <summary>
+    /// The NCSA Combined Log Format: <see cref="Common"/> plus quoted <c>Referer</c> and
+    /// <c>User-Agent</c> fields.
+    /// </summary>
+    Combined = 2,
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Assimalign.Cohesion.Web.Diagnostics.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Assimalign.Cohesion.Web.Diagnostics.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Web.Diagnostics</RootNamespace>
+		<Description>HTTP request/response logging and W3C access logs for Cohesion web applications. Owns the UseHttpLogging middleware (builder-time field flags, allowlist-based header redaction with Authorization/Cookie/Set-Cookie never logged by default, bounded opt-in body capture, duration and status capture, traceparent correlation) and a W3C extended / NCSA common+combined access-log file writer built as an Assimalign.Cohesion.Logging provider — emission rides the repo's own logging pipeline (providers/enrichers/filters), not a parallel one. AOT-safe span formatting, zero reflection.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Routing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Logging" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Extensions/WebApplicationExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+/// <summary>
+/// Pipeline-builder members that add HTTP request/response logging to a web application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The logger is supplied explicitly and the options are frozen at composition time — the
+/// middleware never performs request-time service location. Emission rides the application's
+/// Cohesion logging pipeline: the entries fan out to every registered
+/// <see cref="ILoggerProvider"/> (console, debug, the <see cref="W3CAccessLogProvider"/>, ...)
+/// subject to the factory's filter rules.
+/// </para>
+/// <para>
+/// <b>Ordering.</b> Register HTTP logging <em>first</em>, ahead of authentication, CORS, and
+/// routing, so every exchange is logged — including the ones those middleware reject. Anything
+/// registered before it is invisible to the access log. When bodies are captured
+/// (<see cref="HttpLoggingFields.RequestBody"/> / <see cref="HttpLoggingFields.ResponseBody"/>),
+/// remember the captured bytes are whatever crosses the wire at this position in the pipeline —
+/// place logging <em>after</em> a decompression middleware to capture decoded payloads, before
+/// it to capture the raw ones.
+/// </para>
+/// </remarks>
+public static class WebApplicationExtensions
+{
+    extension(IWebApplicationPipelineBuilder builder)
+    {
+        /// <summary>
+        /// Adds HTTP request/response logging to the pipeline. Each exchange emits one
+        /// structured entry (fields per <see cref="HttpLoggingOptions.Fields"/>, header values
+        /// redacted outside the configured allowlists) through <paramref name="logger"/> when
+        /// the downstream pipeline completes or faults.
+        /// </summary>
+        /// <param name="logger">
+        /// The composed logger the entries are written to — typically
+        /// <c>ILoggerFactory.Create(options.Category)</c> on the application's logger factory.
+        /// </param>
+        /// <param name="configure">An optional callback that configures the logging options.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="logger"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The configured options are invalid (empty category or redaction placeholder, or <see cref="LogLevel.None"/> level).</exception>
+        /// <exception cref="ArgumentOutOfRangeException">A configured body-capture limit is negative.</exception>
+        public IWebApplicationPipelineBuilder UseHttpLogging(ILogger logger, Action<HttpLoggingOptions>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(logger);
+
+            var options = new HttpLoggingOptions();
+            configure?.Invoke(options);
+
+            return builder.Use(new HttpLoggingMiddleware(logger, HttpLoggingSnapshot.Create(options)));
+        }
+
+        /// <summary>
+        /// Adds HTTP request/response logging to the pipeline, resolving the logger for the
+        /// configured <see cref="HttpLoggingOptions.Category"/> from
+        /// <paramref name="loggerFactory"/> at composition time.
+        /// </summary>
+        /// <param name="loggerFactory">The application's logger factory.</param>
+        /// <param name="configure">An optional callback that configures the logging options.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The configured options are invalid (empty category or redaction placeholder, or <see cref="LogLevel.None"/> level).</exception>
+        /// <exception cref="ArgumentOutOfRangeException">A configured body-capture limit is negative.</exception>
+        public IWebApplicationPipelineBuilder UseHttpLogging(ILoggerFactory loggerFactory, Action<HttpLoggingOptions>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(loggerFactory);
+
+            var options = new HttpLoggingOptions();
+            configure?.Invoke(options);
+
+            HttpLoggingSnapshot snapshot = HttpLoggingSnapshot.Create(options);
+
+            return builder.Use(new HttpLoggingMiddleware(loggerFactory.Create(snapshot.Category), snapshot));
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingAttributes.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingAttributes.cs
@@ -1,0 +1,87 @@
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+/// <summary>
+/// The stable attribute names the HTTP logging middleware stamps on the
+/// <see cref="Assimalign.Cohesion.Logging.ILoggerEntry"/> instances it emits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These names are the contract between the middleware and every downstream consumer riding the
+/// Cohesion logging pipeline — the <see cref="W3CAccessLogProvider"/> resolves its W3C fields
+/// from them, and applications can key their own
+/// <see cref="Assimalign.Cohesion.Logging.ILoggerFilter"/> or provider logic off them. The
+/// naming aligns with the OpenTelemetry HTTP semantic conventions where one exists
+/// (<c>http.request.method</c>, <c>http.response.status</c>, ...) without taking an
+/// OpenTelemetry dependency.
+/// </para>
+/// <para>
+/// Header attributes are emitted as <c>http.request.header.&lt;name&gt;</c> /
+/// <c>http.response.header.&lt;name&gt;</c> with the header name lower-cased, so consumers can
+/// look headers up without case juggling.
+/// </para>
+/// </remarks>
+public static class HttpLoggingAttributes
+{
+    /// <summary>Marks what the entry describes: <see cref="EventExchange"/> or <see cref="EventStart"/>.</summary>
+    public const string Event = "http.event";
+
+    /// <summary>The <see cref="Event"/> value for a completed exchange — one entry per request/response pair.</summary>
+    public const string EventExchange = "exchange";
+
+    /// <summary>The <see cref="Event"/> value for the optional request-start entry (<see cref="HttpLoggingOptions.LogRequestStart"/>).</summary>
+    public const string EventStart = "start";
+
+    /// <summary>The request method, e.g. <c>GET</c>. String.</summary>
+    public const string RequestMethod = "http.request.method";
+
+    /// <summary>The request scheme, <c>http</c> or <c>https</c>. String.</summary>
+    public const string RequestScheme = "http.request.scheme";
+
+    /// <summary>The request host (authority). String.</summary>
+    public const string RequestHost = "http.request.host";
+
+    /// <summary>The request path. String.</summary>
+    public const string RequestPath = "http.request.path";
+
+    /// <summary>The request query string without the leading <c>?</c>, re-serialized from the parsed query collection. String.</summary>
+    public const string RequestQuery = "http.request.query";
+
+    /// <summary>The HTTP protocol version, e.g. <c>HTTP/1.1</c>. String.</summary>
+    public const string RequestProtocol = "http.request.protocol";
+
+    /// <summary>Prefix for request header attributes; the suffix is the lower-cased header name. String values.</summary>
+    public const string RequestHeaderPrefix = "http.request.header.";
+
+    /// <summary>The captured request body prefix, UTF-8 decoded. String.</summary>
+    public const string RequestBody = "http.request.body";
+
+    /// <summary>Request body bytes observed at the application layer (W3C <c>cs-bytes</c> source). Long.</summary>
+    public const string RequestBodyBytes = "http.request.body.bytes";
+
+    /// <summary>The response status code. Int.</summary>
+    public const string ResponseStatusCode = "http.response.status";
+
+    /// <summary>Prefix for response header attributes; the suffix is the lower-cased header name. String values.</summary>
+    public const string ResponseHeaderPrefix = "http.response.header.";
+
+    /// <summary>The captured response body prefix, UTF-8 decoded. String.</summary>
+    public const string ResponseBody = "http.response.body";
+
+    /// <summary>Response body bytes observed at the application layer (W3C <c>sc-bytes</c> source). Long.</summary>
+    public const string ResponseBodyBytes = "http.response.body.bytes";
+
+    /// <summary>The exchange duration in milliseconds. Double.</summary>
+    public const string Duration = "http.duration";
+
+    /// <summary>The effective client IP address. String.</summary>
+    public const string ClientAddress = "http.client.address";
+
+    /// <summary>The client port of the transport connection. Int.</summary>
+    public const string ClientPort = "http.client.port";
+
+    /// <summary>The W3C trace-context trace id parsed from the inbound <c>traceparent</c> header. String (32 hex digits).</summary>
+    public const string TraceId = "trace.id";
+
+    /// <summary>The W3C trace-context parent span id parsed from the inbound <c>traceparent</c> header. String (16 hex digits).</summary>
+    public const string SpanId = "span.id";
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingFields.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingFields.cs
@@ -1,0 +1,146 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+/// <summary>
+/// Selects which parts of an HTTP exchange the logging middleware captures and emits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The flags are resolved at builder time through <see cref="HttpLoggingOptions.Fields"/> and may
+/// be overridden per endpoint by attaching an <see cref="HttpLoggingMetadata"/> to the route's
+/// metadata bag. <see cref="None"/> suppresses the log entry entirely — useful for chatty
+/// endpoints such as health probes.
+/// </para>
+/// <para>
+/// <see cref="RequestQuery"/>, <see cref="RequestBody"/>, and <see cref="ResponseBody"/> are
+/// deliberately excluded from <see cref="Default"/>: query strings and bodies routinely carry
+/// credentials, tokens, and personal data, so capturing them is an explicit opt-in.
+/// </para>
+/// </remarks>
+[Flags]
+public enum HttpLoggingFields
+{
+    /// <summary>
+    /// Log nothing. When this is the effective field set for an exchange, no entry is emitted.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The request method (<c>http.request.method</c>).
+    /// </summary>
+    RequestMethod = 1 << 0,
+
+    /// <summary>
+    /// The request scheme (<c>http.request.scheme</c>).
+    /// </summary>
+    RequestScheme = 1 << 1,
+
+    /// <summary>
+    /// The request host (<c>http.request.host</c>).
+    /// </summary>
+    RequestHost = 1 << 2,
+
+    /// <summary>
+    /// The request path (<c>http.request.path</c>).
+    /// </summary>
+    RequestPath = 1 << 3,
+
+    /// <summary>
+    /// The request query string (<c>http.request.query</c>). Excluded from
+    /// <see cref="Default"/> because query strings routinely carry sensitive values.
+    /// </summary>
+    RequestQuery = 1 << 4,
+
+    /// <summary>
+    /// The HTTP protocol version (<c>http.request.protocol</c>).
+    /// </summary>
+    RequestProtocol = 1 << 5,
+
+    /// <summary>
+    /// The request headers (<c>http.request.header.*</c>). Header names always log; a header's
+    /// value logs only when its name is in <see cref="HttpLoggingOptions.AllowedRequestHeaders"/>,
+    /// otherwise the value is replaced with <see cref="HttpLoggingOptions.RedactedValue"/>.
+    /// </summary>
+    RequestHeaders = 1 << 6,
+
+    /// <summary>
+    /// A bounded prefix of the request body (<c>http.request.body</c>), captured only when the
+    /// request content type matches <see cref="HttpLoggingOptions.LoggableBodyContentTypes"/> and
+    /// capped at <see cref="HttpLoggingOptions.RequestBodyLimit"/> bytes. Opt-in.
+    /// </summary>
+    RequestBody = 1 << 7,
+
+    /// <summary>
+    /// The response status code (<c>http.response.status</c>).
+    /// </summary>
+    ResponseStatusCode = 1 << 8,
+
+    /// <summary>
+    /// The response headers (<c>http.response.header.*</c>), value-redacted outside
+    /// <see cref="HttpLoggingOptions.AllowedResponseHeaders"/> exactly like request headers.
+    /// </summary>
+    ResponseHeaders = 1 << 9,
+
+    /// <summary>
+    /// A bounded prefix of the response body (<c>http.response.body</c>), captured only when the
+    /// response content type matches <see cref="HttpLoggingOptions.LoggableBodyContentTypes"/> and
+    /// capped at <see cref="HttpLoggingOptions.ResponseBodyLimit"/> bytes. Opt-in.
+    /// </summary>
+    ResponseBody = 1 << 10,
+
+    /// <summary>
+    /// The wall-clock duration of the exchange in milliseconds (<c>http.duration</c>), measured
+    /// from middleware entry to downstream completion.
+    /// </summary>
+    Duration = 1 << 11,
+
+    /// <summary>
+    /// The effective client address and port (<c>http.client.address</c> /
+    /// <c>http.client.port</c>). Resolved through
+    /// <see cref="HttpLoggingOptions.ClientAddressResolver"/> when set; otherwise the transport
+    /// socket peer.
+    /// </summary>
+    ClientAddress = 1 << 12,
+
+    /// <summary>
+    /// Request and response body byte counts observed at the application layer
+    /// (<c>http.request.body.bytes</c> / <c>http.response.body.bytes</c>) — the W3C
+    /// <c>cs-bytes</c>/<c>sc-bytes</c> source.
+    /// </summary>
+    BytesTransferred = 1 << 13,
+
+    /// <summary>
+    /// W3C trace-context correlation (<c>trace.id</c> / <c>span.id</c>) parsed from the inbound
+    /// <c>traceparent</c> header when present. No OpenTelemetry dependency is taken.
+    /// </summary>
+    TraceContext = 1 << 14,
+
+    /// <summary>
+    /// The request line: method, scheme, host, path, and protocol.
+    /// <see cref="RequestQuery"/> is deliberately not included.
+    /// </summary>
+    RequestLine = RequestMethod | RequestScheme | RequestHost | RequestPath | RequestProtocol,
+
+    /// <summary>
+    /// The request line and request headers.
+    /// </summary>
+    Request = RequestLine | RequestHeaders,
+
+    /// <summary>
+    /// The response status code and response headers.
+    /// </summary>
+    Response = ResponseStatusCode | ResponseHeaders,
+
+    /// <summary>
+    /// The default field set: request line, request headers, response status and headers,
+    /// duration, client address, byte counts, and trace context. Bodies and the query string are
+    /// excluded and must be opted into.
+    /// </summary>
+    Default = Request | Response | Duration | ClientAddress | BytesTransferred | TraceContext,
+
+    /// <summary>
+    /// Every field, including the query string and bounded request/response bodies.
+    /// </summary>
+    All = Default | RequestQuery | RequestBody | ResponseBody,
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingMetadata.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingMetadata.cs
@@ -1,0 +1,50 @@
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+/// <summary>
+/// Endpoint metadata that overrides the HTTP logging field set for the routes it is attached
+/// to. Attach an instance to a route's metadata bag to change what the logging middleware
+/// emits for that endpoint — including <see cref="HttpLoggingFields.None"/> to silence it
+/// entirely (the usual choice for health probes).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The middleware resolves this metadata with last-wins semantics
+/// (<c>IRouterRouteMetadataCollection.GetMetadata&lt;HttpLoggingMetadata&gt;()</c>) after the
+/// downstream pipeline has completed, so a group-level override is superseded by an
+/// endpoint-level one, and the lookup costs nothing on routes that carry no override.
+/// </para>
+/// <para>
+/// Because the override is only observable <em>after</em> routing has run, it can freely turn
+/// emission-time fields on or off (request line, headers, duration, status, ...), but it cannot
+/// arm body capture the global <see cref="HttpLoggingOptions.Fields"/> left disabled: capture
+/// streams are attached before the downstream pipeline runs, when no route is known yet.
+/// <see cref="HttpLoggingFields.RequestBody"/>, <see cref="HttpLoggingFields.ResponseBody"/>,
+/// and <see cref="HttpLoggingFields.BytesTransferred"/> in an override therefore only
+/// <em>narrow</em> the globally armed set.
+/// </para>
+/// <para>
+/// This sealed carrier <em>is</em> the metadata contract — there is deliberately no
+/// <c>IHttpLoggingMetadata</c> interface. Metadata items in the bag are immutable data
+/// carriers; the sealed type guarantees the value the middleware reads is the one attached at
+/// map time.
+/// </para>
+/// </remarks>
+public sealed class HttpLoggingMetadata
+{
+    /// <summary>
+    /// Creates logging metadata carrying the effective field set for the endpoint.
+    /// </summary>
+    /// <param name="fields">
+    /// The fields to emit for exchanges handled by the endpoint.
+    /// <see cref="HttpLoggingFields.None"/> suppresses the entry entirely.
+    /// </param>
+    public HttpLoggingMetadata(HttpLoggingFields fields)
+    {
+        Fields = fields;
+    }
+
+    /// <summary>
+    /// Gets the field set emitted for exchanges handled by the endpoint.
+    /// </summary>
+    public HttpLoggingFields Fields { get; }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/HttpLoggingOptions.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Logging;
+
+/// <summary>
+/// Builder-time configuration for the HTTP logging middleware
+/// (<see cref="WebApplicationExtensions.UseHttpLogging(IWebApplicationPipelineBuilder, ILogger, Action{HttpLoggingOptions})"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The options are read once when the middleware is composed and frozen into an immutable
+/// snapshot — mutating an options instance after <c>UseHttpLogging</c> returns has no effect.
+/// There is no request-time configuration surface.
+/// </para>
+/// <para>
+/// <b>Redaction model.</b> Redaction is allowlist-based: a header's <em>name</em> always logs,
+/// but its <em>value</em> logs only when the name is present in
+/// <see cref="AllowedRequestHeaders"/> / <see cref="AllowedResponseHeaders"/>; every other value
+/// is replaced with <see cref="RedactedValue"/>. Credential-bearing headers —
+/// <c>Authorization</c>, <c>Proxy-Authorization</c>, <c>Cookie</c>, and <c>Set-Cookie</c> — are
+/// deliberately absent from the default allowlists, so their values are never logged unless a
+/// caller explicitly adds them.
+/// </para>
+/// </remarks>
+public sealed class HttpLoggingOptions
+{
+    /// <summary>
+    /// Gets or sets the parts of the exchange to capture and emit. Defaults to
+    /// <see cref="HttpLoggingFields.Default"/> (bodies and query string excluded).
+    /// </summary>
+    public HttpLoggingFields Fields { get; set; } = HttpLoggingFields.Default;
+
+    /// <summary>
+    /// Gets or sets the category the middleware logs under. Defaults to
+    /// <c>Assimalign.Cohesion.Web.Diagnostics.HttpLogging</c>. Use it with
+    /// <see cref="LoggerFilterRule"/> to route access-log entries to (or away from) specific
+    /// providers.
+    /// </summary>
+    public string Category { get; set; } = "Assimalign.Cohesion.Web.Diagnostics.HttpLogging";
+
+    /// <summary>
+    /// Gets or sets the level exchange entries are emitted at. Defaults to
+    /// <see cref="LogLevel.Information"/>. When the composed logger reports the level disabled at
+    /// request time, the middleware is a pure pass-through — nothing is captured or timed. An
+    /// exchange whose downstream middleware throws is escalated to <see cref="LogLevel.Error"/>.
+    /// </summary>
+    public LogLevel Level { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets whether a request-start entry is emitted in addition to the completion
+    /// entry. Defaults to <see langword="false"/>. When enabled, the start entry seeds an
+    /// <see cref="IScopedLogger"/> scope and the completion entry is written through it, so the
+    /// two correlate via <see cref="ILoggerEntry.ParentId"/>.
+    /// </summary>
+    public bool LogRequestStart { get; set; }
+
+    /// <summary>
+    /// Gets the request headers whose values may be logged. Values of headers not in this set
+    /// are replaced with <see cref="RedactedValue"/>. The default set carries common
+    /// content-negotiation, caching, and user-agent headers; <c>Authorization</c>,
+    /// <c>Proxy-Authorization</c>, and <c>Cookie</c> are never included by default.
+    /// </summary>
+    public ISet<HttpHeaderKey> AllowedRequestHeaders { get; } = new HashSet<HttpHeaderKey>
+    {
+        HttpHeaderKey.Accept,
+        HttpHeaderKey.AcceptCharset,
+        HttpHeaderKey.AcceptEncoding,
+        HttpHeaderKey.AcceptLanguage,
+        HttpHeaderKey.CacheControl,
+        HttpHeaderKey.Connection,
+        HttpHeaderKey.ContentEncoding,
+        HttpHeaderKey.ContentLength,
+        HttpHeaderKey.ContentType,
+        HttpHeaderKey.Expect,
+        HttpHeaderKey.Host,
+        HttpHeaderKey.MaxForwards,
+        HttpHeaderKey.Origin,
+        HttpHeaderKey.Pragma,
+        HttpHeaderKey.Range,
+        HttpHeaderKey.Referer,
+        HttpHeaderKey.TE,
+        HttpHeaderKey.Trailer,
+        HttpHeaderKey.TransferEncoding,
+        HttpHeaderKey.Upgrade,
+        HttpHeaderKey.UserAgent,
+        HttpHeaderKey.Via,
+    };
+
+    /// <summary>
+    /// Gets the response headers whose values may be logged. Values of headers not in this set
+    /// are replaced with <see cref="RedactedValue"/>. <c>Set-Cookie</c> is never included by
+    /// default.
+    /// </summary>
+    public ISet<HttpHeaderKey> AllowedResponseHeaders { get; } = new HashSet<HttpHeaderKey>
+    {
+        HttpHeaderKey.AcceptRanges,
+        HttpHeaderKey.Age,
+        HttpHeaderKey.Allow,
+        HttpHeaderKey.AltSvc,
+        HttpHeaderKey.CacheControl,
+        HttpHeaderKey.Connection,
+        HttpHeaderKey.ContentDisposition,
+        HttpHeaderKey.ContentEncoding,
+        HttpHeaderKey.ContentLanguage,
+        HttpHeaderKey.ContentLength,
+        HttpHeaderKey.ContentLocation,
+        HttpHeaderKey.ContentRange,
+        HttpHeaderKey.ContentType,
+        HttpHeaderKey.Date,
+        HttpHeaderKey.Expires,
+        HttpHeaderKey.LastModified,
+        HttpHeaderKey.Location,
+        HttpHeaderKey.RetryAfter,
+        HttpHeaderKey.Server,
+        HttpHeaderKey.TransferEncoding,
+        HttpHeaderKey.Upgrade,
+        HttpHeaderKey.Vary,
+    };
+
+    /// <summary>
+    /// Gets or sets the placeholder written in place of a redacted header value. Defaults to
+    /// <c>[Redacted]</c>.
+    /// </summary>
+    public string RedactedValue { get; set; } = "[Redacted]";
+
+    /// <summary>
+    /// Gets or sets the maximum number of request-body bytes captured when
+    /// <see cref="HttpLoggingFields.RequestBody"/> is enabled. Defaults to 4096. The cap bounds
+    /// only what is <em>captured for logging</em> — the body itself streams through untouched,
+    /// so transport backpressure and request-size limits are unaffected.
+    /// </summary>
+    public int RequestBodyLimit { get; set; } = 4096;
+
+    /// <summary>
+    /// Gets or sets the maximum number of response-body bytes captured when
+    /// <see cref="HttpLoggingFields.ResponseBody"/> is enabled. Defaults to 4096.
+    /// </summary>
+    public int ResponseBodyLimit { get; set; } = 4096;
+
+    /// <summary>
+    /// Gets the content types eligible for body capture. An entry matches when the message's
+    /// media type (the <c>Content-Type</c> value before any parameters) starts with the entry
+    /// (ordinal, case-insensitive), or — for entries beginning with <c>+</c> — when the media
+    /// type ends with that structured-syntax suffix (covering e.g. <c>application/problem+json</c>).
+    /// Bodies whose content type matches no entry are not captured.
+    /// </summary>
+    public IList<string> LoggableBodyContentTypes { get; } = new List<string>
+    {
+        "application/json",
+        "application/xml",
+        "application/x-www-form-urlencoded",
+        "text/",
+        "+json",
+        "+xml",
+    };
+
+    /// <summary>
+    /// Gets or sets the resolver for the effective client address logged under
+    /// <see cref="HttpLoggingAttributes.ClientAddress"/>. When <see langword="null"/> (the
+    /// default) the transport socket peer (<see cref="IHttpConnectionInfo.RemoteIp"/>) is
+    /// logged.
+    /// </summary>
+    /// <remarks>
+    /// This is the composition seam for proxy awareness: once the forwarded-headers middleware
+    /// (issue #778) establishes a trusted client address on the exchange, plug a resolver here
+    /// that reads it. Until then the socket peer is the only honest answer — the middleware
+    /// never trusts <c>X-Forwarded-For</c> on its own.
+    /// </remarks>
+    public Func<IHttpContext, IPAddress?>? ClientAddressResolver { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time source used for duration measurement and the request-start
+    /// timestamp. Defaults to <see cref="TimeProvider.System"/>; substitute a fake in tests to
+    /// make durations deterministic.
+    /// </summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/HttpLoggingMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/HttpLoggingMiddleware.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Routing;
+
+/// <summary>
+/// The HTTP logging middleware: captures request/response metadata for one exchange and emits a
+/// single structured <see cref="LoggerEntry"/> through the composed <see cref="ILogger"/> when
+/// the downstream pipeline completes (or faults). All configuration is builder-time
+/// (<see cref="HttpLoggingSnapshot"/>); the middleware performs no service location and no
+/// reflection.
+/// </summary>
+internal sealed class HttpLoggingMiddleware : IWebApplicationMiddleware
+{
+    private const HttpLoggingFields CaptureFields =
+        HttpLoggingFields.RequestBody | HttpLoggingFields.ResponseBody | HttpLoggingFields.BytesTransferred;
+
+    private readonly ILogger _logger;
+    private readonly HttpLoggingSnapshot _snapshot;
+
+    public HttpLoggingMiddleware(ILogger logger, HttpLoggingSnapshot snapshot)
+    {
+        _logger = logger;
+        _snapshot = snapshot;
+    }
+
+    public async Task InvokeAsync(IHttpContext context, WebApplicationMiddleware next)
+    {
+        if (!_logger.IsEnabled(_snapshot.Level))
+        {
+            // The composed logger would drop the entry anyway: skip timing and capture entirely.
+            await next.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        long started = _snapshot.TimeProvider.GetTimestamp();
+        HttpLoggingFields configured = _snapshot.Fields;
+
+        // Arm body observation before the downstream pipeline runs. Captures tee the first N
+        // bytes only - the body itself streams through, so h2 flow-control backpressure and the
+        // transport's request-size limits are untouched.
+        RequestBodyCaptureStream? requestCapture = null;
+        Stream? originalRequestBody = null;
+        HttpRequest? concreteRequest = context.Request as HttpRequest;
+
+        bool wantBytes = (configured & HttpLoggingFields.BytesTransferred) != 0;
+        bool captureRequestBody = (configured & HttpLoggingFields.RequestBody) != 0
+            && concreteRequest is not null
+            && _snapshot.RequestBodyLimit > 0
+            && _snapshot.IsBodyContentTypeLoggable(context.Request.Headers[HttpHeaderKey.ContentType].Value);
+
+        if (concreteRequest is not null && (captureRequestBody || wantBytes))
+        {
+            originalRequestBody = concreteRequest.Body;
+            requestCapture = new RequestBodyCaptureStream(originalRequestBody, captureRequestBody ? _snapshot.RequestBodyLimit : 0);
+            concreteRequest.Body = requestCapture;
+        }
+
+        ResponseBodyCaptureStream? responseCapture = null;
+        Stream? originalResponseBody = null;
+        bool captureResponseBody = (configured & HttpLoggingFields.ResponseBody) != 0 && _snapshot.ResponseBodyLimit > 0;
+
+        if (captureResponseBody || wantBytes)
+        {
+            originalResponseBody = context.Response.Body;
+            responseCapture = new ResponseBodyCaptureStream(
+                originalResponseBody,
+                captureResponseBody ? _snapshot.ResponseBodyLimit : 0,
+                // The response Content-Type is unknown until the application sets it, so the
+                // capture decision is deferred to the first body write.
+                captureResponseBody ? () => _snapshot.IsBodyContentTypeLoggable(context.Response.Headers[HttpHeaderKey.ContentType].Value) : null);
+            context.Response.Body = responseCapture;
+        }
+
+        ILogger exchangeLogger = _logger;
+        IScopedLogger? scope = null;
+
+        if (_snapshot.LogRequestStart)
+        {
+            // The start entry seeds a scope; the completion entry is written through it so the
+            // two correlate via ILoggerEntry.ParentId.
+            scope = _logger.BeginScope(CreateStartEntry(context));
+            exchangeLogger = scope;
+        }
+
+        Exception? exception = null;
+        try
+        {
+            await next.Invoke(context).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+            throw;
+        }
+        finally
+        {
+            // Restore the streams we installed - but only when they are still the installed
+            // ones. A downstream middleware that swapped in its own wrapper (compression, ...)
+            // owns its restoration; clobbering it here would detach that wrapper mid-chain.
+            if (requestCapture is not null && ReferenceEquals(concreteRequest!.Body, requestCapture))
+            {
+                concreteRequest.Body = originalRequestBody!;
+            }
+
+            if (responseCapture is not null && ReferenceEquals(context.Response.Body, responseCapture))
+            {
+                context.Response.Body = originalResponseBody!;
+            }
+
+            TimeSpan elapsed = _snapshot.TimeProvider.GetElapsedTime(started);
+            HttpLoggingFields effective = ResolveEffectiveFields(context, configured);
+
+            if (effective != HttpLoggingFields.None)
+            {
+                try
+                {
+                    Emit(exchangeLogger, context, effective, elapsed, requestCapture, responseCapture, exception);
+                }
+                catch
+                {
+                    // The access log must never fail an exchange (or mask the application's own
+                    // exception while it unwinds). Sink failures are already isolated by the
+                    // logging pipeline; this guards the attribute-building path itself.
+                }
+            }
+
+            scope?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the field set for the completed exchange: the configured fields unless the
+    /// matched endpoint carries an <see cref="HttpLoggingMetadata"/> override (last-wins via the
+    /// endpoint metadata bag). Capture fields can only narrow — they were armed (or not) before
+    /// routing decided the endpoint.
+    /// </summary>
+    private static HttpLoggingFields ResolveEffectiveFields(IHttpContext context, HttpLoggingFields configured)
+    {
+        HttpLoggingMetadata? metadata = context.GetEndpointMetadata<HttpLoggingMetadata>();
+        if (metadata is null)
+        {
+            return configured;
+        }
+
+        HttpLoggingFields effective = metadata.Fields;
+        effective &= ~(CaptureFields & ~configured);
+        return effective;
+    }
+
+    private LoggerEntry CreateStartEntry(IHttpContext context)
+    {
+        HttpLoggingFields fields = _snapshot.Fields;
+        var attributes = new Dictionary<string, object?>(3, StringComparer.Ordinal)
+        {
+            [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventStart,
+        };
+
+        if ((fields & HttpLoggingFields.RequestMethod) != 0)
+        {
+            attributes[HttpLoggingAttributes.RequestMethod] = context.Request.Method.Value;
+        }
+
+        if ((fields & HttpLoggingFields.RequestPath) != 0)
+        {
+            attributes[HttpLoggingAttributes.RequestPath] = context.Request.Path.Value;
+        }
+
+        return new LoggerEntry(
+            _snapshot.Level,
+            _snapshot.Category,
+            BuildMessage(context, fields, status: null, duration: null, faulted: false, started: true),
+            attributes: attributes,
+            timestamp: _snapshot.TimeProvider.GetUtcNow());
+    }
+
+    private void Emit(
+        ILogger logger,
+        IHttpContext context,
+        HttpLoggingFields fields,
+        TimeSpan elapsed,
+        RequestBodyCaptureStream? requestCapture,
+        ResponseBodyCaptureStream? responseCapture,
+        Exception? exception)
+    {
+        IHttpRequest request = context.Request;
+        IHttpResponse response = context.Response;
+
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventExchange,
+        };
+
+        if ((fields & HttpLoggingFields.RequestMethod) != 0)
+        {
+            attributes[HttpLoggingAttributes.RequestMethod] = request.Method.Value;
+        }
+
+        if ((fields & HttpLoggingFields.RequestScheme) != 0 && request.Scheme != HttpScheme.None)
+        {
+            attributes[HttpLoggingAttributes.RequestScheme] = request.Scheme == HttpScheme.Https ? "https" : "http";
+        }
+
+        if ((fields & HttpLoggingFields.RequestHost) != 0 && !string.IsNullOrEmpty(request.Host.Value))
+        {
+            attributes[HttpLoggingAttributes.RequestHost] = request.Host.Value;
+        }
+
+        if ((fields & HttpLoggingFields.RequestPath) != 0)
+        {
+            attributes[HttpLoggingAttributes.RequestPath] = request.Path.Value;
+        }
+
+        if ((fields & HttpLoggingFields.RequestQuery) != 0 && request.Query.Count > 0)
+        {
+            attributes[HttpLoggingAttributes.RequestQuery] = SerializeQuery(request.Query);
+        }
+
+        if ((fields & HttpLoggingFields.RequestProtocol) != 0 && FormatProtocol(context.Version) is { } protocol)
+        {
+            attributes[HttpLoggingAttributes.RequestProtocol] = protocol;
+        }
+
+        if ((fields & HttpLoggingFields.RequestHeaders) != 0)
+        {
+            AddHeaders(attributes, request.Headers, HttpLoggingAttributes.RequestHeaderPrefix, _snapshot.AllowedRequestHeaders);
+        }
+
+        if ((fields & HttpLoggingFields.RequestBody) != 0 && requestCapture is not null && !requestCapture.Captured.IsEmpty)
+        {
+            attributes[HttpLoggingAttributes.RequestBody] = Encoding.UTF8.GetString(requestCapture.Captured);
+        }
+
+        if ((fields & HttpLoggingFields.ResponseStatusCode) != 0)
+        {
+            attributes[HttpLoggingAttributes.ResponseStatusCode] = response.StatusCode.Value;
+        }
+
+        if ((fields & HttpLoggingFields.ResponseHeaders) != 0)
+        {
+            AddHeaders(attributes, response.Headers, HttpLoggingAttributes.ResponseHeaderPrefix, _snapshot.AllowedResponseHeaders);
+        }
+
+        if ((fields & HttpLoggingFields.ResponseBody) != 0 && responseCapture is not null && !responseCapture.Captured.IsEmpty)
+        {
+            attributes[HttpLoggingAttributes.ResponseBody] = Encoding.UTF8.GetString(responseCapture.Captured);
+        }
+
+        if ((fields & HttpLoggingFields.BytesTransferred) != 0)
+        {
+            if (requestCapture is not null)
+            {
+                attributes[HttpLoggingAttributes.RequestBodyBytes] = requestCapture.BytesRead;
+            }
+
+            if (responseCapture is not null)
+            {
+                attributes[HttpLoggingAttributes.ResponseBodyBytes] = responseCapture.BytesWritten;
+            }
+        }
+
+        if ((fields & HttpLoggingFields.Duration) != 0)
+        {
+            attributes[HttpLoggingAttributes.Duration] = elapsed.TotalMilliseconds;
+        }
+
+        if ((fields & HttpLoggingFields.ClientAddress) != 0)
+        {
+            if (ResolveClientAddress(context) is { } address)
+            {
+                attributes[HttpLoggingAttributes.ClientAddress] = address.ToString();
+            }
+
+            if (context.ConnectionInfo.RemotePort > 0)
+            {
+                attributes[HttpLoggingAttributes.ClientPort] = context.ConnectionInfo.RemotePort;
+            }
+        }
+
+        if ((fields & HttpLoggingFields.TraceContext) != 0
+            && request.Headers.TryGetValue(HttpHeaderKey.TraceParent, out HttpHeaderValue traceParent)
+            && TraceParent.TryParse(traceParent.Value, out string traceId, out string spanId))
+        {
+            attributes[HttpLoggingAttributes.TraceId] = traceId;
+            attributes[HttpLoggingAttributes.SpanId] = spanId;
+        }
+
+        var entry = new LoggerEntry(
+            exception is null ? _snapshot.Level : LogLevel.Error,
+            _snapshot.Category,
+            BuildMessage(context, fields, response.StatusCode.Value, elapsed, faulted: exception is not null, started: false),
+            exception,
+            attributes,
+            timestamp: _snapshot.TimeProvider.GetUtcNow());
+
+        logger.Log(entry);
+    }
+
+    private void AddHeaders(
+        Dictionary<string, object?> attributes,
+        IHttpHeaderCollection headers,
+        string prefix,
+        FrozenSet<HttpHeaderKey> allowed)
+    {
+        foreach (KeyValuePair<HttpHeaderKey, HttpHeaderValue> header in headers)
+        {
+            string name = string.Concat(prefix, header.Key.Value.ToLowerInvariant());
+            attributes[name] = allowed.Contains(header.Key) ? header.Value.Value : _snapshot.RedactedValue;
+        }
+    }
+
+    private IPAddress? ResolveClientAddress(IHttpContext context)
+    {
+        if (_snapshot.ClientAddressResolver is { } resolver)
+        {
+            try
+            {
+                return resolver(context);
+            }
+            catch
+            {
+                // A faulting resolver must not fail the exchange; fall back to the socket peer.
+            }
+        }
+
+        return context.ConnectionInfo.RemoteIp;
+    }
+
+    private static string BuildMessage(
+        IHttpContext context,
+        HttpLoggingFields fields,
+        int? status,
+        TimeSpan? duration,
+        bool faulted,
+        bool started)
+    {
+        string method = (fields & HttpLoggingFields.RequestMethod) != 0 ? context.Request.Method.Value : "-";
+        string path = (fields & HttpLoggingFields.RequestPath) != 0 ? context.Request.Path.Value : "-";
+
+        if (started)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{method} {path} started");
+        }
+
+        string statusText = status is { } s && (fields & HttpLoggingFields.ResponseStatusCode) != 0
+            ? s.ToString(CultureInfo.InvariantCulture)
+            : "-";
+        string durationText = duration is { } d && (fields & HttpLoggingFields.Duration) != 0
+            ? string.Create(CultureInfo.InvariantCulture, $" in {d.TotalMilliseconds:F3} ms")
+            : string.Empty;
+        string faultText = faulted ? " (faulted)" : string.Empty;
+
+        return string.Create(CultureInfo.InvariantCulture, $"{method} {path} -> {statusText}{durationText}{faultText}");
+    }
+
+    private static string? FormatProtocol(HttpVersion version) => version switch
+    {
+        HttpVersion.Http11 => "HTTP/1.1",
+        HttpVersion.Http20 => "HTTP/2",
+        HttpVersion.Http30 => "HTTP/3",
+        _ => null,
+    };
+
+    private static string SerializeQuery(IHttpQueryCollection query)
+    {
+        var builder = new StringBuilder();
+
+        foreach (KeyValuePair<HttpQueryKey, HttpQueryValue> pair in query)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('&');
+            }
+
+            builder.Append(Uri.EscapeDataString(pair.Key.Value));
+
+            if (!string.IsNullOrEmpty(pair.Value.Value))
+            {
+                builder.Append('=');
+                builder.Append(Uri.EscapeDataString(pair.Value.Value));
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/HttpLoggingSnapshot.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/HttpLoggingSnapshot.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Logging;
+
+/// <summary>
+/// The immutable middleware-side view of <see cref="HttpLoggingOptions"/>, frozen when
+/// <c>UseHttpLogging</c> composes the pipeline. Mutations to the options object after
+/// composition are invisible by design — there is no request-time configuration.
+/// </summary>
+internal sealed class HttpLoggingSnapshot
+{
+    private HttpLoggingSnapshot(
+        HttpLoggingFields fields,
+        string category,
+        LogLevel level,
+        bool logRequestStart,
+        FrozenSet<HttpHeaderKey> allowedRequestHeaders,
+        FrozenSet<HttpHeaderKey> allowedResponseHeaders,
+        string redactedValue,
+        int requestBodyLimit,
+        int responseBodyLimit,
+        string[] loggableBodyContentTypes,
+        Func<IHttpContext, IPAddress?>? clientAddressResolver,
+        TimeProvider timeProvider)
+    {
+        Fields = fields;
+        Category = category;
+        Level = level;
+        LogRequestStart = logRequestStart;
+        AllowedRequestHeaders = allowedRequestHeaders;
+        AllowedResponseHeaders = allowedResponseHeaders;
+        RedactedValue = redactedValue;
+        RequestBodyLimit = requestBodyLimit;
+        ResponseBodyLimit = responseBodyLimit;
+        LoggableBodyContentTypes = loggableBodyContentTypes;
+        ClientAddressResolver = clientAddressResolver;
+        TimeProvider = timeProvider;
+    }
+
+    public HttpLoggingFields Fields { get; }
+    public string Category { get; }
+    public LogLevel Level { get; }
+    public bool LogRequestStart { get; }
+    public FrozenSet<HttpHeaderKey> AllowedRequestHeaders { get; }
+    public FrozenSet<HttpHeaderKey> AllowedResponseHeaders { get; }
+    public string RedactedValue { get; }
+    public int RequestBodyLimit { get; }
+    public int ResponseBodyLimit { get; }
+    public string[] LoggableBodyContentTypes { get; }
+    public Func<IHttpContext, IPAddress?>? ClientAddressResolver { get; }
+    public TimeProvider TimeProvider { get; }
+
+    /// <summary>
+    /// Validates and freezes the supplied options.
+    /// </summary>
+    /// <exception cref="ArgumentException">A textual option is null or empty, or <see cref="HttpLoggingOptions.Level"/> is <see cref="LogLevel.None"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">A body limit is negative.</exception>
+    /// <exception cref="ArgumentNullException">The time provider is <see langword="null"/>.</exception>
+    public static HttpLoggingSnapshot Create(HttpLoggingOptions options)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(options.Category);
+        ArgumentException.ThrowIfNullOrEmpty(options.RedactedValue);
+        ArgumentOutOfRangeException.ThrowIfNegative(options.RequestBodyLimit);
+        ArgumentOutOfRangeException.ThrowIfNegative(options.ResponseBodyLimit);
+        ArgumentNullException.ThrowIfNull(options.TimeProvider);
+
+        if (options.Level == LogLevel.None)
+        {
+            throw new ArgumentException(
+                "The HTTP logging level must not be LogLevel.None - it could never emit. To silence " +
+                "logging for specific endpoints attach HttpLoggingMetadata with HttpLoggingFields.None; " +
+                "to silence it globally do not call UseHttpLogging.",
+                nameof(options));
+        }
+
+        var contentTypes = new List<string>(options.LoggableBodyContentTypes.Count);
+        foreach (string contentType in options.LoggableBodyContentTypes)
+        {
+            if (!string.IsNullOrWhiteSpace(contentType))
+            {
+                contentTypes.Add(contentType);
+            }
+        }
+
+        return new HttpLoggingSnapshot(
+            options.Fields,
+            options.Category,
+            options.Level,
+            options.LogRequestStart,
+            options.AllowedRequestHeaders.ToFrozenSet(),
+            options.AllowedResponseHeaders.ToFrozenSet(),
+            options.RedactedValue,
+            options.RequestBodyLimit,
+            options.ResponseBodyLimit,
+            contentTypes.ToArray(),
+            options.ClientAddressResolver,
+            options.TimeProvider);
+    }
+
+    /// <summary>
+    /// Decides whether a message body with the supplied <c>Content-Type</c> value is eligible
+    /// for capture: prefix entries match the start of the media type, <c>+suffix</c> entries
+    /// match its structured-syntax suffix. Parameters after <c>;</c> are ignored.
+    /// </summary>
+    public bool IsBodyContentTypeLoggable(ReadOnlySpan<char> contentTypeValue)
+    {
+        int parameterSeparator = contentTypeValue.IndexOf(';');
+        if (parameterSeparator >= 0)
+        {
+            contentTypeValue = contentTypeValue[..parameterSeparator];
+        }
+
+        contentTypeValue = contentTypeValue.Trim();
+        if (contentTypeValue.IsEmpty)
+        {
+            return false;
+        }
+
+        foreach (string entry in LoggableBodyContentTypes)
+        {
+            bool matches = entry.StartsWith('+')
+                ? contentTypeValue.EndsWith(entry, StringComparison.OrdinalIgnoreCase)
+                : contentTypeValue.StartsWith(entry, StringComparison.OrdinalIgnoreCase);
+
+            if (matches)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/RequestBodyCaptureStream.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/RequestBodyCaptureStream.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+/// <summary>
+/// Transparent read-path wrapper over a request body stream: counts the bytes the application
+/// actually reads and, when capture is armed, tees the first <c>limit</c> bytes into a bounded
+/// buffer. The body itself streams through untouched — no additional buffering, so transport
+/// backpressure and request-size limits behave exactly as without the wrapper.
+/// </summary>
+internal sealed class RequestBodyCaptureStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly int _captureLimit;
+    private byte[]? _captured;
+    private int _capturedCount;
+    private long _bytesRead;
+
+    public RequestBodyCaptureStream(Stream inner, int captureLimit)
+    {
+        _inner = inner;
+        _captureLimit = captureLimit;
+    }
+
+    /// <summary>Total bytes the application read from the body.</summary>
+    public long BytesRead => _bytesRead;
+
+    /// <summary>The captured body prefix; empty when capture was not armed or nothing was read.</summary>
+    public ReadOnlySpan<byte> Captured => _captured is null ? default : _captured.AsSpan(0, _capturedCount);
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => _inner.CanWrite;
+    public override bool CanTimeout => _inner.CanTimeout;
+    public override long Length => _inner.Length;
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+    public override int ReadTimeout
+    {
+        get => _inner.ReadTimeout;
+        set => _inner.ReadTimeout = value;
+    }
+    public override int WriteTimeout
+    {
+        get => _inner.WriteTimeout;
+        set => _inner.WriteTimeout = value;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        int read = _inner.Read(buffer, offset, count);
+        Observe(buffer.AsSpan(offset, read));
+        return read;
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        int read = _inner.Read(buffer);
+        Observe(buffer[..read]);
+        return read;
+    }
+
+    public override int ReadByte()
+    {
+        int value = _inner.ReadByte();
+        if (value >= 0)
+        {
+            byte b = (byte)value;
+            Observe(new ReadOnlySpan<byte>(in b));
+        }
+
+        return value;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        int read = await _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+        Observe(buffer.AsSpan(offset, read));
+        return read;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        Observe(buffer.Span[..read]);
+        return read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+    public override void SetLength(long value) => _inner.SetLength(value);
+    public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+    public override void Write(ReadOnlySpan<byte> buffer) => _inner.Write(buffer);
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _inner.WriteAsync(buffer, offset, count, cancellationToken);
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => _inner.WriteAsync(buffer, cancellationToken);
+    public override void Flush() => _inner.Flush();
+    public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+    private void Observe(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return;
+        }
+
+        _bytesRead += data.Length;
+
+        if (_captureLimit <= 0 || _capturedCount >= _captureLimit)
+        {
+            return;
+        }
+
+        _captured ??= new byte[_captureLimit];
+
+        int take = Math.Min(data.Length, _captureLimit - _capturedCount);
+        data[..take].CopyTo(_captured.AsSpan(_capturedCount));
+        _capturedCount += take;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/ResponseBodyCaptureStream.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/ResponseBodyCaptureStream.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+/// <summary>
+/// Transparent write-path wrapper over a response body stream: counts the bytes the
+/// application writes and, when capture is armed, tees the first <c>limit</c> bytes into a
+/// bounded buffer. Whether capture applies is decided lazily at the first write via the
+/// supplied predicate, because the response <c>Content-Type</c> is unknown until the
+/// application sets it. Writes pass straight through — the wrapper never buffers the full
+/// body, so streaming responses and flow-control backpressure are unaffected.
+/// </summary>
+internal sealed class ResponseBodyCaptureStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly int _captureLimit;
+    private Func<bool>? _capturePredicate;
+    private bool _capture;
+    private byte[]? _captured;
+    private int _capturedCount;
+    private long _bytesWritten;
+
+    public ResponseBodyCaptureStream(Stream inner, int captureLimit, Func<bool>? capturePredicate)
+    {
+        _inner = inner;
+        _captureLimit = captureLimit;
+        _capturePredicate = capturePredicate;
+    }
+
+    /// <summary>Total bytes the application wrote to the body.</summary>
+    public long BytesWritten => _bytesWritten;
+
+    /// <summary>The captured body prefix; empty when capture never armed or nothing was written.</summary>
+    public ReadOnlySpan<byte> Captured => _captured is null ? default : _captured.AsSpan(0, _capturedCount);
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => _inner.CanWrite;
+    public override bool CanTimeout => _inner.CanTimeout;
+    public override long Length => _inner.Length;
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+    public override int ReadTimeout
+    {
+        get => _inner.ReadTimeout;
+        set => _inner.ReadTimeout = value;
+    }
+    public override int WriteTimeout
+    {
+        get => _inner.WriteTimeout;
+        set => _inner.WriteTimeout = value;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _inner.Write(buffer, offset, count);
+        Observe(buffer.AsSpan(offset, count));
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _inner.Write(buffer);
+        Observe(buffer);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        _inner.WriteByte(value);
+        Observe(new ReadOnlySpan<byte>(in value));
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        await _inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+        Observe(buffer.AsSpan(offset, count));
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        await _inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        Observe(buffer.Span);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => _inner.ReadAsync(buffer, cancellationToken);
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+    public override void SetLength(long value) => _inner.SetLength(value);
+    public override void Flush() => _inner.Flush();
+    public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+    private void Observe(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return;
+        }
+
+        _bytesWritten += data.Length;
+
+        if (_capturePredicate is { } predicate)
+        {
+            // Evaluate once, at the first write - the application has set its response head
+            // (including Content-Type) by the time it starts writing the body.
+            _capture = _captureLimit > 0 && predicate();
+            _capturePredicate = null;
+        }
+
+        if (!_capture || _capturedCount >= _captureLimit)
+        {
+            return;
+        }
+
+        _captured ??= new byte[_captureLimit];
+
+        int take = Math.Min(data.Length, _captureLimit - _capturedCount);
+        data[..take].CopyTo(_captured.AsSpan(_capturedCount));
+        _capturedCount += take;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/TraceParent.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/TraceParent.cs
@@ -1,0 +1,91 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+/// <summary>
+/// Span-based parser for the W3C trace-context <c>traceparent</c> header
+/// (<c>version "-" trace-id "-" parent-id "-" trace-flags</c>). This is the whole
+/// OpenTelemetry correlation boundary for HTTP logging: the ids are surfaced as entry
+/// attributes and nothing OTel-specific is referenced.
+/// </summary>
+internal static class TraceParent
+{
+    // 2 (version) + 1 + 32 (trace-id) + 1 + 16 (parent-id) + 1 + 2 (flags)
+    private const int Length = 55;
+
+    /// <summary>
+    /// Attempts to extract the trace id and parent span id from a <c>traceparent</c> value.
+    /// Returns <see langword="false"/> for malformed values and for the all-zero invalid ids
+    /// the specification reserves.
+    /// </summary>
+    public static bool TryParse(ReadOnlySpan<char> value, out string traceId, out string spanId)
+    {
+        traceId = string.Empty;
+        spanId = string.Empty;
+
+        value = value.Trim();
+
+        // Future versions may append fields after the flags; accept them but require the
+        // fixed-length prefix and its separators.
+        if (value.Length < Length || (value.Length > Length && value[Length] != '-'))
+        {
+            return false;
+        }
+
+        if (value[2] != '-' || value[35] != '-' || value[52] != '-')
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> version = value[..2];
+        ReadOnlySpan<char> trace = value.Slice(3, 32);
+        ReadOnlySpan<char> span = value.Slice(36, 16);
+        ReadOnlySpan<char> flags = value.Slice(53, 2);
+
+        // version 0xff is forbidden by the spec.
+        if (!IsLowerHex(version) || version is "ff")
+        {
+            return false;
+        }
+
+        if (!IsLowerHex(trace) || !IsLowerHex(span) || !IsLowerHex(flags))
+        {
+            return false;
+        }
+
+        if (IsAllZero(trace) || IsAllZero(span))
+        {
+            return false;
+        }
+
+        traceId = trace.ToString();
+        spanId = span.ToString();
+        return true;
+    }
+
+    private static bool IsLowerHex(ReadOnlySpan<char> value)
+    {
+        foreach (char c in value)
+        {
+            if (c is (< '0' or > '9') and (< 'a' or > 'f'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsAllZero(ReadOnlySpan<char> value)
+    {
+        foreach (char c in value)
+        {
+            if (c != '0')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/W3CAccessLogFormatter.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/W3CAccessLogFormatter.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Assimalign.Cohesion.Logging;
+
+/// <summary>
+/// Renders one completed-exchange <see cref="ILoggerEntry"/> (identified by the
+/// <see cref="HttpLoggingAttributes"/> contract) as a W3C extended or NCSA common/combined
+/// access-log line. All numeric and date rendering goes through invariant
+/// <see cref="ISpanFormattable.TryFormat"/> into stack buffers — no reflection, no
+/// culture-sensitive fallbacks. Text fields are sanitized against log injection: control
+/// characters never reach the file.
+/// </summary>
+internal static class W3CAccessLogFormatter
+{
+    /// <summary>The fixed field list every W3C-extended file declares.</summary>
+    public const string ExtendedFields =
+        "date time c-ip cs-method cs-uri-stem cs-uri-query sc-status cs-bytes sc-bytes time-taken cs-version cs-host cs(User-Agent) cs(Referer)";
+
+    private const string RequestUserAgent = "http.request.header.user-agent";
+    private const string RequestReferer = "http.request.header.referer";
+
+    /// <summary>
+    /// Appends the directive block that opens a W3C-extended file.
+    /// </summary>
+    public static void AppendExtendedDirectives(StringBuilder builder, DateTimeOffset timestamp)
+    {
+        builder.Append("#Version: 1.0\n");
+        builder.Append("#Software: Assimalign.Cohesion.Web.Diagnostics\n");
+        builder.Append("#Date: ");
+        AppendUtc(builder, timestamp, "yyyy-MM-dd HH:mm:ss");
+        builder.Append('\n');
+        builder.Append("#Fields: ");
+        builder.Append(ExtendedFields);
+        builder.Append('\n');
+    }
+
+    /// <summary>
+    /// Appends one access-log line (terminated with <c>\n</c>) for the supplied entry.
+    /// </summary>
+    public static void AppendLine(StringBuilder builder, ILoggerEntry entry, AccessLogFormat format)
+    {
+        if (format == AccessLogFormat.W3CExtended)
+        {
+            AppendExtendedLine(builder, entry);
+        }
+        else
+        {
+            AppendNcsaLine(builder, entry, includeCombinedFields: format == AccessLogFormat.Combined);
+        }
+    }
+
+    private static void AppendExtendedLine(StringBuilder builder, ILoggerEntry entry)
+    {
+        // date time
+        AppendUtc(builder, entry.Timestamp, "yyyy-MM-dd");
+        builder.Append(' ');
+        AppendUtc(builder, entry.Timestamp, "HH:mm:ss");
+        builder.Append(' ');
+
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.ClientAddress);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.RequestMethod);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.RequestPath);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.RequestQuery);
+        builder.Append(' ');
+        AppendNumber(builder, entry, HttpLoggingAttributes.ResponseStatusCode);
+        builder.Append(' ');
+        AppendNumber(builder, entry, HttpLoggingAttributes.RequestBodyBytes);
+        builder.Append(' ');
+        AppendNumber(builder, entry, HttpLoggingAttributes.ResponseBodyBytes);
+        builder.Append(' ');
+
+        // time-taken: seconds, millisecond precision.
+        if (TryGetDouble(entry, HttpLoggingAttributes.Duration, out double milliseconds))
+        {
+            AppendInvariant(builder, milliseconds / 1000d, "F3");
+        }
+        else
+        {
+            builder.Append('-');
+        }
+
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.RequestProtocol);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, HttpLoggingAttributes.RequestHost);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, RequestUserAgent);
+        builder.Append(' ');
+        AppendExtendedText(builder, entry, RequestReferer);
+        builder.Append('\n');
+    }
+
+    private static void AppendNcsaLine(StringBuilder builder, ILoggerEntry entry, bool includeCombinedFields)
+    {
+        // host ident authuser: no identity surface is logged, so ident/authuser are always '-'.
+        AppendNcsaBareText(builder, entry, HttpLoggingAttributes.ClientAddress);
+        builder.Append(" - - [");
+        AppendUtc(builder, entry.Timestamp, "dd/MMM/yyyy:HH:mm:ss");
+        builder.Append(" +0000] \"");
+
+        AppendNcsaQuotedPart(builder, GetText(entry, HttpLoggingAttributes.RequestMethod) ?? "-");
+        builder.Append(' ');
+        AppendNcsaQuotedPart(builder, GetText(entry, HttpLoggingAttributes.RequestPath) ?? "-");
+
+        if (GetText(entry, HttpLoggingAttributes.RequestQuery) is { Length: > 0 } query)
+        {
+            builder.Append('?');
+            AppendNcsaQuotedPart(builder, query);
+        }
+
+        builder.Append(' ');
+        AppendNcsaQuotedPart(builder, GetText(entry, HttpLoggingAttributes.RequestProtocol) ?? "-");
+        builder.Append("\" ");
+
+        AppendNumber(builder, entry, HttpLoggingAttributes.ResponseStatusCode);
+        builder.Append(' ');
+        AppendNumber(builder, entry, HttpLoggingAttributes.ResponseBodyBytes);
+
+        if (includeCombinedFields)
+        {
+            builder.Append(" \"");
+            AppendNcsaQuotedPart(builder, GetText(entry, RequestReferer) ?? "-");
+            builder.Append("\" \"");
+            AppendNcsaQuotedPart(builder, GetText(entry, RequestUserAgent) ?? "-");
+            builder.Append('"');
+        }
+
+        builder.Append('\n');
+    }
+
+    private static string? GetText(ILoggerEntry entry, string attribute)
+        => entry.Attributes.TryGetValue(attribute, out object? value) && value is string text && text.Length > 0
+            ? text
+            : null;
+
+    private static bool TryGetDouble(ILoggerEntry entry, string attribute, out double result)
+    {
+        if (entry.Attributes.TryGetValue(attribute, out object? value) && value is double d)
+        {
+            result = d;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// W3C-extended text field: spaces become <c>+</c> (the IIS convention, so the
+    /// space-separated line stays parseable) and control characters are dropped.
+    /// </summary>
+    private static void AppendExtendedText(StringBuilder builder, ILoggerEntry entry, string attribute)
+    {
+        string? text = GetText(entry, attribute);
+        if (text is null)
+        {
+            builder.Append('-');
+            return;
+        }
+
+        foreach (char c in text)
+        {
+            if (c is < ' ' or '\x7f')
+            {
+                continue;
+            }
+
+            builder.Append(c == ' ' ? '+' : c);
+        }
+    }
+
+    /// <summary>
+    /// NCSA unquoted field (the host position): whitespace and control characters are dropped
+    /// so the field cannot split or forge the line.
+    /// </summary>
+    private static void AppendNcsaBareText(StringBuilder builder, ILoggerEntry entry, string attribute)
+    {
+        string? text = GetText(entry, attribute);
+        if (text is null)
+        {
+            builder.Append('-');
+            return;
+        }
+
+        foreach (char c in text)
+        {
+            if (c is <= ' ' or '\x7f')
+            {
+                continue;
+            }
+
+            builder.Append(c);
+        }
+    }
+
+    /// <summary>
+    /// NCSA quoted-field content: quotes and backslashes are escaped, control characters
+    /// dropped.
+    /// </summary>
+    private static void AppendNcsaQuotedPart(StringBuilder builder, string text)
+    {
+        foreach (char c in text)
+        {
+            if (c is < ' ' or '\x7f')
+            {
+                continue;
+            }
+
+            if (c is '"' or '\\')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(c);
+        }
+    }
+
+    private static void AppendNumber(StringBuilder builder, ILoggerEntry entry, string attribute)
+    {
+        if (!entry.Attributes.TryGetValue(attribute, out object? value))
+        {
+            builder.Append('-');
+            return;
+        }
+
+        switch (value)
+        {
+            case int number:
+                AppendInvariant(builder, number);
+                break;
+            case long number:
+                AppendInvariant(builder, number);
+                break;
+            default:
+                builder.Append('-');
+                break;
+        }
+    }
+
+    private static void AppendInvariant(StringBuilder builder, long value)
+    {
+        Span<char> buffer = stackalloc char[20];
+        value.TryFormat(buffer, out int written, provider: CultureInfo.InvariantCulture);
+        builder.Append(buffer[..written]);
+    }
+
+    private static void AppendInvariant(StringBuilder builder, double value, string format)
+    {
+        Span<char> buffer = stackalloc char[32];
+        if (value.TryFormat(buffer, out int written, format, CultureInfo.InvariantCulture))
+        {
+            builder.Append(buffer[..written]);
+        }
+        else
+        {
+            builder.Append(value.ToString(format, CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static void AppendUtc(StringBuilder builder, DateTimeOffset timestamp, string format)
+    {
+        Span<char> buffer = stackalloc char[32];
+        if (timestamp.UtcDateTime.TryFormat(buffer, out int written, format, CultureInfo.InvariantCulture))
+        {
+            builder.Append(buffer[..written]);
+        }
+        else
+        {
+            builder.Append(timestamp.UtcDateTime.ToString(format, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/W3CAccessLogWriter.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Internal/W3CAccessLogWriter.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Assimalign.Cohesion.Logging;
+
+/// <summary>
+/// The file sink behind <see cref="W3CAccessLogProvider"/>: buffered, lock-serialized writes
+/// into per-UTC-day files (<c>{prefix}-{yyyyMMdd}.log</c>), size-based rolling into sequenced
+/// files within a day, oldest-first retention sweeps, and a periodic flush timer. Rolling
+/// decisions key off the <em>entry's</em> timestamp, so behavior is deterministic under a fake
+/// <see cref="TimeProvider"/> upstream.
+/// </summary>
+internal sealed class W3CAccessLogWriter : IDisposable
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly Lock _lock = new();
+    private readonly StringBuilder _buffer = new(capacity: 512);
+    private readonly string _directory;
+    private readonly string _prefix;
+    private readonly AccessLogFormat _format;
+    private readonly long? _fileSizeLimit;
+    private readonly int? _retainedFileCountLimit;
+    private readonly Timer? _flushTimer;
+
+    private StreamWriter? _writer;
+    private string? _currentPath;
+    private DateOnly _currentDate;
+    private int _sequence;
+    private long _approximateSize;
+    private bool _dirty;
+    private bool _disposed;
+
+    public W3CAccessLogWriter(
+        string directory,
+        string prefix,
+        AccessLogFormat format,
+        long? fileSizeLimit,
+        int? retainedFileCountLimit,
+        TimeSpan flushInterval)
+    {
+        _directory = directory;
+        _prefix = prefix;
+        _format = format;
+        _fileSizeLimit = fileSizeLimit;
+        _retainedFileCountLimit = retainedFileCountLimit;
+
+        if (flushInterval > TimeSpan.Zero)
+        {
+            _flushTimer = new Timer(static state => ((W3CAccessLogWriter)state!).TimerFlush(), this, flushInterval, flushInterval);
+        }
+    }
+
+    public void Write(ILoggerEntry entry)
+    {
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            DateOnly date = DateOnly.FromDateTime(entry.Timestamp.UtcDateTime);
+
+            if (_writer is null || date != _currentDate)
+            {
+                Open(date, startSequence: 0, entry.Timestamp);
+            }
+            else if (_fileSizeLimit is { } limit && _approximateSize >= limit)
+            {
+                Open(date, _sequence + 1, entry.Timestamp);
+            }
+
+            _buffer.Clear();
+            W3CAccessLogFormatter.AppendLine(_buffer, entry, _format);
+            _writer!.Write(_buffer);
+
+            // Char count approximates bytes (the line is ASCII-dominant); the size limit is
+            // documented as approximate.
+            _approximateSize += _buffer.Length;
+
+            if (_flushTimer is null)
+            {
+                _writer.Flush();
+            }
+            else
+            {
+                _dirty = true;
+            }
+        }
+    }
+
+    public void Flush()
+    {
+        lock (_lock)
+        {
+            if (_disposed || _writer is null)
+            {
+                return;
+            }
+
+            _writer.Flush();
+            _dirty = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Dispose the timer first: an in-flight callback either finishes before we take the
+        // lock or observes _disposed afterwards.
+        _flushTimer?.Dispose();
+
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            CloseWriter();
+        }
+    }
+
+    private void TimerFlush()
+    {
+        lock (_lock)
+        {
+            if (_disposed || !_dirty || _writer is null)
+            {
+                return;
+            }
+
+            try
+            {
+                _writer.Flush();
+                _dirty = false;
+            }
+            catch
+            {
+                // A transient flush failure (disk pressure, ...) must not take down the timer;
+                // the next write or flush retries.
+            }
+        }
+    }
+
+    private void Open(DateOnly date, int startSequence, DateTimeOffset timestamp)
+    {
+        CloseWriter();
+
+        _currentDate = date;
+        _sequence = startSequence;
+
+        Directory.CreateDirectory(_directory);
+
+        // Skip sequences whose files are already full - a restart appends to the day's current
+        // file rather than overwriting or endlessly re-rolling.
+        while (true)
+        {
+            string path = BuildPath(date, _sequence);
+            long existingLength = File.Exists(path) ? new FileInfo(path).Length : 0;
+
+            if (_fileSizeLimit is { } limit && existingLength >= limit)
+            {
+                _sequence++;
+                continue;
+            }
+
+            var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+            _writer = new StreamWriter(stream, Utf8NoBom, bufferSize: 64 * 1024) { AutoFlush = false };
+            _currentPath = path;
+            _approximateSize = existingLength;
+
+            if (_format == AccessLogFormat.W3CExtended && existingLength == 0)
+            {
+                _buffer.Clear();
+                W3CAccessLogFormatter.AppendExtendedDirectives(_buffer, timestamp);
+                _writer.Write(_buffer);
+                _approximateSize += _buffer.Length;
+                _dirty = true;
+            }
+
+            break;
+        }
+
+        ApplyRetention();
+    }
+
+    private void ApplyRetention()
+    {
+        if (_retainedFileCountLimit is not { } keep)
+        {
+            return;
+        }
+
+        try
+        {
+            var files = new List<FileInfo>();
+            foreach (string path in Directory.EnumerateFiles(_directory, _prefix + "-*.log"))
+            {
+                files.Add(new FileInfo(path));
+            }
+
+            if (files.Count <= keep)
+            {
+                return;
+            }
+
+            files.Sort(static (left, right) => left.LastWriteTimeUtc.CompareTo(right.LastWriteTimeUtc));
+
+            int excess = files.Count - keep;
+            for (int i = 0; i < files.Count && excess > 0; i++)
+            {
+                if (string.Equals(files[i].FullName, _currentPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    files[i].Delete();
+                }
+                catch
+                {
+                    // A file locked by an external reader is skipped; the next roll retries.
+                }
+
+                excess--;
+            }
+        }
+        catch
+        {
+            // Retention is best-effort: enumeration failures must never block logging.
+        }
+    }
+
+    private void CloseWriter()
+    {
+        if (_writer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _writer.Flush();
+        }
+        catch
+        {
+            // Flush-on-close is best-effort; disposal below still releases the handle.
+        }
+
+        _writer.Dispose();
+        _writer = null;
+        _currentPath = null;
+        _dirty = false;
+    }
+
+    private string BuildPath(DateOnly date, int sequence)
+    {
+        string name = sequence == 0
+            ? string.Create(CultureInfo.InvariantCulture, $"{_prefix}-{date:yyyyMMdd}.log")
+            : string.Create(CultureInfo.InvariantCulture, $"{_prefix}-{date:yyyyMMdd}.{sequence:D3}.log");
+
+        return Path.Combine(_directory, name);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Properties/AssemblyInfo.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// Friend access for the Web.Diagnostics test project. The Cohesion repo is not strong-name
+// signed in CI builds, so the declaration deliberately omits a PublicKey clause to avoid CS0281
+// in Release.
+[assembly: InternalsVisibleTo("Assimalign.Cohesion.Web.Diagnostics.Tests")]

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/W3CAccessLogOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/W3CAccessLogOptions.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+/// <summary>
+/// Configuration shape for <see cref="W3CAccessLogProvider"/>.
+/// </summary>
+/// <remarks>
+/// The options are validated and copied when the provider is constructed; later mutation has no
+/// effect.
+/// </remarks>
+public sealed class W3CAccessLogOptions
+{
+    /// <summary>
+    /// Gets or sets the directory the log files are written to. Required; created on first
+    /// write when it does not exist.
+    /// </summary>
+    public string? Directory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the log file name prefix. Files are named
+    /// <c>{prefix}-{yyyyMMdd}.log</c>, with a <c>.{seq:000}</c> segment appended when
+    /// <see cref="FileSizeLimit"/> rolls a day over multiple files. Defaults to <c>access</c>.
+    /// </summary>
+    public string FileNamePrefix { get; set; } = "access";
+
+    /// <summary>
+    /// Gets or sets the line format. Defaults to <see cref="AccessLogFormat.W3CExtended"/>.
+    /// </summary>
+    public AccessLogFormat Format { get; set; } = AccessLogFormat.W3CExtended;
+
+    /// <summary>
+    /// Gets or sets the approximate per-file size limit in bytes; when a file exceeds it, the
+    /// provider rolls to the next sequence number for the same UTC day. <see langword="null"/>
+    /// disables size-based rolling. Defaults to 10 MiB.
+    /// </summary>
+    public long? FileSizeLimit { get; set; } = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets how many log files are retained; when a roll creates a new file, the oldest
+    /// files (ordinal name order) beyond the limit are deleted. <see langword="null"/> disables
+    /// retention. Defaults to 31.
+    /// </summary>
+    public int? RetainedFileCountLimit { get; set; } = 31;
+
+    /// <summary>
+    /// Gets or sets how often buffered output is flushed to disk. Writes are buffered between
+    /// flushes; <see cref="TimeSpan.Zero"/> flushes after every entry. Buffered output is also
+    /// flushed when the provider is disposed or <see cref="W3CAccessLogProvider.Flush"/> is
+    /// called. Defaults to one second.
+    /// </summary>
+    public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(1);
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/W3CAccessLogProvider.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/src/W3CAccessLogProvider.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+
+namespace Assimalign.Cohesion.Web.Diagnostics;
+
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> that renders completed HTTP exchanges as W3C extended or
+/// NCSA common/combined access-log files with buffered, size- and day-rolled output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider is a plain member of the Cohesion logging pipeline: register it on the
+/// application's <see cref="ILoggerFactoryBuilder"/> next to console/debug providers and let
+/// the HTTP logging middleware (<c>UseHttpLogging</c>) emit through the composed logger. It
+/// renders only entries stamped <see cref="HttpLoggingAttributes.Event"/> =
+/// <see cref="HttpLoggingAttributes.EventExchange"/> — one line per completed exchange — and
+/// ignores everything else, so it is safe in a factory that also carries application logging.
+/// Use a <see cref="LoggerFilterRule"/> scoped to this provider's type to trim the fan-out when
+/// application log volume is high.
+/// </para>
+/// <para>
+/// Files are written to <see cref="W3CAccessLogOptions.Directory"/> as
+/// <c>{prefix}-{yyyyMMdd}.log</c>, rolling to <c>{prefix}-{yyyyMMdd}.{seq:000}.log</c> when
+/// <see cref="W3CAccessLogOptions.FileSizeLimit"/> is exceeded, with oldest-first deletion
+/// beyond <see cref="W3CAccessLogOptions.RetainedFileCountLimit"/>. Output is buffered and
+/// flushed on <see cref="W3CAccessLogOptions.FlushInterval"/>, on <see cref="Flush"/>, and on
+/// disposal. The provider is thread-safe; lines from concurrent exchanges never interleave.
+/// </para>
+/// </remarks>
+public sealed class W3CAccessLogProvider : LoggerProvider
+{
+    private readonly W3CAccessLogWriter _writer;
+
+    /// <summary>
+    /// Initializes the provider from the supplied options. The options are validated and
+    /// copied; later mutation has no effect.
+    /// </summary>
+    /// <param name="options">The access-log options. <see cref="W3CAccessLogOptions.Directory"/> is required.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <see cref="W3CAccessLogOptions.Directory"/> is null or empty, the file name prefix is
+    /// empty or contains invalid file name characters, or the format is not a defined
+    /// <see cref="AccessLogFormat"/> value.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A size, retention, or flush-interval option is zero or negative where a positive value is
+    /// required.
+    /// </exception>
+    public W3CAccessLogProvider(W3CAccessLogOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrEmpty(options.Directory, "options.Directory");
+        ArgumentException.ThrowIfNullOrEmpty(options.FileNamePrefix, "options.FileNamePrefix");
+
+        if (options.FileNamePrefix.AsSpan().IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("The file name prefix contains invalid file name characters.", nameof(options));
+        }
+
+        if (options.Format is not (AccessLogFormat.W3CExtended or AccessLogFormat.Common or AccessLogFormat.Combined))
+        {
+            throw new ArgumentException($"Unknown access log format '{options.Format}'.", nameof(options));
+        }
+
+        if (options.FileSizeLimit is { } sizeLimit)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sizeLimit, "options.FileSizeLimit");
+        }
+
+        if (options.RetainedFileCountLimit is { } retained)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(retained, "options.RetainedFileCountLimit");
+        }
+
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.FlushInterval, TimeSpan.Zero, "options.FlushInterval");
+
+        _writer = new W3CAccessLogWriter(
+            options.Directory,
+            options.FileNamePrefix,
+            options.Format,
+            options.FileSizeLimit,
+            options.RetainedFileCountLimit,
+            options.FlushInterval);
+    }
+
+    /// <inheritdoc />
+    public override string Name => "W3CAccessLog";
+
+    /// <summary>
+    /// Flushes buffered output to disk. Called automatically on the configured
+    /// <see cref="W3CAccessLogOptions.FlushInterval"/> and on disposal; call it directly when a
+    /// test or shutdown path needs the file contents immediately.
+    /// </summary>
+    public void Flush() => _writer.Flush();
+
+    /// <inheritdoc />
+    protected override Logger CreateCore(string category) => new W3CAccessLogLogger(category, this);
+
+    /// <inheritdoc />
+    protected override void DisposeCore() => _writer.Dispose();
+
+    internal void Write(ILoggerEntry entry)
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        // One line per completed exchange: anything not stamped as an exchange event (request
+        // starts, scope seeds, application logging sharing the factory) is not an access-log
+        // line and is ignored.
+        if (entry.Attributes.TryGetValue(HttpLoggingAttributes.Event, out object? value)
+            && value is HttpLoggingAttributes.EventExchange)
+        {
+            _writer.Write(entry);
+        }
+    }
+
+    private sealed class W3CAccessLogLogger : Logger
+    {
+        private readonly W3CAccessLogProvider _provider;
+
+        public W3CAccessLogLogger(string category, W3CAccessLogProvider provider)
+            : base(category)
+        {
+            _provider = provider;
+        }
+
+        public override bool IsEnabled(LogLevel level) => base.IsEnabled(level) && !_provider.IsDisposed;
+
+        protected override void WriteCore(ILoggerEntry entry) => _provider.Write(entry);
+
+        protected override IScopedLogger BeginScopeCore(ILoggerEntry entry)
+        {
+            // Scope seeds are not exchanges; Write filters them out. The scope simply keeps
+            // routing entries to the provider.
+            _provider.Write(entry);
+            return new W3CAccessLogScopedLogger(Category, _provider, entry.Id);
+        }
+    }
+
+    private sealed class W3CAccessLogScopedLogger : ScopedLogger
+    {
+        private readonly W3CAccessLogProvider _provider;
+
+        public W3CAccessLogScopedLogger(string category, W3CAccessLogProvider provider, LogId parentId)
+            : base(category, parentId)
+        {
+            _provider = provider;
+        }
+
+        public override bool IsEnabled(LogLevel level) => base.IsEnabled(level) && !_provider.IsDisposed;
+
+        protected override void WriteCore(ILoggerEntry entry) => _provider.Write(entry);
+
+        protected override IScopedLogger BeginScopeCore(ILoggerEntry entry)
+        {
+            _provider.Write(entry);
+            return new W3CAccessLogScopedLogger(Category, _provider, entry.Id);
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/Assimalign.Cohesion.Web.Diagnostics.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/Assimalign.Cohesion.Web.Diagnostics.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Diagnostics" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
+	</ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/HttpLoggingEndToEndTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/HttpLoggingEndToEndTests.cs
@@ -1,0 +1,544 @@
+using System.Net;
+using System.Text;
+
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Diagnostics.Tests.TestObjects;
+using Assimalign.Cohesion.Web.Routing;
+using Assimalign.Cohesion.Web.Routing.Metadata;
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using CohesionHttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using HttpHeaderKey = Assimalign.Cohesion.Http.HttpHeaderKey;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests;
+
+/// <summary>
+/// End-to-end coverage over the Web.Testing factory: requests flow the real pipeline
+/// (in-memory transport, HTTP/1.1) and the middleware's entries are captured through a real
+/// <see cref="LoggerFactoryBuilder"/>-built factory, asserting field capture, redaction,
+/// per-endpoint overrides, fault escalation, and correlation.
+/// </summary>
+public class HttpLoggingEndToEndTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Waits until the recording provider has seen <paramref name="count"/> entries. The
+    /// completion entry is emitted just before the pipeline returns to the server, which can
+    /// race the client observing the final response bytes.
+    /// </summary>
+    private static async Task<IReadOnlyList<ILoggerEntry>> WaitForEntriesAsync(
+        RecordingLoggerProvider recorded,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            IReadOnlyList<ILoggerEntry> entries = recorded.Entries;
+            if (entries.Count >= count)
+            {
+                return entries;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(10, cancellationToken);
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: A GET emits one exchange entry with the default fields")]
+    public async Task Get_DefaultFields_ShouldEmitExchangeEntry()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category))
+            .Use(async (context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("hello"), context.RequestCancelled);
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/probe", cancellation.Token);
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+
+        entry.Category.ShouldBe("Assimalign.Cohesion.Web.Diagnostics.HttpLogging");
+        entry.Level.ShouldBe(LogLevel.Information);
+        entry.Message.ShouldStartWith("GET /probe -> 200 in ");
+        entry.Message.ShouldEndWith(" ms");
+
+        entry.Attributes[HttpLoggingAttributes.Event].ShouldBe(HttpLoggingAttributes.EventExchange);
+        entry.Attributes[HttpLoggingAttributes.RequestMethod].ShouldBe("GET");
+        entry.Attributes[HttpLoggingAttributes.RequestPath].ShouldBe("/probe");
+        entry.Attributes[HttpLoggingAttributes.RequestHost].ShouldBe("localhost");
+        entry.Attributes[HttpLoggingAttributes.RequestProtocol].ShouldBe("HTTP/1.1");
+        entry.Attributes[HttpLoggingAttributes.ResponseStatusCode].ShouldBe(200);
+        entry.Attributes[HttpLoggingAttributes.ResponseBodyBytes].ShouldBe(5L);
+        entry.Attributes[HttpLoggingAttributes.Duration].ShouldBeOfType<double>().ShouldBeGreaterThanOrEqualTo(0d);
+
+        // Default field set captures no bodies and no query.
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.RequestBody).ShouldBeFalse();
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.ResponseBody).ShouldBeFalse();
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.RequestQuery).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: Credential-bearing header values are redacted, allowlisted ones are not")]
+    public async Task Headers_OutsideAllowlist_ShouldBeRedacted()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category))
+            .Use((context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                context.Response.Headers[HttpHeaderKey.SetCookie] = "sid=response-cookie-value";
+                context.Response.Headers[HttpHeaderKey.Server] = "Cohesion";
+                return Task.CompletedTask;
+            });
+
+        using HttpClient client = factory.CreateClient();
+        using HttpRequestMessage request = new(System.Net.Http.HttpMethod.Get, "/secure");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token-123");
+        request.Headers.TryAddWithoutValidation("Cookie", "session=cookie-secret-456");
+        request.Headers.TryAddWithoutValidation("X-Api-Key", "custom-secret-789");
+        request.Headers.TryAddWithoutValidation("User-Agent", "CohesionTests/1.0");
+
+        // Act
+        (await client.SendAsync(request, cancellation.Token)).Dispose();
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+
+        // Names always log; values outside the allowlist are the redaction placeholder.
+        entry.Attributes["http.request.header.authorization"].ShouldBe("[Redacted]");
+        entry.Attributes["http.request.header.cookie"].ShouldBe("[Redacted]");
+        entry.Attributes["http.request.header.x-api-key"].ShouldBe("[Redacted]");
+        entry.Attributes["http.request.header.user-agent"].ShouldBe("CohesionTests/1.0");
+        entry.Attributes["http.response.header.set-cookie"].ShouldBe("[Redacted]");
+        entry.Attributes["http.response.header.server"].ShouldBe("Cohesion");
+
+        // Belt and braces: no secret value survives anywhere in the entry.
+        foreach (object? value in entry.Attributes.Values)
+        {
+            if (value is string text)
+            {
+                text.ShouldNotContain("secret-token-123");
+                text.ShouldNotContain("cookie-secret-456");
+                text.ShouldNotContain("custom-secret-789");
+                text.ShouldNotContain("response-cookie-value");
+            }
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: The query string logs only when opted in")]
+    public async Task Query_OptIn_ShouldLogSerializedQuery()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(
+                loggerFactory.Create(new HttpLoggingOptions().Category),
+                options => options.Fields = HttpLoggingFields.Default | HttpLoggingFields.RequestQuery)
+            .Use((context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        (await client.GetAsync("/search?q=alpha&flag", cancellation.Token)).Dispose();
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Attributes[HttpLoggingAttributes.RequestQuery].ShouldBeOfType<string>().ShouldContain("q=alpha", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: Opt-in body capture is bounded and content-type gated")]
+    public async Task Bodies_OptIn_ShouldCaptureBoundedPrefixes()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(
+                loggerFactory.Create(new HttpLoggingOptions().Category),
+                options =>
+                {
+                    options.Fields = HttpLoggingFields.All;
+                    options.RequestBodyLimit = 8;
+                    options.ResponseBodyLimit = 8;
+                })
+            .Use(async (context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                context.Response.Headers[HttpHeaderKey.ContentType] = context.Request.Headers[HttpHeaderKey.ContentType].Value;
+                await context.Request.Body.CopyToAsync(context.Response.Body, context.RequestCancelled);
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act — 16 bytes of JSON-typed payload, echoed back.
+        using StringContent json = new("0123456789ABCDEF", Encoding.UTF8, "application/json");
+        (await client.PostAsync("/echo", json, cancellation.Token)).Dispose();
+
+        // Assert — captures stop at the 8-byte cap; byte counts see the full body.
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Attributes[HttpLoggingAttributes.RequestBody].ShouldBe("01234567");
+        entry.Attributes[HttpLoggingAttributes.ResponseBody].ShouldBe("01234567");
+        entry.Attributes[HttpLoggingAttributes.RequestBodyBytes].ShouldBe(16L);
+        entry.Attributes[HttpLoggingAttributes.ResponseBodyBytes].ShouldBe(16L);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: Binary content types are counted but never captured")]
+    public async Task Bodies_BinaryContentType_ShouldCountWithoutCapturing()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(
+                loggerFactory.Create(new HttpLoggingOptions().Category),
+                options => options.Fields = HttpLoggingFields.All)
+            .Use(async (context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                context.Response.Headers[HttpHeaderKey.ContentType] = "application/octet-stream";
+                await context.Request.Body.CopyToAsync(context.Response.Body, context.RequestCancelled);
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        using ByteArrayContent binary = new(Encoding.UTF8.GetBytes("0123456789ABCDEF"));
+        binary.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+
+        // Act
+        (await client.PostAsync("/blob", binary, cancellation.Token)).Dispose();
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.RequestBody).ShouldBeFalse();
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.ResponseBody).ShouldBeFalse();
+        entry.Attributes[HttpLoggingAttributes.RequestBodyBytes].ShouldBe(16L);
+        entry.Attributes[HttpLoggingAttributes.ResponseBodyBytes].ShouldBe(16L);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: HttpLoggingFields.None endpoint metadata silences the endpoint")]
+    public async Task EndpointMetadata_None_ShouldSuppressEntry()
+    {
+        // Arrange — a health-style route silenced via the endpoint metadata bag, and a normal
+        // route that still logs.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Builder.AddRouting();
+
+        factory.Application.UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category));
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/healthz",
+            new RouterRouteHandler(context =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            }),
+            new RouterRouteMetadataCollection(new HttpLoggingMetadata(HttpLoggingFields.None))));
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/orders",
+            new RouterRouteHandler(context =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            })));
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act — the probe first; sequential requests on one connection serialize, so if the
+        // probe were going to log, its entry would precede the /orders one.
+        (await client.GetAsync("/healthz", cancellation.Token)).Dispose();
+        (await client.GetAsync("/orders", cancellation.Token)).Dispose();
+
+        // Assert
+        IReadOnlyList<ILoggerEntry> entries = await WaitForEntriesAsync(recorded, 1, cancellation.Token);
+        entries.Count.ShouldBe(1);
+        entries[0].Attributes[HttpLoggingAttributes.RequestPath].ShouldBe("/orders");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: Endpoint metadata narrows the emitted field set")]
+    public async Task EndpointMetadata_NarrowedFields_ShouldLimitAttributes()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Builder.AddRouting();
+
+        factory.Application.UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category));
+
+        IRouterBuilder routes = factory.Application.UseRouting();
+        routes.Map(new Route(
+            CohesionHttpMethod.Get,
+            "/mini",
+            new RouterRouteHandler(context =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            }),
+            new RouterRouteMetadataCollection(
+                new HttpLoggingMetadata(HttpLoggingFields.RequestMethod | HttpLoggingFields.ResponseStatusCode))));
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        (await client.GetAsync("/mini", cancellation.Token)).Dispose();
+
+        // Assert — only the two overridden fields survive; the message mirrors the reduction.
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Message.ShouldBe("GET - -> 200");
+        entry.Attributes[HttpLoggingAttributes.RequestMethod].ShouldBe("GET");
+        entry.Attributes[HttpLoggingAttributes.ResponseStatusCode].ShouldBe(200);
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.RequestPath).ShouldBeFalse();
+        entry.Attributes.ContainsKey(HttpLoggingAttributes.Duration).ShouldBeFalse();
+        entry.Attributes.Keys.ShouldNotContain(key => key.StartsWith(HttpLoggingAttributes.RequestHeaderPrefix, StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: A faulting downstream escalates the entry to Error and rethrows")]
+    public async Task Fault_Downstream_ShouldEscalateToErrorAndRethrow()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category))
+            // Async lambda so overload resolution binds the request-time middleware shape
+            // (Func<IHttpContext, WebApplicationMiddleware, Task>) - a bare throw expression
+            // would also satisfy the pipeline-build-time Use overload.
+            .Use(async (context, next) =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act — the middleware rethrows, so the server's exception-isolation boundary tears the
+        // connection down and the client observes a transport failure.
+        await Should.ThrowAsync<HttpRequestException>(() => client.GetAsync("/kaboom", cancellation.Token));
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Level.ShouldBe(LogLevel.Error);
+        entry.Exception.ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("boom");
+        entry.Message.ShouldEndWith("(faulted)");
+        entry.Attributes[HttpLoggingAttributes.RequestPath].ShouldBe("/kaboom");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: An inbound traceparent yields trace and span id attributes")]
+    public async Task TraceContext_InboundTraceparent_ShouldAttachIds()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(loggerFactory.Create(new HttpLoggingOptions().Category))
+            .Use((context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            });
+
+        using HttpClient client = factory.CreateClient();
+        using HttpRequestMessage request = new(System.Net.Http.HttpMethod.Get, "/traced");
+        request.Headers.TryAddWithoutValidation("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
+
+        // Act
+        (await client.SendAsync(request, cancellation.Token)).Dispose();
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Attributes[HttpLoggingAttributes.TraceId].ShouldBe("0af7651916cd43dd8448eb211c80319c");
+        entry.Attributes[HttpLoggingAttributes.SpanId].ShouldBe("b7ad6b7169203331");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: LogRequestStart correlates start and completion via ParentId")]
+    public async Task RequestStart_Enabled_ShouldCorrelateEntries()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(
+                loggerFactory.Create(new HttpLoggingOptions().Category),
+                options => options.LogRequestStart = true)
+            .Use((context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        (await client.GetAsync("/scoped", cancellation.Token)).Dispose();
+
+        // Assert — the start entry seeds the scope; the completion entry inherits its id.
+        IReadOnlyList<ILoggerEntry> entries = await WaitForEntriesAsync(recorded, 2, cancellation.Token);
+        entries.Count.ShouldBe(2);
+
+        ILoggerEntry start = entries[0];
+        ILoggerEntry exchange = entries[1];
+
+        start.Attributes[HttpLoggingAttributes.Event].ShouldBe(HttpLoggingAttributes.EventStart);
+        start.Message.ShouldBe("GET /scoped started");
+        exchange.Attributes[HttpLoggingAttributes.Event].ShouldBe(HttpLoggingAttributes.EventExchange);
+        exchange.ParentId.ShouldBe(start.Id);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: The client-address resolver seam overrides the socket peer")]
+    public async Task ClientAddress_ResolverSeam_ShouldOverrideSocketPeer()
+    {
+        // Arrange — until the #778 forwarded middleware merges, the resolver is the seam a
+        // proxy-aware composition plugs in; the default remains the socket peer.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        RecordingLoggerProvider recorded = new();
+        using ILoggerFactory loggerFactory = new LoggerFactoryBuilder().AddProvider(recorded).Build();
+
+        await using WebApplicationTestFactory factory = new();
+        factory.Application
+            .UseHttpLogging(
+                loggerFactory.Create(new HttpLoggingOptions().Category),
+                options => options.ClientAddressResolver = _ => IPAddress.Parse("203.0.113.9"))
+            .Use((context, next) =>
+            {
+                context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                return Task.CompletedTask;
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        (await client.GetAsync("/fronted", cancellation.Token)).Dispose();
+
+        // Assert
+        ILoggerEntry entry = (await WaitForEntriesAsync(recorded, 1, cancellation.Token))[0];
+        entry.Attributes[HttpLoggingAttributes.ClientAddress].ShouldBe("203.0.113.9");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - E2E: The W3C provider writes an access-log line with no redacted secrets")]
+    public async Task W3CProvider_EndToEnd_ShouldWriteRedactedAccessLog()
+    {
+        // Arrange — the full composition: middleware emits through a factory that fans out to
+        // both the recording provider and the W3C file provider.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        string directory = Path.Combine(Path.GetTempPath(), "cohesion-w3c-tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            RecordingLoggerProvider recorded = new();
+            W3CAccessLogProvider accessLog = new(new W3CAccessLogOptions
+            {
+                Directory = directory,
+                FlushInterval = TimeSpan.Zero,
+            });
+
+            using ILoggerFactory loggerFactory = new LoggerFactoryBuilder()
+                .AddProvider(recorded)
+                .AddProvider(accessLog)
+                .Build();
+
+            await using WebApplicationTestFactory factory = new();
+            factory.Application
+                .UseHttpLogging(loggerFactory)
+                .Use((context, next) =>
+                {
+                    context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+                    return Task.CompletedTask;
+                });
+
+            using HttpClient client = factory.CreateClient();
+            using HttpRequestMessage request = new(System.Net.Http.HttpMethod.Get, "/w3c-e2e");
+            request.Headers.TryAddWithoutValidation("Authorization", "Bearer hunter2-secret");
+            request.Headers.TryAddWithoutValidation("User-Agent", "CohesionW3C/1.0");
+
+            // Act
+            (await client.SendAsync(request, cancellation.Token)).Dispose();
+            await WaitForEntriesAsync(recorded, 1, cancellation.Token);
+            accessLog.Flush();
+
+            // Assert
+            string[] files = Directory.GetFiles(directory, "access-*.log");
+            files.Length.ShouldBe(1);
+
+            // The provider still holds the file open for writing (FileShare.Read), so the
+            // reader must share write access.
+            string content;
+            using (FileStream stream = new(files[0], FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader reader = new(stream))
+            {
+                content = reader.ReadToEnd();
+            }
+            content.ShouldStartWith("#Version: 1.0\n");
+            content.ShouldContain("GET /w3c-e2e - 200", Case.Sensitive);
+            content.ShouldContain("CohesionW3C/1.0", Case.Sensitive);
+            content.ShouldNotContain("hunter2-secret");
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/HttpLoggingOptionsTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/HttpLoggingOptionsTests.cs
@@ -1,0 +1,116 @@
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Shouldly;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests;
+
+/// <summary>
+/// Locks in the security-relevant defaults of <see cref="HttpLoggingOptions"/> and the
+/// validation performed when they are frozen into a snapshot.
+/// </summary>
+public class HttpLoggingOptionsTests
+{
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Options: Credential-bearing headers must not be in the default allowlists")]
+    public void Defaults_ShouldExcludeCredentialBearingHeaders()
+    {
+        // Arrange
+        HttpLoggingOptions options = new();
+
+        // Assert — the redaction-by-default contract of issue #794.
+        options.AllowedRequestHeaders.ShouldNotContain(HttpHeaderKey.Authorization);
+        options.AllowedRequestHeaders.ShouldNotContain(HttpHeaderKey.ProxyAuthorization);
+        options.AllowedRequestHeaders.ShouldNotContain(HttpHeaderKey.Cookie);
+        options.AllowedResponseHeaders.ShouldNotContain(HttpHeaderKey.SetCookie);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Options: Default allowlists carry the standard access-log headers")]
+    public void Defaults_ShouldAllowCommonAccessLogHeaders()
+    {
+        // Arrange
+        HttpLoggingOptions options = new();
+
+        // Assert — User-Agent and Referer feed the W3C/NCSA formats; Content-Type/Length are
+        // routine diagnostics.
+        options.AllowedRequestHeaders.ShouldContain(HttpHeaderKey.UserAgent);
+        options.AllowedRequestHeaders.ShouldContain(HttpHeaderKey.Referer);
+        options.AllowedRequestHeaders.ShouldContain(HttpHeaderKey.ContentType);
+        options.AllowedRequestHeaders.ShouldContain(HttpHeaderKey.ContentLength);
+        options.AllowedRequestHeaders.ShouldContain(HttpHeaderKey.Host);
+        options.AllowedResponseHeaders.ShouldContain(HttpHeaderKey.ContentType);
+        options.AllowedResponseHeaders.ShouldContain(HttpHeaderKey.Location);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Options: Defaults exclude bodies and query string from the field set")]
+    public void Defaults_ShouldExcludeBodiesAndQuery()
+    {
+        // Arrange
+        HttpLoggingOptions options = new();
+
+        // Assert
+        options.Fields.ShouldBe(HttpLoggingFields.Default);
+        (options.Fields & HttpLoggingFields.RequestBody).ShouldBe(HttpLoggingFields.None);
+        (options.Fields & HttpLoggingFields.ResponseBody).ShouldBe(HttpLoggingFields.None);
+        (options.Fields & HttpLoggingFields.RequestQuery).ShouldBe(HttpLoggingFields.None);
+        (options.Fields & HttpLoggingFields.RequestHeaders).ShouldNotBe(HttpLoggingFields.None);
+        (options.Fields & HttpLoggingFields.Duration).ShouldNotBe(HttpLoggingFields.None);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Snapshot: Should reject a LogLevel.None level")]
+    public void Snapshot_LevelNone_ShouldThrow()
+    {
+        // Arrange
+        HttpLoggingOptions options = new() { Level = LogLevel.None };
+
+        // Act + Assert
+        Should.Throw<ArgumentException>(() => HttpLoggingSnapshot.Create(options));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Snapshot: Should reject invalid textual and numeric options")]
+    public void Snapshot_InvalidOptions_ShouldThrow()
+    {
+        Should.Throw<ArgumentException>(() => HttpLoggingSnapshot.Create(new HttpLoggingOptions { Category = "" }));
+        Should.Throw<ArgumentException>(() => HttpLoggingSnapshot.Create(new HttpLoggingOptions { RedactedValue = "" }));
+        Should.Throw<ArgumentOutOfRangeException>(() => HttpLoggingSnapshot.Create(new HttpLoggingOptions { RequestBodyLimit = -1 }));
+        Should.Throw<ArgumentOutOfRangeException>(() => HttpLoggingSnapshot.Create(new HttpLoggingOptions { ResponseBodyLimit = -1 }));
+        Should.Throw<ArgumentNullException>(() => HttpLoggingSnapshot.Create(new HttpLoggingOptions { TimeProvider = null! }));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - Snapshot: Mutating options after freezing has no effect")]
+    public void Snapshot_ShouldFreezeOptionValues()
+    {
+        // Arrange
+        HttpLoggingOptions options = new();
+        HttpLoggingSnapshot snapshot = HttpLoggingSnapshot.Create(options);
+
+        // Act — mutations after composition must be invisible.
+        options.AllowedRequestHeaders.Add(HttpHeaderKey.Authorization);
+        options.RedactedValue = "changed";
+
+        // Assert
+        snapshot.AllowedRequestHeaders.Contains(HttpHeaderKey.Authorization).ShouldBeFalse();
+        snapshot.RedactedValue.ShouldBe("[Redacted]");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.Diagnostics] - Snapshot: Body content-type gate matches prefixes and structured-syntax suffixes")]
+    [InlineData("application/json", true)]
+    [InlineData("application/json; charset=utf-8", true)]
+    [InlineData("APPLICATION/JSON", true)]
+    [InlineData("application/problem+json", true)]
+    [InlineData("application/soap+xml; action=\"x\"", true)]
+    [InlineData("text/plain", true)]
+    [InlineData("text/html; charset=utf-8", true)]
+    [InlineData("application/x-www-form-urlencoded", true)]
+    [InlineData("application/octet-stream", false)]
+    [InlineData("image/png", false)]
+    [InlineData("", false)]
+    public void Snapshot_BodyContentTypeGate_ShouldMatchExpectations(string contentType, bool expected)
+    {
+        // Arrange
+        HttpLoggingSnapshot snapshot = HttpLoggingSnapshot.Create(new HttpLoggingOptions());
+
+        // Act + Assert
+        snapshot.IsBodyContentTypeLoggable(contentType).ShouldBe(expected);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/TestObjects/RecordingLoggerProvider.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/TestObjects/RecordingLoggerProvider.cs
@@ -1,0 +1,61 @@
+using System.Collections.Concurrent;
+
+using Assimalign.Cohesion.Logging;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests.TestObjects;
+
+/// <summary>
+/// In-memory logger provider that records every entry it receives, in arrival order. The tests
+/// register it on a real <see cref="LoggerFactoryBuilder"/> so entries flow the same composite
+/// (and scope-stamping) path they would in an application.
+/// </summary>
+internal sealed class RecordingLoggerProvider : LoggerProvider
+{
+    private readonly ConcurrentQueue<ILoggerEntry> _entries = new();
+
+    public override string Name => "Recording";
+
+    public IReadOnlyList<ILoggerEntry> Entries => [.. _entries];
+
+    protected override Logger CreateCore(string category) => new RecordingLogger(category, this);
+
+    private void Record(ILoggerEntry entry) => _entries.Enqueue(entry);
+
+    private sealed class RecordingLogger : Logger
+    {
+        private readonly RecordingLoggerProvider _provider;
+
+        public RecordingLogger(string category, RecordingLoggerProvider provider)
+            : base(category)
+        {
+            _provider = provider;
+        }
+
+        protected override void WriteCore(ILoggerEntry entry) => _provider.Record(entry);
+
+        protected override IScopedLogger BeginScopeCore(ILoggerEntry entry)
+        {
+            _provider.Record(entry);
+            return new RecordingScopedLogger(Category, _provider, entry.Id);
+        }
+    }
+
+    private sealed class RecordingScopedLogger : ScopedLogger
+    {
+        private readonly RecordingLoggerProvider _provider;
+
+        public RecordingScopedLogger(string category, RecordingLoggerProvider provider, LogId parentId)
+            : base(category, parentId)
+        {
+            _provider = provider;
+        }
+
+        protected override void WriteCore(ILoggerEntry entry) => _provider.Record(entry);
+
+        protected override IScopedLogger BeginScopeCore(ILoggerEntry entry)
+        {
+            _provider.Record(entry);
+            return new RecordingScopedLogger(Category, _provider, entry.Id);
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/TraceParentTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/TraceParentTests.cs
@@ -1,0 +1,50 @@
+using Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Shouldly;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests;
+
+/// <summary>
+/// Covers the span-based <c>traceparent</c> parser used for the OpenTelemetry correlation
+/// boundary (trace/span ids as attributes; no OTel dependency).
+/// </summary>
+public class TraceParentTests
+{
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - TraceParent: Should parse a valid header")]
+    public void TryParse_ValidHeader_ShouldExtractIds()
+    {
+        // Act
+        bool parsed = TraceParent.TryParse("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", out string traceId, out string spanId);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        traceId.ShouldBe("0af7651916cd43dd8448eb211c80319c");
+        spanId.ShouldBe("b7ad6b7169203331");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - TraceParent: Should accept future versions with trailing fields")]
+    public void TryParse_FutureVersionWithSuffix_ShouldExtractIds()
+    {
+        // Act — later trace-context versions may append '-' separated fields.
+        bool parsed = TraceParent.TryParse("01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra", out string traceId, out _);
+
+        // Assert
+        parsed.ShouldBeTrue();
+        traceId.ShouldBe("0af7651916cd43dd8448eb211c80319c");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.Diagnostics] - TraceParent: Should reject malformed headers")]
+    [InlineData("")]
+    [InlineData("nonsense")]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331")]                      // too short
+    [InlineData("ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")]                   // forbidden version
+    [InlineData("00-00000000000000000000000000000000-b7ad6b7169203331-01")]                   // all-zero trace id
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01")]                   // all-zero span id
+    [InlineData("00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01")]                   // uppercase hex
+    [InlineData("00_0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")]                   // wrong separator
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01x")]                  // suffix without separator
+    public void TryParse_MalformedHeader_ShouldReturnFalse(string value)
+    {
+        TraceParent.TryParse(value, out _, out _).ShouldBeFalse();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/W3CAccessLogFormatterTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/W3CAccessLogFormatterTests.cs
@@ -1,0 +1,141 @@
+using System.Text;
+
+using Assimalign.Cohesion.Logging;
+using Assimalign.Cohesion.Web.Diagnostics.Internal;
+
+using Shouldly;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests;
+
+/// <summary>
+/// Exact-output coverage for the access-log line renderer: W3C extended and NCSA
+/// common/combined shapes, absent-value dashes, space encoding, and log-injection
+/// sanitization.
+/// </summary>
+public class W3CAccessLogFormatterTests
+{
+    private static readonly DateTimeOffset Timestamp = new(2026, 7, 11, 13, 45, 30, TimeSpan.Zero);
+
+    private static LoggerEntry CreateEntry(Action<Dictionary<string, object?>>? mutate = null)
+    {
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventExchange,
+            [HttpLoggingAttributes.ClientAddress] = "203.0.113.7",
+            [HttpLoggingAttributes.RequestMethod] = "GET",
+            [HttpLoggingAttributes.RequestPath] = "/orders/42",
+            [HttpLoggingAttributes.RequestQuery] = "page=2",
+            [HttpLoggingAttributes.ResponseStatusCode] = 200,
+            [HttpLoggingAttributes.ResponseBodyBytes] = 1234L,
+            [HttpLoggingAttributes.Duration] = 123.456d,
+            [HttpLoggingAttributes.RequestProtocol] = "HTTP/1.1",
+            [HttpLoggingAttributes.RequestHost] = "example.test",
+            ["http.request.header.user-agent"] = "Unit Agent/1.0",
+            ["http.request.header.referer"] = "https://ref.example/",
+        };
+
+        mutate?.Invoke(attributes);
+
+        return new LoggerEntry(LogLevel.Information, "test", "msg", attributes: attributes, timestamp: Timestamp);
+    }
+
+    private static string Render(ILoggerEntry entry, AccessLogFormat format)
+    {
+        StringBuilder builder = new();
+        W3CAccessLogFormatter.AppendLine(builder, entry, format);
+        return builder.ToString();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: Extended line renders every field in declaration order")]
+    public void Extended_FullEntry_ShouldRenderExactLine()
+    {
+        // Act — cs-bytes is absent from the entry, so it renders '-'; the user agent's space
+        // becomes '+' per the extended-format convention.
+        string line = Render(CreateEntry(), AccessLogFormat.W3CExtended);
+
+        // Assert
+        line.ShouldBe("2026-07-11 13:45:30 203.0.113.7 GET /orders/42 page=2 200 - 1234 0.123 HTTP/1.1 example.test Unit+Agent/1.0 https://ref.example/\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: Absent attributes render as dashes")]
+    public void Extended_EmptyEntry_ShouldRenderDashes()
+    {
+        // Arrange
+        LoggerEntry entry = new(
+            LogLevel.Information,
+            "test",
+            "msg",
+            attributes: new Dictionary<string, object?> { [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventExchange },
+            timestamp: Timestamp);
+
+        // Act
+        string line = Render(entry, AccessLogFormat.W3CExtended);
+
+        // Assert
+        line.ShouldBe("2026-07-11 13:45:30 - - - - - - - - - - - -\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: Control characters are stripped from text fields")]
+    public void Extended_ControlCharacters_ShouldBeStripped()
+    {
+        // Arrange — a hostile user agent attempting to forge a second log line.
+        LoggerEntry entry = CreateEntry(attributes => attributes["http.request.header.user-agent"] = "evil\r\n2026-01-01 injected");
+
+        // Act
+        string line = Render(entry, AccessLogFormat.W3CExtended);
+
+        // Assert — the CR/LF never reach the file; the space is '+'-encoded.
+        line.ShouldNotContain("\r");
+        line.Count(c => c == '\n').ShouldBe(1);
+        line.ShouldContain("evil2026-01-01+injected", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: Directives declare version, software, date, and the field list")]
+    public void Directives_ShouldRenderHeaderBlock()
+    {
+        // Act
+        StringBuilder builder = new();
+        W3CAccessLogFormatter.AppendExtendedDirectives(builder, Timestamp);
+        string directives = builder.ToString();
+
+        // Assert
+        directives.ShouldBe(
+            "#Version: 1.0\n" +
+            "#Software: Assimalign.Cohesion.Web.Diagnostics\n" +
+            "#Date: 2026-07-11 13:45:30\n" +
+            "#Fields: date time c-ip cs-method cs-uri-stem cs-uri-query sc-status cs-bytes sc-bytes time-taken cs-version cs-host cs(User-Agent) cs(Referer)\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: NCSA common line renders host, UTC timestamp, request, status, and bytes")]
+    public void Common_FullEntry_ShouldRenderExactLine()
+    {
+        // Act
+        string line = Render(CreateEntry(), AccessLogFormat.Common);
+
+        // Assert
+        line.ShouldBe("203.0.113.7 - - [11/Jul/2026:13:45:30 +0000] \"GET /orders/42?page=2 HTTP/1.1\" 200 1234\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: NCSA combined line appends quoted referer and user agent")]
+    public void Combined_FullEntry_ShouldRenderExactLine()
+    {
+        // Act
+        string line = Render(CreateEntry(), AccessLogFormat.Combined);
+
+        // Assert — quoted fields keep their spaces (no '+' encoding in NCSA).
+        line.ShouldBe("203.0.113.7 - - [11/Jul/2026:13:45:30 +0000] \"GET /orders/42?page=2 HTTP/1.1\" 200 1234 \"https://ref.example/\" \"Unit Agent/1.0\"\n");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C formatter: NCSA quoted fields escape quotes and backslashes")]
+    public void Combined_QuotedField_ShouldEscapeDelimiters()
+    {
+        // Arrange
+        LoggerEntry entry = CreateEntry(attributes => attributes["http.request.header.user-agent"] = "agent \"quoted\" \\ tail");
+
+        // Act
+        string line = Render(entry, AccessLogFormat.Combined);
+
+        // Assert
+        line.ShouldContain("\"agent \\\"quoted\\\" \\\\ tail\"", Case.Sensitive);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/W3CAccessLogProviderTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Diagnostics/tests/W3CAccessLogProviderTests.cs
@@ -1,0 +1,226 @@
+using Assimalign.Cohesion.Logging;
+
+using Shouldly;
+
+namespace Assimalign.Cohesion.Web.Diagnostics.Tests;
+
+/// <summary>
+/// File-behavior coverage for <see cref="W3CAccessLogProvider"/>: directive blocks, day and
+/// size rolling, retention sweeps, exchange-entry filtering, and flush semantics.
+/// </summary>
+public class W3CAccessLogProviderTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "cohesion-w3c-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_directory))
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; leaked temp directories are harmless.
+        }
+    }
+
+    /// <summary>
+    /// Reads a log file the provider may still hold open for writing: the writer opens with
+    /// <see cref="FileShare.Read"/>, so readers must share write access.
+    /// </summary>
+    private static string ReadLogFile(string path)
+    {
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using StreamReader reader = new(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static LoggerEntry CreateExchangeEntry(DateTimeOffset timestamp, string path = "/orders", int status = 200)
+        => new(
+            LogLevel.Information,
+            "access",
+            "msg",
+            attributes: new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventExchange,
+                [HttpLoggingAttributes.RequestMethod] = "GET",
+                [HttpLoggingAttributes.RequestPath] = path,
+                [HttpLoggingAttributes.ResponseStatusCode] = status,
+            },
+            timestamp: timestamp);
+
+    private W3CAccessLogOptions CreateOptions(Action<W3CAccessLogOptions>? mutate = null)
+    {
+        W3CAccessLogOptions options = new()
+        {
+            Directory = _directory,
+            FlushInterval = TimeSpan.Zero,
+        };
+        mutate?.Invoke(options);
+        return options;
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Writes the directive block and one line per exchange")]
+    public void Write_ExchangeEntry_ShouldProduceDirectivesAndLine()
+    {
+        // Arrange
+        using W3CAccessLogProvider provider = new(CreateOptions());
+        ILogger logger = ((ILoggerProvider)provider).Create("access");
+
+        // Act
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 11, 8, 0, 0, TimeSpan.Zero)));
+
+        // Assert
+        string file = Path.Combine(_directory, "access-20260711.log");
+        File.Exists(file).ShouldBeTrue();
+
+        string content = ReadLogFile(file);
+        content.ShouldStartWith("#Version: 1.0\n");
+        content.ShouldContain("#Fields: date time c-ip cs-method", Case.Sensitive);
+        content.ShouldContain("2026-07-11 08:00:00 - GET /orders - 200", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Ignores entries that are not completed exchanges")]
+    public void Write_NonExchangeEntries_ShouldBeIgnored()
+    {
+        // Arrange
+        using W3CAccessLogProvider provider = new(CreateOptions());
+        ILogger logger = ((ILoggerProvider)provider).Create("app");
+
+        // Act — plain application logging and a request-start entry share the factory.
+        logger.Log(new LoggerEntry(LogLevel.Information, "app", "application message"));
+        logger.Log(new LoggerEntry(
+            LogLevel.Information,
+            "access",
+            "start",
+            attributes: new Dictionary<string, object?> { [HttpLoggingAttributes.Event] = HttpLoggingAttributes.EventStart }));
+
+        // Assert — no exchange, no file.
+        Directory.Exists(_directory).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Rolls to a new file when the UTC day changes")]
+    public void Write_AcrossUtcDays_ShouldRollFiles()
+    {
+        // Arrange
+        using W3CAccessLogProvider provider = new(CreateOptions());
+        ILogger logger = ((ILoggerProvider)provider).Create("access");
+
+        // Act
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 11, 23, 59, 59, TimeSpan.Zero)));
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 12, 0, 0, 1, TimeSpan.Zero)));
+
+        // Assert
+        File.Exists(Path.Combine(_directory, "access-20260711.log")).ShouldBeTrue();
+        File.Exists(Path.Combine(_directory, "access-20260712.log")).ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Rolls to a sequenced file when the size limit is exceeded")]
+    public void Write_OverSizeLimit_ShouldRollToSequencedFile()
+    {
+        // Arrange — the limit is far below one directive block, so every entry rolls.
+        using W3CAccessLogProvider provider = new(CreateOptions(options => options.FileSizeLimit = 16));
+        ILogger logger = ((ILoggerProvider)provider).Create("access");
+        DateTimeOffset timestamp = new(2026, 7, 11, 8, 0, 0, TimeSpan.Zero);
+
+        // Act
+        logger.Log(CreateExchangeEntry(timestamp, "/first"));
+        logger.Log(CreateExchangeEntry(timestamp, "/second"));
+
+        // Assert
+        ReadLogFile(Path.Combine(_directory, "access-20260711.log")).ShouldContain("/first", Case.Sensitive);
+        ReadLogFile(Path.Combine(_directory, "access-20260711.001.log")).ShouldContain("/second", Case.Sensitive);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Deletes the oldest files beyond the retention limit")]
+    public void Write_BeyondRetention_ShouldDeleteOldestFiles()
+    {
+        // Arrange
+        using W3CAccessLogProvider provider = new(CreateOptions(options => options.RetainedFileCountLimit = 2));
+        ILogger logger = ((ILoggerProvider)provider).Create("access");
+
+        // Act — three UTC days; the roll to day three sweeps day one away.
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero)));
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 11, 12, 0, 0, TimeSpan.Zero)));
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 12, 12, 0, 0, TimeSpan.Zero)));
+
+        // Assert
+        File.Exists(Path.Combine(_directory, "access-20260710.log")).ShouldBeFalse();
+        File.Exists(Path.Combine(_directory, "access-20260711.log")).ShouldBeTrue();
+        File.Exists(Path.Combine(_directory, "access-20260712.log")).ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Buffered output reaches disk on Flush and on dispose")]
+    public void Write_Buffered_ShouldFlushOnDemandAndOnDispose()
+    {
+        // Arrange — a flush interval long enough that only explicit flushes matter.
+        string file = Path.Combine(_directory, "access-20260711.log");
+        W3CAccessLogProvider provider = new(CreateOptions(options => options.FlushInterval = TimeSpan.FromHours(1)));
+
+        try
+        {
+            ILogger logger = ((ILoggerProvider)provider).Create("access");
+            DateTimeOffset timestamp = new(2026, 7, 11, 8, 0, 0, TimeSpan.Zero);
+
+            // Act + Assert — buffered: the first line may not be on disk yet.
+            logger.Log(CreateExchangeEntry(timestamp, "/buffered"));
+            provider.Flush();
+            ReadLogFile(file).ShouldContain("/buffered", Case.Sensitive);
+
+            logger.Log(CreateExchangeEntry(timestamp, "/on-dispose"));
+            provider.Dispose();
+            ReadLogFile(file).ShouldContain("/on-dispose", Case.Sensitive);
+        }
+        finally
+        {
+            provider.Dispose();
+        }
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: NCSA formats write bare lines without directives")]
+    public void Write_CommonFormat_ShouldNotWriteDirectives()
+    {
+        // Arrange
+        using W3CAccessLogProvider provider = new(CreateOptions(options => options.Format = AccessLogFormat.Common));
+        ILogger logger = ((ILoggerProvider)provider).Create("access");
+
+        // Act
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 11, 8, 0, 0, TimeSpan.Zero)));
+
+        // Assert
+        string content = ReadLogFile(Path.Combine(_directory, "access-20260711.log"));
+        content.ShouldNotContain("#Version");
+        content.ShouldStartWith("- - - [11/Jul/2026:08:00:00 +0000] \"GET /orders -\" 200 -");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Constructor rejects invalid options")]
+    public void Constructor_InvalidOptions_ShouldThrow()
+    {
+        Should.Throw<ArgumentNullException>(() => new W3CAccessLogProvider(null!));
+        Should.Throw<ArgumentException>(() => new W3CAccessLogProvider(new W3CAccessLogOptions()));
+        Should.Throw<ArgumentException>(() => new W3CAccessLogProvider(CreateOptions(options => options.FileNamePrefix = "")));
+        Should.Throw<ArgumentException>(() => new W3CAccessLogProvider(CreateOptions(options => options.FileNamePrefix = "pre/fix")));
+        Should.Throw<ArgumentException>(() => new W3CAccessLogProvider(CreateOptions(options => options.Format = (AccessLogFormat)99)));
+        Should.Throw<ArgumentOutOfRangeException>(() => new W3CAccessLogProvider(CreateOptions(options => options.FileSizeLimit = 0)));
+        Should.Throw<ArgumentOutOfRangeException>(() => new W3CAccessLogProvider(CreateOptions(options => options.RetainedFileCountLimit = 0)));
+        Should.Throw<ArgumentOutOfRangeException>(() => new W3CAccessLogProvider(CreateOptions(options => options.FlushInterval = TimeSpan.FromSeconds(-1))));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Diagnostics] - W3C provider: Registers on a logger factory like any other provider")]
+    public void Provider_OnLoggerFactory_ShouldReceiveFanOut()
+    {
+        // Arrange — the provider is an ordinary member of the logging pipeline.
+        using W3CAccessLogProvider provider = new(CreateOptions());
+        using ILoggerFactory factory = new LoggerFactoryBuilder().AddProvider(provider).Build();
+        ILogger logger = factory.Create("access");
+
+        // Act
+        logger.Log(CreateExchangeEntry(new DateTimeOffset(2026, 7, 11, 9, 30, 0, TimeSpan.Zero), "/via-factory"));
+
+        // Assert
+        ReadLogFile(Path.Combine(_directory, "access-20260711.log")).ShouldContain("/via-factory", Case.Sensitive);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.slnx
+++ b/resources/Web/Assimalign.Cohesion.Web.slnx
@@ -98,6 +98,17 @@
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Cors/tests/">
 		<Project Path="Assimalign.Cohesion.Web.Cors/tests/Assimalign.Cohesion.Web.Cors.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Diagnostics/" />
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Diagnostics/docs/">
+		<File Path="Assimalign.Cohesion.Web.Diagnostics/docs/DESIGN.md" />
+		<File Path="Assimalign.Cohesion.Web.Diagnostics/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Diagnostics/src/">
+		<Project Path="Assimalign.Cohesion.Web.Diagnostics/src/Assimalign.Cohesion.Web.Diagnostics.csproj" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Diagnostics/tests/">
+		<Project Path="Assimalign.Cohesion.Web.Diagnostics/tests/Assimalign.Cohesion.Web.Diagnostics.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Forms/" />
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Forms/docs/">
 		<File Path="Assimalign.Cohesion.Web.Forms/docs/DESIGN.md" />

--- a/resources/Web/README.md
+++ b/resources/Web/README.md
@@ -76,6 +76,7 @@ A new `Assimalign.Cohesion.Web.<Feature>` project is not done until all of these
 | `Assimalign.Cohesion.Web.ForwardedHeaders` | First-position forwarded-headers middleware (`UseForwardedHeaders`): proxy trust model over the core `Http` parsing primitives, publishing the `Http.Forwarded` effective-identity feature |
 | `Assimalign.Cohesion.Web.CookiePolicy` / `.Cors` / `.Forms` / `.Sessions` / `.Health` | Request-pipeline feature libraries over their `Http.*` counterparts |
 | `Assimalign.Cohesion.Web.StaticFiles` | Static file serving over an `IFileSystem` mount: conditional GET, single byte ranges, default documents, content-type mapping, precompressed `.br`/`.gz` negotiation |
+| `Assimalign.Cohesion.Web.Diagnostics` | HTTP request/response logging middleware (field flags, allowlist redaction, bounded body capture) + the W3C/NCSA access-log file provider riding `Assimalign.Cohesion.Logging` |
 | `Assimalign.Cohesion.Web.Testing` | In-memory test factory for the runtime (sanctioned Web.Hosting reference) |
 | `Assimalign.Cohesion.Web.ApplicationModel` | Placeholder awaiting the ApplicationModel Phase-4 rebuild |
 


### PR DESCRIPTION
## Summary

Builds `resources/Web/Assimalign.Cohesion.Web.Diagnostics` (#794, Stage 2 · Lane E): HTTP request/response logging and W3C access logs as **one** middleware-first diagnostics package — no ASP.NET-style micro-packages — with emission riding the repo's own `Assimalign.Cohesion.Logging` pipeline (providers/enrichers/filters), not a parallel path.

- **`UseHttpLogging(ILogger | ILoggerFactory, Action<HttpLoggingOptions>?)`** — the composed logger is handed in at builder time (the `MapHealthChecks` precedent; no request-time service location, no DI). Options validate and freeze into an immutable snapshot at `Use` time; mutations after composition are invisible by design.
- **Field flags (`HttpLoggingFields`)**: request line, headers, opt-in bounded bodies, status, duration, client address, byte counts, trace context. `Default` deliberately excludes **bodies and the query string** (they routinely carry secrets); `None` suppresses the entry entirely.
- **Allowlist-based redaction (fails closed)**: header *names* always log; *values* log only when the header is in `AllowedRequestHeaders`/`AllowedResponseHeaders`. `Authorization`, `Proxy-Authorization`, `Cookie`, and `Set-Cookie` are never in the defaults — asserted E2E.
- **Bounded body capture that cannot fight the transport**: tee-wrappers copy the first N bytes as the body streams through — no full-body buffering, so h2 flow-control backpressure (#750), h1 data-rate gates (#810), and request-size limits (#764/#818) are untouched. Request-side interposition type-tests the settable-`Body` `HttpRequest` base (every transport derives from it) and degrades gracefully; response capture defers its content-type gate to the first write (the response head doesn't exist earlier).
- **Per-endpoint overrides via the merged #150 metadata bag, where cheap**: a sealed `HttpLoggingMetadata` carrier (per the metadata-carrier discipline — no interface) read **after** `next` completes, when routing has installed `IRouteMatchFeature` — one last-wins lookup, effectively free. Emission-time fields widen/narrow freely; capture fields can only narrow (streams are armed before routing runs — documented). `HttpLoggingFields.None` is the health-probe silencer.
- **`W3CAccessLogProvider`** — a real `LoggerProvider` registered on `LoggerFactoryBuilder` beside console/debug: W3C Extended (`#Version`/`#Fields` directives, `-` absents, `+` space encoding) plus NCSA common/combined; buffered lock-serialized writes with timer flush; UTC-day files with size-based sequence rolling and oldest-first retention; renders **only** entries stamped `http.event = "exchange"`, so co-registration with application logging is safe. Rolling keys off entry timestamps → deterministic under a fake `TimeProvider`.
- **The middleware↔provider contract is the stable attribute names in `HttpLoggingAttributes`** (`http.request.method`, `http.response.status`, `http.duration`, …), OTel-semconv-aligned with zero OTel dependency — the #583/#317 correlation boundary. Inbound `traceparent` is span-parsed into `trace.id`/`span.id`; optional `LogRequestStart` correlates start→completion via the Logging library's own `IScopedLogger`/`ParentId` mechanism.
- **Effective client IP**: #778 (forwarded middleware) has not merged, so the default logs the socket peer (`ConnectionInfo.RemoteIp`) and **`HttpLoggingOptions.ClientAddressResolver` is the documented seam** the forwarded feature plugs into. The middleware never trusts `X-Forwarded-For` on its own.
- **AOT-safe, zero reflection**: flags enum + `is`-test metadata discovery + `FrozenSet<HttpHeaderKey>` allowlists + invariant `TryFormat` span rendering; control characters are stripped and NCSA quotes escaped at the text boundary (log-injection defense).
- **Faults**: the entry escalates to `Error` with the exception attached and `(faulted)` in the message, then rethrows — observing is this package's job; the exception *boundary* stays #881's. The emit path can never fail an exchange.

## Verification

| Suite | Result |
| --- | --- |
| Web.Diagnostics tests (unit + Web.Testing factory E2E) | 56/56 |
| E2E redaction (Authorization/Cookie/X-Api-Key/Set-Cookie values never appear; secret sweep over all attributes + the W3C file) | ✅ |
| `resources/Web/Assimalign.Cohesion.Web.slnx` full build (COHRES001/002 guards) | 0 errors |
| `dotnet pack` App.Web.Runtime (manifest hard-fail validation) | ✅ pack succeeds |

Wiring per `web-area.md`: App.Web ItemGroup in `frameworks/Assimalign.Cohesion.App.props` (no new outside-area transitives — Logging/Routing already delivered), `resource-web.yml` CI matrix, Web + root slnx, `resources/Web/README.md` project-map row, `docs/OVERVIEW.md` + `docs/DESIGN.md`. Sibling Batch-4a sessions touch the same App.props/CI lines — trivial rebase expected.

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
