### PR TITLE
feat(web.staticfiles): static file serving over the FileSystem library [L03.01.01.06]

### DIFF
--- a/.github/workflows/resource-web.yml
+++ b/.github/workflows/resource-web.yml
@@ -34,6 +34,7 @@ jobs:
             'Assimalign.Cohesion.Web.ProblemDetails',
             'Assimalign.Cohesion.Web.Routing',
             'Assimalign.Cohesion.Web.Sessions',
+            'Assimalign.Cohesion.Web.StaticFiles',
             'Assimalign.Cohesion.Web.Testing'
         ]
     steps:

--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -2088,6 +2088,17 @@
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Sessions/tests/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.Sessions/tests/Assimalign.Cohesion.Web.Sessions.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.StaticFiles/" />
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md" />
+		<File Path="resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Assimalign.Cohesion.Web.StaticFiles.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/Assimalign.Cohesion.Web.StaticFiles.Tests.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Testing/">
 		<File Path="resources/Web/Assimalign.Cohesion.Web.Testing/README.md" />
 	</Folder>

--- a/frameworks/Assimalign.Cohesion.App.props
+++ b/frameworks/Assimalign.Cohesion.App.props
@@ -166,6 +166,7 @@
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.ProblemDetails" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Routing" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Sessions" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.StaticFiles" />
 
         <!-- Supporting libraries the Web family closes over that the base App
              framework does not carry (computed transitive closure). -->

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md
@@ -1,0 +1,134 @@
+# Assimalign.Cohesion.Web.StaticFiles — Design
+
+## Design intent
+
+Serve files from a mounted `IFileSystem` as a single middleware-first feature package: one
+`UseStaticFiles` verb on `IWebApplicationPipelineBuilder`, one internal
+`IWebApplicationMiddleware` that writes responses imperatively, and zero request-time
+composition. The package is deliberately a *composer of protocol primitives* — conditional
+requests, range selection, content negotiation, and content-type mapping all come from
+`Assimalign.Cohesion.Http` (`HttpConditionalRequest`, `HttpRangeSelector`, `HttpIfRange`,
+`HttpContentNegotiation`, `HttpContentTypes`), so RFC semantics live in one tested place and
+this middleware only sequences them.
+
+Unlike ASP.NET's per-concern packaging (StaticFiles + DefaultFiles + DirectoryBrowser as
+separate middlewares that must be ordered correctly), one package covers file serving,
+default documents, and precompressed-asset negotiation — the Cohesion lean-dependency-tree
+rule applied to a feature family that always ships together.
+
+## Why-this-not-that decisions
+
+- **`IFileSystem` as the content root, not a bespoke file-provider seam.** The FileSystem
+  library already models mounts (physical, in-memory, aggregate, isolated-storage) with a
+  richer surface than ASP.NET's `IFileProvider`, and the mount boundary doubles as the
+  security boundary: the middleware cannot express a lookup outside the mounted root.
+- **Middleware-first, no result types.** The 2026-07-10 direction withdrew `IResult`; this
+  package writes status, headers, and body directly on `IHttpResponse`. The `#864` edge
+  (serializer registry / `OnError`) was dropped from this item accordingly — errors here are
+  protocol outcomes (`304`/`404`/`412`/`416`), not application faults.
+- **Reject hostile paths with `404`, don't pass them along.** Under the mount prefix, a path
+  containing dot segments (or `:`/NUL) is answered `404` directly rather than forwarded to
+  downstream middleware. Forwarding would hand a hostile path to whatever handler comes next;
+  answering is the honest owner behavior for URL space the mount claims. Outside-the-claim
+  misses (plain not-found, unmapped extensions, bare directories) *do* pass through — those
+  are legitimately someone else's URLs.
+- **Two-layer traversal defense.** Layer 1 is an explicit gate (`StaticFilePath.
+  HasUnsafeSegments`) over the decoded path: any `.`/`..` segment — split on both `/` and
+  `\`, since `FileSystemPath` treats backslash as a separator — plus `:` (Windows drive/ADS
+  shapes) and NUL. Layer 2 is `FileSystemPath.Parse` itself, which throws on interior dot
+  segments and illegal characters; the gate runs first so hostile requests get a
+  deterministic `404` instead of exception-driven flow. Non-canonical-but-safe forms
+  (`/./x`) are also rejected rather than normalized — Cohesion transports do not collapse
+  dot segments, and a static server has no business inventing URL equivalences.
+- **Directory detection by info type, not `FileAttributes`.** Not every mount stamps
+  `FileAttributes.Directory` (InMemory leaves attributes unset); every mount returns an
+  `IFileSystemDirectory`-typed info. Type tests are the portable signal.
+- **Strong ETag from `Size` + `UpdatedOn` (hex ticks-dash-length).** Cheap (no content
+  hashing), stable per representation, and distinct across representations — a precompressed
+  sibling naturally carries different size/mtime, satisfying the RFC 9110 rule that distinct
+  encodings must not share a strong validator. Timestamps are normalized to UTC and
+  truncated to whole seconds *for comparisons and emission* (HTTP-date resolution), while
+  the ETag uses full-resolution ticks for discrimination.
+- **Preconditions evaluate against the *negotiated* representation.** Sibling selection runs
+  before validator derivation, so `If-None-Match`/`If-Range` compare against the validators
+  of the representation that would actually be served — and a `Range` applies to the encoded
+  bytes (RFC 9110 §14.2: ranges address the selected representation).
+- **Single-range only; multi-range falls back to full `200`.** `multipart/byteranges`
+  assembly is complexity with almost no modern client demand; the RFC permits serving the
+  full representation instead. `HttpRangeSelector`'s DoS guard (16-range cap → full) rides
+  along for free.
+- **`Vary: Accept-Encoding` whenever a sibling exists** — including on identity responses
+  and `304`s. The URL's response varies the moment a sibling is on disk, regardless of what
+  this particular client received; caches must know. No siblings → no `Vary`.
+- **Identity fallback instead of `406`.** When negotiation reports even identity refused
+  (`identity;q=0` with no acceptable coding), the middleware serves identity anyway: for
+  cacheable static assets a spec-permitted `406` punishes misconfigured clients for no
+  operational gain.
+- **Slash-less directory URLs redirect (`301`) before serving a default document.** Serving
+  directory content at `/docs` would break every relative link inside the document;
+  canonicalizing to `/docs/` first is the correctness move. The query string is preserved by
+  re-encoding the parsed pairs (semantic, not byte-for-byte, fidelity — an accepted trade
+  since the raw query text is not surfaced by `IHttpRequest`).
+- **Unknown extensions blocked by default.** Serving unmapped types as `octet-stream` invites
+  accidental exposure (config files, dotfiles); the default passes them through so the
+  application decides. `ServeUnknownContentTypes` + `FallbackContentType` opt in explicitly.
+- **Open the stream only after all no-body outcomes are resolved.** `304`/`412`/`416` never
+  touch the file; a file that vanishes between resolution and open yields a clean `404`
+  because nothing has been committed to the response yet.
+
+## Request flow
+
+```
+GET/HEAD?  ──no──▶ next
+prefix match (segment-aligned, ordinal)? ──no──▶ next
+h1 percent-decode compensation (see below)
+unsafe segments (../.\:/NUL)? ──yes──▶ 404 (terminal)
+FileSystemPath.Parse  ──throws──▶ 404
+resolve: file | directory(+default doc | 301 append-slash) | miss ──▶ next
+content type (overlay map; unknown → next unless opted in)
+negotiate precompressed sibling (.br/.gz, server prefers br) → validators
+preconditions (RFC 9110 §13.2.2) ──▶ 304 | 412
+range (GET only; If-Range gate) ──▶ 416 | single 206 | full 200
+open stream → head (Content-*, ETag, Last-Modified, Accept-Ranges, Cache-Control, Vary) → body (GET)
+```
+
+## HTTP/1.1 percent-decode parity (known transport gap)
+
+The h2/h3 transports percent-decode the request path before middleware sees it
+(`HttpPath.FromUriComponent`), but the HTTP/1.1 reader currently surfaces the raw
+request-target text (`HttpRequestTarget` does no decoding). Undefended, `%2e%2e` would read
+as a literal segment name on h1 and as `..` on h2 — the classic encoded-traversal split.
+The middleware compensates: when `Version == Http11` and the path contains `%`, it decodes
+once (`Uri.UnescapeDataString`) before prefix matching and the traversal gate, so every
+transport funnels the same text through the same defense. This also makes encoded *legit*
+names (`my%20file.txt`) resolve on h1.
+
+This is a deliberate, removable wart: the right fix is decode parity in the h1 transport,
+filed as a follow-up work item — **remove this compensation in the same change** or h1 paths
+would double-decode.
+
+## AOT posture
+
+No reflection anywhere: the content-type table is a `FrozenDictionary` built at composition
+time, negotiation and precondition evaluation are static pure functions over value types,
+and body copies use `ArrayPool<byte>` buffers. The package inherits `IsAotCompatible=true`.
+
+## Error model
+
+No package-specific exception types. `FileSystemException` from mount lookups is absorbed
+into not-found/pass-through semantics; `ArgumentException` from `UseStaticFiles` validation
+(bad prefix, bad default-document name, unparseable `Cache-Control`, missing fallback type)
+surfaces at composition time. A file that shrinks mid-range-copy aborts the response with
+`EndOfStreamException` rather than silently serving wrong bytes (matching the h2
+truncated-body abort posture).
+
+## Non-goals
+
+- **Directory browsing** — deferred follow-up (explicitly out of #777's scope).
+- **Fingerprinted asset manifests** — deferred behind endpoint routing (#28).
+- **On-the-fly compression** — that is `Web.Compression`'s job (#779); this package only
+  selects pre-existing sibling files.
+- **`multipart/byteranges`** — multi-range sets serve the full representation.
+- **Windows short-name (8.3) / trailing-dot equivalence defense** — the mount confines every
+  lookup, so such OS-level aliasing cannot escape the root; serve dedicated mounts rather
+  than pointing a physical mount at a directory whose *siblings* are sensitive.

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/OVERVIEW.md
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/OVERVIEW.md
@@ -1,0 +1,64 @@
+# Assimalign.Cohesion.Web.StaticFiles — Overview
+
+Static file serving for the Cohesion Web pipeline, built over the `libraries/FileSystem`
+abstractions. One feature package covers file serving, default documents, conditional GET,
+single byte-range responses, content-type mapping, and precompressed (`.br`/`.gz`) sibling
+negotiation — composed from the shared `Assimalign.Cohesion.Http` protocol primitives rather
+than re-deriving any RFC semantics locally.
+
+## Scope
+
+- **Content root = an `IFileSystem` mount.** Any implementation works: `PhysicalFileSystem`,
+  `InMemoryFileSystem`, `AggregateFileSystem` composites. The middleware can never address
+  anything outside the mount — path-traversal defense is a hard guarantee, not an option.
+- **`GET`/`HEAD` only.** Everything else passes through to the next middleware.
+- **Builder-time composition only.** The file system and every option are supplied at
+  `UseStaticFiles(...)` and frozen into the middleware; there is no service container, no
+  configuration binding, and no request-time service location (the Web-area rule).
+
+## Usage
+
+```csharp
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Web.StaticFiles;
+
+var contentRoot = new PhysicalFileSystem(new PhysicalFileSystemOptions { /* root */ });
+
+app.UseStaticFiles(contentRoot, options =>
+{
+    options.RequestPath = new HttpPath("/static");     // mount prefix (default "/")
+    options.CacheControl = "public, max-age=3600";     // emitted on every served response
+    options.DefaultDocuments.Add("default.html");      // probed after index.html/index.htm
+    options.ContentTypeMappings[".gltf"] = "model/gltf+json";
+    options.ServeUnknownContentTypes = false;          // default: unmapped extensions pass through
+    options.ServePrecompressedAssets = true;           // default: .br/.gz siblings negotiate
+});
+```
+
+## What a served response carries
+
+| Concern | Behavior |
+|---|---|
+| Validators | Strong `ETag` derived from `Size` + `UpdatedOn`; `Last-Modified` (HTTP-date). |
+| Conditional GET | `If-None-Match` / `If-Modified-Since` → `304`; `If-Match` / `If-Unmodified-Since` → `412` (RFC 9110 §13.2.2 via `HttpConditionalRequest`). |
+| Ranges | `Accept-Ranges: bytes`; single satisfiable byte range → `206` + `Content-Range`; multi-range set → full `200` fallback; unsatisfiable → `416` + `bytes */N` (via `HttpRangeSelector`); `If-Range` gates application. |
+| Content types | Extension lookup via `HttpContentTypes` with builder-time overlays; unmapped extensions pass through by default or serve the configured fallback type. |
+| Precompression | On-disk `name.ext.br` / `name.ext.gz` siblings negotiate against `Accept-Encoding` (server prefers `br`); served with the logical file's `Content-Type`, the sibling's bytes/length/validators, `Content-Encoding`, and `Vary: Accept-Encoding` (emitted whenever a sibling exists, including on identity responses). |
+| Default documents | Directory requests probe the configured names in order; a slash-less directory URL is `301`-redirected to its canonical slash form first. |
+| HEAD | Same header section as `GET` (including `Content-Length`), no body. |
+
+## Dependencies
+
+- `Assimalign.Cohesion.Web` — pipeline contracts (`IWebApplicationPipelineBuilder`,
+  `IWebApplicationMiddleware`).
+- `Assimalign.Cohesion.Http` — the protocol primitives listed above.
+- `Assimalign.Cohesion.FileSystem` — the content-root abstraction.
+
+Per the Web-area hosting-isolation rule this package never references `Web.Hosting`;
+applications receive it through the `App.Web` shared framework (`Sdk.Web`).
+
+## Deferred follow-ups
+
+Directory browsing and fingerprinted-asset manifests are deliberately out of scope (the
+latter waits on endpoint routing, #28). See `DESIGN.md` for the reasoning and for the
+HTTP/1.1 percent-decode parity note.

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Assimalign.Cohesion.Web.StaticFiles.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Assimalign.Cohesion.Web.StaticFiles.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Web.StaticFiles</RootNamespace>
+		<Description>Static file serving for the Cohesion Web pipeline over the FileSystem library. UseStaticFiles mounts any IFileSystem (physical, in-memory, aggregate) at a request-path prefix with builder-time options: default documents, Cache-Control, content-type overlays. Implements RFC 9110 conditional GET (ETag from Size+UpdatedOn, Last-Modified, If-None-Match/If-Modified-Since to 304), single byte-range 206/416 responses, HEAD, precompressed sibling (.br/.gz) negotiation with Content-Encoding + Vary, and hard path-traversal defense (requests can never escape the mounted root).</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.FileSystem" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Extensions/WebApplicationStaticFilesExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Extensions/WebApplicationStaticFilesExtensions.cs
@@ -1,0 +1,96 @@
+using System;
+
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.StaticFiles.Internal;
+
+namespace Assimalign.Cohesion.Web.StaticFiles;
+
+/// <summary>
+/// Pipeline-builder members that serve static files from a mounted <see cref="IFileSystem"/>.
+/// </summary>
+/// <remarks>
+/// Registration is dependency-free per the Web-area rules: the file system and options are
+/// supplied explicitly at composition time and snapshotted into the middleware — no service
+/// container, no configuration binding, no request-time service location. Mount any
+/// <see cref="IFileSystem"/> implementation (physical, in-memory, aggregate); the middleware
+/// can never address anything outside that mount.
+/// </remarks>
+public static class WebApplicationStaticFilesExtensions
+{
+    extension(IWebApplicationPipelineBuilder builder)
+    {
+        /// <summary>
+        /// Serves <c>GET</c>/<c>HEAD</c> requests from <paramref name="fileSystem"/> at the site
+        /// root with default options: default documents (<c>index.html</c>/<c>index.htm</c>),
+        /// conditional GET, single byte-range support, precompressed <c>.br</c>/<c>.gz</c>
+        /// sibling negotiation, and unknown extensions blocked.
+        /// </summary>
+        /// <param name="fileSystem">The file system to serve as the content root.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="fileSystem"/> is <see langword="null"/>.</exception>
+        public IWebApplicationPipelineBuilder UseStaticFiles(IFileSystem fileSystem)
+            => builder.UseStaticFiles(fileSystem, configure: null);
+
+        /// <summary>
+        /// Serves <c>GET</c>/<c>HEAD</c> requests from <paramref name="fileSystem"/> with
+        /// caller-configured <see cref="StaticFilesOptions"/> (request-path prefix, default
+        /// documents, <c>Cache-Control</c>, content-type overlays, precompression).
+        /// </summary>
+        /// <param name="fileSystem">The file system to serve as the content root.</param>
+        /// <param name="configure">A callback that configures the composition-time options.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="fileSystem"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the configured options are invalid: a request path that does not begin
+        /// with <c>/</c>, a default-document name that is empty or contains a path separator or
+        /// dot segment, a <c>Cache-Control</c> value that does not parse per RFC 9111, or an
+        /// empty fallback content type while <see cref="StaticFilesOptions.ServeUnknownContentTypes"/> is enabled.
+        /// </exception>
+        public IWebApplicationPipelineBuilder UseStaticFiles(IFileSystem fileSystem, Action<StaticFilesOptions>? configure)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(fileSystem);
+
+            var options = new StaticFilesOptions();
+            configure?.Invoke(options);
+            Validate(options);
+
+            return builder.Use(new StaticFilesMiddleware(fileSystem, options));
+        }
+    }
+
+    private static void Validate(StaticFilesOptions options)
+    {
+        // HttpPath also admits the "*" asterisk form; a mount prefix must be an origin-form path.
+        if (options.RequestPath.Value.Length == 0 || options.RequestPath.Value[0] != '/')
+        {
+            throw new ArgumentException(
+                $"The static-files request path must begin with '/': '{options.RequestPath.Value}'.");
+        }
+
+        foreach (string document in options.DefaultDocuments)
+        {
+            if (string.IsNullOrWhiteSpace(document)
+                || document.AsSpan().ContainsAny('/', '\\')
+                || document.AsSpan().IndexOfAnyExcept('.') < 0)
+            {
+                throw new ArgumentException(
+                    $"Default-document names must be bare file names: '{document}'.");
+            }
+        }
+
+        if (!string.IsNullOrEmpty(options.CacheControl)
+            && !HttpCacheControl.TryParse(options.CacheControl, out _))
+        {
+            throw new ArgumentException(
+                $"The Cache-Control value is not a valid RFC 9111 field value: '{options.CacheControl}'.");
+        }
+
+        if (options.ServeUnknownContentTypes && string.IsNullOrWhiteSpace(options.FallbackContentType))
+        {
+            throw new ArgumentException(
+                "A fallback content type is required when unknown content types are served.");
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilePath.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilePath.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Internal;
+
+/// <summary>
+/// Path helpers for the static-files middleware: segment-aligned prefix matching and the
+/// traversal gate that keeps every lookup inside the mounted file-system root.
+/// </summary>
+internal static class StaticFilePath
+{
+    /// <summary>
+    /// Matches <paramref name="path"/> against a normalized request-path prefix (empty for the
+    /// root mount, otherwise <c>/seg[/seg...]</c> with no trailing slash) and returns the
+    /// remainder. Matching is segment-aligned — <c>/staticfiles</c> does not match the prefix
+    /// <c>/static</c> — and ordinal, mirroring <see cref="Assimalign.Cohesion.Http.HttpPath"/>
+    /// equality. An exact-prefix match yields an empty remainder (the mount root requested
+    /// without a trailing slash).
+    /// </summary>
+    public static bool TryGetRelativePath(string path, string prefix, out string remainder)
+    {
+        if (prefix.Length == 0)
+        {
+            remainder = path;
+            return true;
+        }
+
+        if (!path.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            remainder = string.Empty;
+            return false;
+        }
+
+        if (path.Length == prefix.Length)
+        {
+            remainder = string.Empty;
+            return true;
+        }
+
+        if (path[prefix.Length] == '/')
+        {
+            remainder = path[prefix.Length..];
+            return true;
+        }
+
+        remainder = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Rejects request paths that could resolve outside the mounted root or address something
+    /// other than a plain file. Transports percent-decode the request path before it reaches
+    /// middleware (all but <c>%2F</c>), so encoded traversal like <c>%2e%2e</c> or <c>..%5C</c>
+    /// arrives here as literal dot segments — this gate sees the same text a file system would.
+    /// </summary>
+    /// <remarks>
+    /// Unsafe shapes: any NUL; any <c>:</c> (Windows drive roots and NTFS alternate data
+    /// streams); any segment — split on both <c>/</c> and <c>\</c>, since
+    /// <c>FileSystemPath</c> treats backslash as a separator — equal to <c>.</c> or <c>..</c>.
+    /// <c>FileSystemPath.Parse</c> independently throws on interior dot segments and illegal
+    /// characters; this check runs first so hostile requests get a deterministic <c>404</c>
+    /// instead of exception-driven control flow.
+    /// </remarks>
+    public static bool HasUnsafeSegments(ReadOnlySpan<char> remainder)
+    {
+        if (remainder.ContainsAny('\0', ':'))
+        {
+            return true;
+        }
+
+        while (!remainder.IsEmpty)
+        {
+            int separator = remainder.IndexOfAny('/', '\\');
+            ReadOnlySpan<char> segment = separator < 0 ? remainder : remainder[..separator];
+            remainder = separator < 0 ? ReadOnlySpan<char>.Empty : remainder[(separator + 1)..];
+
+            // "." and ".." are the only all-dot segments short enough to be dot segments.
+            if (segment.Length is 1 or 2 && segment.IndexOfAnyExcept('.') < 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilesMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilesMiddleware.cs
@@ -1,0 +1,648 @@
+using System;
+using System.Buffers;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Internal;
+
+/// <summary>
+/// Serves <c>GET</c>/<c>HEAD</c> requests under a request-path prefix from a mounted
+/// <see cref="IFileSystem"/>, composing the shared protocol primitives: RFC 9110 &#167; 13
+/// preconditions via <see cref="HttpConditionalRequest"/>, &#167; 14 byte ranges via
+/// <see cref="HttpRangeSelector"/>, content types via <see cref="HttpContentTypes"/>, and
+/// <c>Accept-Encoding</c> negotiation of precompressed siblings via
+/// <see cref="HttpContentNegotiation"/>. All composition state is frozen at construction —
+/// no request-time service location, no per-request allocation beyond the exchange itself.
+/// </summary>
+internal sealed class StaticFilesMiddleware : IWebApplicationMiddleware
+{
+    private const int CopyBufferSize = 64 * 1024;
+
+    // Precompressed sibling codings in server preference order (RFC 9110 §12.5.3 lets the
+    // server break client ties): brotli first, then gzip.
+    private static readonly (string Coding, string Suffix)[] PrecompressedCodings =
+    [
+        ("br", ".br"),
+        ("gzip", ".gz"),
+    ];
+
+    private readonly IFileSystem _fileSystem;
+    private readonly string _prefix;
+    private readonly string[] _defaultDocuments;
+    private readonly string? _cacheControl;
+    private readonly FrozenDictionary<string, string> _contentTypes;
+    private readonly bool _serveUnknownContentTypes;
+    private readonly string _fallbackContentType;
+    private readonly bool _servePrecompressedAssets;
+
+    public StaticFilesMiddleware(IFileSystem fileSystem, StaticFilesOptions options)
+    {
+        _fileSystem = fileSystem;
+        // "/" mounts at the site root (empty prefix); anything else is stored without a
+        // trailing slash so segment-aligned matching stays uniform.
+        _prefix = options.RequestPath.Value == "/" ? string.Empty : options.RequestPath.Value.TrimEnd('/');
+        _defaultDocuments = [.. options.DefaultDocuments];
+        _cacheControl = string.IsNullOrEmpty(options.CacheControl) ? null : options.CacheControl;
+        _contentTypes = options.ContentTypeMappings.Count == 0
+            ? HttpContentTypes.Default
+            : HttpContentTypes.CreateMap(options.ContentTypeMappings);
+        _serveUnknownContentTypes = options.ServeUnknownContentTypes;
+        _fallbackContentType = options.FallbackContentType;
+        _servePrecompressedAssets = options.ServePrecompressedAssets;
+    }
+
+    public async Task InvokeAsync(IHttpContext context, WebApplicationMiddleware next)
+    {
+        HttpMethod method = context.Request.Method;
+        if (method != HttpMethod.Get && method != HttpMethod.Head)
+        {
+            await next.Invoke(context);
+            return;
+        }
+
+        // Transport-parity compensation: the h2/h3 transports percent-decode the request path
+        // before it reaches middleware (HttpPath.FromUriComponent), but HTTP/1.x currently
+        // surfaces the raw request-target text. Decode here so the traversal gate and the file
+        // lookup see the same text on every transport — otherwise "%2e%2e" would read as a
+        // literal segment name on h1 and as ".." on h2. Remove once the h1 transport gains
+        // decode parity (filed as a follow-up; see docs/DESIGN.md).
+        string path = context.Request.Path.Value;
+        if (context.Version == HttpVersion.Http11 && path.Contains('%'))
+        {
+            path = Uri.UnescapeDataString(path);
+        }
+
+        if (!StaticFilePath.TryGetRelativePath(path, _prefix, out string remainder))
+        {
+            await next.Invoke(context);
+            return;
+        }
+
+        // The traversal gate: under our prefix, a path with dot segments (or NUL/':') is
+        // hostile or nonsensical — answer 404 directly rather than letting it reach any
+        // resolver. See StaticFilePath.HasUnsafeSegments for what the transports decode.
+        if (StaticFilePath.HasUnsafeSegments(remainder))
+        {
+            context.Response.StatusCode = HttpStatusCode.NotFound;
+            return;
+        }
+
+        // An exact-prefix match ("" remainder) is the mount root addressed without a trailing
+        // slash; normalize the lookup to the file-system root and remember the slash for the
+        // default-document redirect decision.
+        bool hadTrailingSlash = remainder.Length > 0 && remainder[^1] == '/';
+        string candidate = remainder.Length == 0 ? "/" : remainder;
+
+        FileSystemPath filePath;
+        try
+        {
+            filePath = FileSystemPath.Parse(candidate);
+        }
+        catch (ArgumentException)
+        {
+            // Second defense layer: FileSystemPath rejects interior dot segments and illegal
+            // path characters outright. Anything it refuses is not a servable file.
+            context.Response.StatusCode = HttpStatusCode.NotFound;
+            return;
+        }
+
+        // The mount root exists by definition; everything else must resolve through the mount.
+        IFileSystemInfo? info = null;
+        if (candidate != "/" && !TryGetInfo(filePath, out info))
+        {
+            await next.Invoke(context);
+            return;
+        }
+
+        string logicalName;
+        IFileSystemFile file;
+
+        // Directory detection is by info type, not FileAttributes: not every mount stamps
+        // FileAttributes.Directory (InMemory leaves attributes unset), but every mount returns
+        // an IFileSystemDirectory-typed info for a directory.
+        if (info is null || info is IFileSystemDirectory)
+        {
+            if (!TryResolveDefaultDocument(candidate, out IFileSystemFile? document, out string documentName))
+            {
+                // No default document (or none configured): directory browsing is a deferred
+                // follow-up, so the directory itself is not servable.
+                await next.Invoke(context);
+                return;
+            }
+
+            if (!hadTrailingSlash)
+            {
+                // Serving directory content at the slash-less URL would break every relative
+                // link inside the document, so canonicalize first (RFC 9110 §15.4.2).
+                RedirectAppendingSlash(context);
+                return;
+            }
+
+            file = document;
+            logicalName = documentName;
+        }
+        else
+        {
+            if (info is not IFileSystemFile resolved)
+            {
+                await next.Invoke(context);
+                return;
+            }
+
+            file = resolved;
+            logicalName = GetFileName(candidate);
+        }
+
+        // Content-type gate before any validator work: a file this middleware will not claim
+        // should never emit validators or 304s. The logical (unencoded) name decides the type —
+        // a precompressed sibling only changes the coding, never the media type.
+        if (!HttpContentTypes.TryGetContentType(_contentTypes, logicalName, out string contentType))
+        {
+            if (!_serveUnknownContentTypes)
+            {
+                await next.Invoke(context);
+                return;
+            }
+            contentType = _fallbackContentType;
+        }
+
+        // Negotiate the representation (identity vs precompressed sibling) before evaluating
+        // preconditions: validators belong to the representation actually selected.
+        IFileSystemFile servedFile = file;
+        string? contentEncoding = null;
+        bool varyByAcceptEncoding = false;
+
+        if (_servePrecompressedAssets)
+        {
+            SelectPrecompressedSibling(context, candidate, ref servedFile, ref contentEncoding, ref varyByAcceptEncoding);
+        }
+
+        long length = servedFile.Size;
+        DateTimeOffset lastModified = TruncateToSeconds(NormalizeTimestamp(servedFile.UpdatedOn));
+        // Strong validator from the served representation's Size + UpdatedOn: hex ticks and hex
+        // length are valid etagc characters, and a sibling naturally yields a different tag than
+        // the identity file — distinct representations must not share a strong ETag.
+        HttpEntityTag etag = HttpEntityTag.Strong(string.Create(
+            CultureInfo.InvariantCulture,
+            $"{NormalizeTimestamp(servedFile.UpdatedOn).UtcTicks:x}-{length:x}"));
+
+        switch (EvaluatePreconditions(context.Request, method, etag, lastModified))
+        {
+            case HttpPreconditionOutcome.NotModified:
+                WriteNotModified(context, etag, lastModified, varyByAcceptEncoding);
+                return;
+            case HttpPreconditionOutcome.PreconditionFailed:
+                context.Response.StatusCode = HttpStatusCode.PreconditionFailed;
+                return;
+        }
+
+        // Range applies to GET only (RFC 9110 §14.2 — Range on HEAD has no defined effect;
+        // this server ignores it) and only when If-Range, if present, still matches.
+        HttpRangeSlice? slice = null;
+        if (method == HttpMethod.Get
+            && TryGetRangeSelection(context.Request, etag, lastModified, length, out HttpRangeSelection selection))
+        {
+            if (selection.Status == HttpRangeSelectionStatus.Unsatisfiable)
+            {
+                WriteRangeNotSatisfiable(context, selection, etag, lastModified, varyByAcceptEncoding);
+                return;
+            }
+
+            // Only a single satisfiable range produces a 206; a multi-range set deliberately
+            // falls back to the full 200 representation (multipart/byteranges is out of scope).
+            if (selection.IsSingleSlice)
+            {
+                slice = selection.Slices[0];
+            }
+        }
+
+        Stream source;
+        try
+        {
+            source = servedFile.Open();
+        }
+        catch (FileSystemException)
+        {
+            // The file vanished between resolution and open; nothing has been committed to the
+            // response yet, so an honest 404 is still available.
+            context.Response.StatusCode = HttpStatusCode.NotFound;
+            return;
+        }
+
+        await using (source.ConfigureAwait(false))
+        {
+            IHttpHeaderCollection headers = context.Response.Headers;
+
+            context.Response.StatusCode = slice is null ? HttpStatusCode.Ok : HttpStatusCode.PartialContent;
+            headers[HttpHeaderKey.ContentType] = contentType;
+            headers[HttpHeaderKey.ContentLength] = (slice?.Length ?? length).ToString(CultureInfo.InvariantCulture);
+            headers[HttpHeaderKey.AcceptRanges] = HttpRangeHeader.BytesUnit;
+            headers[HttpHeaderKey.ETag] = etag.ToString();
+            headers[HttpHeaderKey.LastModified] = HttpDate.Format(lastModified);
+
+            if (_cacheControl is not null)
+            {
+                headers[HttpHeaderKey.CacheControl] = _cacheControl;
+            }
+            if (contentEncoding is not null)
+            {
+                headers[HttpHeaderKey.ContentEncoding] = contentEncoding;
+            }
+            if (varyByAcceptEncoding)
+            {
+                AppendVaryAcceptEncoding(headers);
+            }
+            if (slice is HttpRangeSlice partial)
+            {
+                headers[HttpHeaderKey.ContentRange] = partial.ContentRange.ToString();
+            }
+
+            if (method == HttpMethod.Head)
+            {
+                // RFC 9110 §9.3.2: same header section as GET, never a body. The transports
+                // suppress HEAD bodies as well; skipping the copy here saves the file read.
+                return;
+            }
+
+            if (slice is HttpRangeSlice single)
+            {
+                await CopySliceAsync(source, context.Response.Body, single.Offset, single.Length, context.RequestCancelled).ConfigureAwait(false);
+            }
+            else
+            {
+                await source.CopyToAsync(context.Response.Body, context.RequestCancelled).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private bool TryGetInfo(FileSystemPath path, [NotNullWhen(true)] out IFileSystemInfo? info)
+    {
+        info = null;
+        try
+        {
+            if (!_fileSystem.Exists(path))
+            {
+                return false;
+            }
+            info = _fileSystem.GetInfo(path);
+            return true;
+        }
+        catch (FileSystemException)
+        {
+            // A lookup race (deleted between Exists and GetInfo) or a mount-specific refusal:
+            // either way the path is not servable.
+            return false;
+        }
+    }
+
+    private bool TryResolveDefaultDocument(string directory, [NotNullWhen(true)] out IFileSystemFile? document, out string documentName)
+    {
+        document = null;
+        documentName = string.Empty;
+
+        if (_defaultDocuments.Length == 0)
+        {
+            return false;
+        }
+
+        string directoryPrefix = directory == "/" ? "/" : directory.TrimEnd('/') + "/";
+        foreach (string name in _defaultDocuments)
+        {
+            if (TryGetInfo(FileSystemPath.Parse(directoryPrefix + name), out IFileSystemInfo? info)
+                && info is IFileSystemFile candidate)
+            {
+                document = candidate;
+                documentName = name;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void SelectPrecompressedSibling(
+        IHttpContext context,
+        string candidate,
+        ref IFileSystemFile servedFile,
+        ref string? contentEncoding,
+        ref bool varyByAcceptEncoding)
+    {
+        Span<int> available = stackalloc int[PrecompressedCodings.Length];
+        int count = 0;
+        for (int i = 0; i < PrecompressedCodings.Length; i++)
+        {
+            if (TryGetInfo(FileSystemPath.Parse(candidate + PrecompressedCodings[i].Suffix), out IFileSystemInfo? info)
+                && info is IFileSystemFile)
+            {
+                available[count++] = i;
+            }
+        }
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        // The same URL can now yield different representations by Accept-Encoding, so every
+        // response for it must carry Vary — including the identity one a non-accepting client gets.
+        varyByAcceptEncoding = true;
+
+        string[] serverCodings = new string[count];
+        for (int i = 0; i < count; i++)
+        {
+            serverCodings[i] = PrecompressedCodings[available[i]].Coding;
+        }
+
+        string? acceptEncoding = context.Request.Headers.TryGetValue(HttpHeaderKey.AcceptEncoding, out HttpHeaderValue acceptEncodingValue)
+            ? (string?)acceptEncodingValue
+            : null;
+
+        // A false return means even identity was refused (identity;q=0). RFC 9110 §12.5.3 lets
+        // the server answer 406 or ignore the field; a static asset server serves identity —
+        // refusing cacheable bytes over a hostile-or-misconfigured header helps no one.
+        if (!HttpContentNegotiation.TrySelectEncoding(acceptEncoding, serverCodings, out string selected)
+            || selected == "identity")
+        {
+            return;
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            (string coding, string suffix) = PrecompressedCodings[available[i]];
+            if (coding == selected
+                && TryGetInfo(FileSystemPath.Parse(candidate + suffix), out IFileSystemInfo? sibling)
+                && sibling is IFileSystemFile siblingFile)
+            {
+                servedFile = siblingFile;
+                contentEncoding = coding;
+                return;
+            }
+        }
+    }
+
+    private static HttpPreconditionOutcome EvaluatePreconditions(
+        IHttpRequest request,
+        HttpMethod method,
+        HttpEntityTag etag,
+        DateTimeOffset lastModified)
+    {
+        // Malformed precondition fields are treated as absent: HttpEntityTagCondition parses
+        // strictly (RFC 9110 §13.1.1/§13.1.2 lists), and §13.1.3/§13.1.4 say an unparseable
+        // date is ignored.
+        HttpEntityTagCondition? ifMatch = null;
+        if (request.Headers.TryGetValue(HttpHeaderKey.IfMatch, out HttpHeaderValue ifMatchValue)
+            && HttpEntityTagCondition.TryParse((string?)ifMatchValue, out HttpEntityTagCondition parsedIfMatch))
+        {
+            ifMatch = parsedIfMatch;
+        }
+
+        HttpEntityTagCondition? ifNoneMatch = null;
+        if (request.Headers.TryGetValue(HttpHeaderKey.IfNoneMatch, out HttpHeaderValue ifNoneMatchValue)
+            && HttpEntityTagCondition.TryParse((string?)ifNoneMatchValue, out HttpEntityTagCondition parsedIfNoneMatch))
+        {
+            ifNoneMatch = parsedIfNoneMatch;
+        }
+
+        DateTimeOffset? ifModifiedSince = null;
+        if (request.Headers.TryGetValue(HttpHeaderKey.IfModifiedSince, out HttpHeaderValue ifModifiedSinceValue)
+            && HttpDate.TryParse((string?)ifModifiedSinceValue, out DateTimeOffset parsedIfModifiedSince))
+        {
+            ifModifiedSince = parsedIfModifiedSince;
+        }
+
+        DateTimeOffset? ifUnmodifiedSince = null;
+        if (request.Headers.TryGetValue(HttpHeaderKey.IfUnmodifiedSince, out HttpHeaderValue ifUnmodifiedSinceValue)
+            && HttpDate.TryParse((string?)ifUnmodifiedSinceValue, out DateTimeOffset parsedIfUnmodifiedSince))
+        {
+            ifUnmodifiedSince = parsedIfUnmodifiedSince;
+        }
+
+        return HttpConditionalRequest.Evaluate(new HttpConditionalRequestContext
+        {
+            Method = method,
+            ETag = etag,
+            LastModified = lastModified,
+            IfMatch = ifMatch,
+            IfNoneMatch = ifNoneMatch,
+            IfModifiedSince = ifModifiedSince,
+            IfUnmodifiedSince = ifUnmodifiedSince,
+        });
+    }
+
+    private static bool TryGetRangeSelection(
+        IHttpRequest request,
+        HttpEntityTag etag,
+        DateTimeOffset lastModified,
+        long length,
+        out HttpRangeSelection selection)
+    {
+        selection = default;
+
+        if (!request.Headers.TryGetValue(HttpHeaderKey.Range, out HttpHeaderValue rangeValue))
+        {
+            return false;
+        }
+
+        // RFC 9110 §13.2.2 step 5: a present If-Range gates whether the Range is honored at
+        // all. An unparseable If-Range cannot be validated, so the range is ignored.
+        if (request.Headers.TryGetValue(HttpHeaderKey.IfRange, out HttpHeaderValue ifRangeValue))
+        {
+            if (!HttpIfRange.TryParse((string?)ifRangeValue, out HttpIfRange ifRange)
+                || !ifRange.Matches(etag, lastModified))
+            {
+                return false;
+            }
+        }
+
+        // An unrecognized unit or malformed range-set fails the parse — the RFC's signal to
+        // ignore the header and serve the full representation.
+        if (!HttpRangeHeader.TryParse((string?)rangeValue, out HttpRangeHeader range))
+        {
+            return false;
+        }
+
+        selection = HttpRangeSelector.Select(range, length);
+        return true;
+    }
+
+    private void WriteNotModified(IHttpContext context, HttpEntityTag etag, DateTimeOffset lastModified, bool varyByAcceptEncoding)
+    {
+        // RFC 9110 §15.4.5: a 304 carries the headers a 200 would need for cache updating —
+        // validators, Cache-Control, Vary — and no content headers or body.
+        IHttpHeaderCollection headers = context.Response.Headers;
+
+        context.Response.StatusCode = HttpStatusCode.NotModified;
+        headers[HttpHeaderKey.ETag] = etag.ToString();
+        headers[HttpHeaderKey.LastModified] = HttpDate.Format(lastModified);
+
+        if (_cacheControl is not null)
+        {
+            headers[HttpHeaderKey.CacheControl] = _cacheControl;
+        }
+        if (varyByAcceptEncoding)
+        {
+            AppendVaryAcceptEncoding(headers);
+        }
+    }
+
+    private void WriteRangeNotSatisfiable(
+        IHttpContext context,
+        in HttpRangeSelection selection,
+        HttpEntityTag etag,
+        DateTimeOffset lastModified,
+        bool varyByAcceptEncoding)
+    {
+        IHttpHeaderCollection headers = context.Response.Headers;
+
+        context.Response.StatusCode = HttpStatusCode.RequestedRangeNotSatisfiable;
+        // RFC 9110 §14.4: the unsatisfied-range form reports the selected representation's
+        // complete length so the client can retry with a valid range.
+        headers[HttpHeaderKey.ContentRange] = selection.UnsatisfiedContentRange.ToString();
+        headers[HttpHeaderKey.AcceptRanges] = HttpRangeHeader.BytesUnit;
+        headers[HttpHeaderKey.ETag] = etag.ToString();
+        headers[HttpHeaderKey.LastModified] = HttpDate.Format(lastModified);
+
+        if (_cacheControl is not null)
+        {
+            headers[HttpHeaderKey.CacheControl] = _cacheControl;
+        }
+        if (varyByAcceptEncoding)
+        {
+            AppendVaryAcceptEncoding(headers);
+        }
+    }
+
+    private static void RedirectAppendingSlash(IHttpContext context)
+    {
+        // Reconstructing the query from the parsed collection re-encodes each part; a redirect
+        // target needs semantic, not byte-for-byte, fidelity.
+        string location = context.Request.Path.Value + "/";
+        if (context.Request.Query.Count > 0)
+        {
+            var builder = new StringBuilder(location).Append('?');
+            bool first = true;
+            foreach (KeyValuePair<HttpQueryKey, HttpQueryValue> pair in context.Request.Query)
+            {
+                if (!first)
+                {
+                    builder.Append('&');
+                }
+                first = false;
+                builder.Append(Uri.EscapeDataString(pair.Key.ToString())).Append('=').Append(Uri.EscapeDataString(pair.Value.ToString()));
+            }
+            location = builder.ToString();
+        }
+
+        context.Response.StatusCode = HttpStatusCode.MovedPermanently;
+        context.Response.Headers[HttpHeaderKey.Location] = location;
+    }
+
+    private static void AppendVaryAcceptEncoding(IHttpHeaderCollection headers)
+    {
+        if (!headers.TryGetValue(HttpHeaderKey.Vary, out HttpHeaderValue existing))
+        {
+            headers[HttpHeaderKey.Vary] = "Accept-Encoding";
+            return;
+        }
+
+        string current = (string?)existing ?? string.Empty;
+        ReadOnlySpan<char> span = current.AsSpan();
+        foreach (Range segment in span.Split(','))
+        {
+            ReadOnlySpan<char> token = span[segment].Trim();
+            if (token.Equals("Accept-Encoding", StringComparison.OrdinalIgnoreCase) || token is "*")
+            {
+                return;
+            }
+        }
+
+        headers[HttpHeaderKey.Vary] = current.Length == 0 ? "Accept-Encoding" : current + ", Accept-Encoding";
+    }
+
+    private static string GetFileName(string candidate)
+    {
+        int separator = candidate.LastIndexOf('/');
+        return separator < 0 ? candidate : candidate[(separator + 1)..];
+    }
+
+    private static DateTimeOffset NormalizeTimestamp(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => new DateTimeOffset(value),
+        DateTimeKind.Local => new DateTimeOffset(value).ToUniversalTime(),
+        // File systems that don't stamp a kind report wall-clock UTC in this repo's mounts.
+        _ => new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc)),
+    };
+
+    private static DateTimeOffset TruncateToSeconds(DateTimeOffset value)
+        // HTTP-date resolution is one second; validators must compare at the emitted precision.
+        => new(value.UtcTicks - (value.UtcTicks % TimeSpan.TicksPerSecond), TimeSpan.Zero);
+
+    private static async Task CopySliceAsync(Stream source, Stream destination, long offset, long count, CancellationToken cancellationToken)
+    {
+        if (source.CanSeek)
+        {
+            source.Seek(offset, SeekOrigin.Begin);
+        }
+        else
+        {
+            await SkipAsync(source, offset, cancellationToken).ConfigureAwait(false);
+        }
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(CopyBufferSize);
+        try
+        {
+            long remaining = count;
+            while (remaining > 0)
+            {
+                int read = await source
+                    .ReadAsync(buffer.AsMemory(0, (int)Math.Min(buffer.Length, remaining)), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read <= 0)
+                {
+                    // The file shrank after the head (with its Content-Range) was computed:
+                    // completing the response would silently serve wrong bytes, so abort it.
+                    throw new EndOfStreamException("The file ended before the selected byte range was fully written.");
+                }
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                remaining -= read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static async Task SkipAsync(Stream source, long count, CancellationToken cancellationToken)
+    {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(CopyBufferSize);
+        try
+        {
+            long remaining = count;
+            while (remaining > 0)
+            {
+                int read = await source
+                    .ReadAsync(buffer.AsMemory(0, (int)Math.Min(buffer.Length, remaining)), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read <= 0)
+                {
+                    throw new EndOfStreamException("The file ended before the selected byte range was reached.");
+                }
+                remaining -= read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Properties/AssemblyInfo.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Friend access for the Web.StaticFiles test project. The Cohesion repo is not strong-name signed
+// in CI builds, so the declaration deliberately omits a PublicKey clause to avoid CS0281 in Release.
+[assembly: InternalsVisibleTo("Assimalign.Cohesion.Web.StaticFiles.Tests")]

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/StaticFilesOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/StaticFilesOptions.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Cohesion.Http;
+
+namespace Assimalign.Cohesion.Web.StaticFiles;
+
+/// <summary>
+/// Builder-time configuration for <c>UseStaticFiles</c>. All values are snapshotted when the
+/// middleware is composed — mutating an options instance after registration has no effect, and
+/// nothing is resolved or re-read per request.
+/// </summary>
+public sealed class StaticFilesOptions
+{
+    /// <summary>
+    /// Gets or sets the request-path prefix the middleware serves under. Requests whose path does
+    /// not begin with this prefix (segment-aligned, ordinal comparison) pass through to the next
+    /// middleware. The default is <c>/</c>, which serves the mounted file system at the site root.
+    /// </summary>
+    public HttpPath RequestPath { get; set; } = HttpPath.Root;
+
+    /// <summary>
+    /// Gets the default-document names probed, in order, when a request maps to a directory. The
+    /// first name that exists as a file in that directory is served; an empty list disables
+    /// default documents entirely. Names must be bare file names (no path separators). The
+    /// defaults are <c>index.html</c> then <c>index.htm</c>.
+    /// </summary>
+    public IList<string> DefaultDocuments { get; } = new List<string> { "index.html", "index.htm" };
+
+    /// <summary>
+    /// Gets or sets the <c>Cache-Control</c> field value emitted on every served response
+    /// (<c>200</c>/<c>206</c>/<c>304</c>/<c>416</c>), for example
+    /// <c>public, max-age=3600, immutable</c>. <see langword="null"/> or empty emits no
+    /// <c>Cache-Control</c> header. The value is validated against the RFC 9111 grammar when the
+    /// middleware is composed.
+    /// </summary>
+    public string? CacheControl { get; set; }
+
+    /// <summary>
+    /// Gets the extension-to-content-type overrides overlaid onto
+    /// <see cref="HttpContentTypes.Default"/> when the middleware is composed. Keys may be given
+    /// with or without a leading dot and are case-insensitive; a key matching a default extension
+    /// replaces the default value.
+    /// </summary>
+    public IDictionary<string, string> ContentTypeMappings { get; }
+        = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether files whose extension has no content-type mapping
+    /// are served with <see cref="FallbackContentType"/>. When <see langword="false"/> (the
+    /// default) such requests pass through to the next middleware — unknown types are blocked
+    /// rather than guessed, so the application decides what owns them.
+    /// </summary>
+    public bool ServeUnknownContentTypes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content type used for unmapped extensions when
+    /// <see cref="ServeUnknownContentTypes"/> is enabled. The default is
+    /// <c>application/octet-stream</c>.
+    /// </summary>
+    public string FallbackContentType { get; set; } = HttpContentTypes.Fallback;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether precompressed sibling assets are served. When a
+    /// resolved file has an on-disk sibling with a <c>.br</c> or <c>.gz</c> suffix appended (for
+    /// example <c>app.js.br</c> beside <c>app.js</c>), the response is negotiated against the
+    /// request's <c>Accept-Encoding</c>: the sibling's bytes are sent with the original file's
+    /// content type, the matching <c>Content-Encoding</c>, and <c>Vary: Accept-Encoding</c>.
+    /// Enabled by default.
+    /// </summary>
+    public bool ServePrecompressedAssets { get; set; } = true;
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/Assimalign.Cohesion.Web.StaticFiles.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/Assimalign.Cohesion.Web.StaticFiles.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.StaticFiles" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.FileSystem" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.FileSystem.InMemory" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilePathTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilePathTests.cs
@@ -1,0 +1,58 @@
+using Assimalign.Cohesion.Web.StaticFiles.Internal;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Tests;
+
+/// <summary>
+/// Focused coverage of the prefix-matching and traversal-gate helpers.
+/// </summary>
+public class StaticFilePathTests
+{
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - TryGetRelativePath: should match segment-aligned prefixes")]
+    [InlineData("/static/app.css", "/static", true, "/app.css")]
+    [InlineData("/static", "/static", true, "")]
+    [InlineData("/static/", "/static", true, "/")]
+    [InlineData("/static/a/b.txt", "/static", true, "/a/b.txt")]
+    [InlineData("/staticfiles/app.css", "/static", false, "")]
+    [InlineData("/other/app.css", "/static", false, "")]
+    [InlineData("/Static/app.css", "/static", false, "")]
+    [InlineData("/anything", "", true, "/anything")]
+    public void TryGetRelativePath_ShouldMatchSegmentAligned(string path, string prefix, bool expected, string expectedRemainder)
+    {
+        // Act
+        bool matched = StaticFilePath.TryGetRelativePath(path, prefix, out string remainder);
+
+        // Assert
+        matched.ShouldBe(expected);
+        if (expected)
+        {
+            remainder.ShouldBe(expectedRemainder);
+        }
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - HasUnsafeSegments: should flag traversal and reserved shapes")]
+    [InlineData("/../x", true)]
+    [InlineData("/a/../x", true)]
+    [InlineData("/..", true)]
+    [InlineData("/.", true)]
+    [InlineData("/./x", true)]
+    [InlineData("/a\\..\\x", true)]
+    [InlineData("/..\\x", true)]
+    [InlineData("/a:b", true)]
+    [InlineData("/file.txt::$DATA", true)]
+    [InlineData("/a\0b", true)]
+    [InlineData("/a/b.txt", false)]
+    [InlineData("/.well-known/x", false)]
+    [InlineData("/a.b/c.d.txt", false)]
+    [InlineData("/...x", false)]
+    [InlineData("/", false)]
+    [InlineData("", false)]
+    public void HasUnsafeSegments_ShouldFlagTraversalShapes(string remainder, bool expected)
+    {
+        // Act / Assert
+        StaticFilePath.HasUnsafeSegments(remainder).ShouldBe(expected);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesEndToEndTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesEndToEndTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Tests;
+
+/// <summary>
+/// Full-pipeline coverage driven end to end over the in-memory transport through
+/// <see cref="WebApplicationTestFactory"/>: real client, real HTTP/1.1 wire exchange, real
+/// server dispatch — including the encoded traversal forms only a live transport decodes.
+/// </summary>
+public class StaticFilesEndToEndTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    private static WebApplicationTestFactory CreateFactory(InMemoryFileSystem site, Action<StaticFilesOptions>? configure = null)
+    {
+        var factory = new WebApplicationTestFactory();
+        factory.Application.UseStaticFiles(site, configure);
+        return factory;
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: GET should serve the file with entity headers over the wire")]
+    public async Task E2E_Get_ShouldServeFileWithEntityHeaders()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("index.html", "<html>home</html>"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/index.html", cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("<html>home</html>");
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("text/html");
+        response.Content.Headers.ContentLength.ShouldBe(17);
+        response.Headers.ETag.ShouldNotBeNull();
+        response.Content.Headers.LastModified.ShouldNotBeNull();
+        response.Headers.AcceptRanges.ShouldContain("bytes");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: revalidating with the returned ETag should yield 304")]
+    public async Task E2E_RevalidateWithETag_ShouldYield304()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("app.css", "body{}"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        using HttpResponseMessage first = await client.GetAsync("/app.css", cancellation.Token);
+        EntityTagHeaderValue etag = first.Headers.ETag!;
+
+        // Act — the natural cache revalidation flow.
+        using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "/app.css");
+        request.Headers.IfNoneMatch.Add(etag);
+        using HttpResponseMessage second = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        second.StatusCode.ShouldBe(NetHttpStatusCode.NotModified);
+        (await second.Content.ReadAsStringAsync(cancellation.Token)).ShouldBeEmpty();
+        second.Headers.ETag.ShouldBe(etag);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: a single byte range should yield 206 with Content-Range")]
+    public async Task E2E_SingleByteRange_ShouldYield206()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "/data.txt");
+        request.Headers.Range = new RangeHeaderValue(2, 5);
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.PartialContent);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("2345");
+        response.Content.Headers.ContentRange!.ToString().ShouldBe("bytes 2-5/10");
+        response.Content.Headers.ContentLength.ShouldBe(4);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: an unsatisfiable range should yield 416 with bytes */N")]
+    public async Task E2E_UnsatisfiableRange_ShouldYield416()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "/data.txt");
+        request.Headers.Range = new RangeHeaderValue(100, 200);
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.RequestedRangeNotSatisfiable);
+        response.Content.Headers.ContentRange!.ToString().ShouldBe("bytes */10");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: HEAD should return the GET header section with an empty body")]
+    public async Task E2E_Head_ShouldReturnHeadersWithoutBody()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Head, "/page.html");
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsByteArrayAsync(cancellation.Token)).ShouldBeEmpty();
+        response.Content.Headers.ContentLength.ShouldBe(7);
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("text/html");
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: encoded traversal must never escape the mounted root")]
+    [InlineData("/static/%2e%2e/secret.txt")]
+    [InlineData("/static/%2e%2e/%2e%2e/secret.txt")]
+    [InlineData("/static/..%5csecret.txt")]
+    [InlineData("/static/nested/%2e%2e/%2e%2e/secret.txt")]
+    public async Task E2E_EncodedTraversal_ShouldYield404(string attackPath)
+    {
+        // Arrange — the transport percent-decodes these into literal dot segments before the
+        // middleware sees them; the URI client-side keeps them encoded, so the hostile form
+        // actually reaches the server (a literal "/../" would be normalized away by HttpClient).
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("public.txt", "public"),
+            ("secret.txt", "top-secret"));
+        await using WebApplicationTestFactory factory = CreateFactory(
+            site, options => options.RequestPath = new HttpPath("/static"));
+        using HttpClient client = factory.CreateClient();
+
+        // Act — DangerousDisablePathAndQueryCanonicalization stops the client-side Uri from
+        // collapsing the encoded dot segments, so the hostile bytes actually hit the wire.
+        var rawUri = new Uri(
+            "http://localhost" + attackPath,
+            new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+        using HttpResponseMessage response = await client.GetAsync(rawUri, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.NotFound);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldNotContain("top-secret");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: Accept-Encoding negotiation should serve the precompressed sibling")]
+    public async Task E2E_AcceptEncodingBr_ShouldServePrecompressedSibling()
+    {
+        // Arrange — SocketsHttpHandler does not auto-decompress unless configured, so the raw
+        // sibling bytes and the Content-Encoding header are observable.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, "/app.js");
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("brotli-bytes");
+        response.Content.Headers.ContentEncoding.ShouldContain("br");
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("text/javascript");
+        response.Headers.Vary.ShouldContain("Accept-Encoding");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: a directory URL should redirect to its slash form and serve the default document")]
+    public async Task E2E_DirectoryWithoutSlash_ShouldRedirectAndServeDefaultDocument()
+    {
+        // Arrange — HttpClient follows the 301 automatically, so the observable outcome is the
+        // default document served from the slash form.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("docs/index.html", "docs home"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync("/docs", cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("docs home");
+        response.RequestMessage!.RequestUri!.AbsolutePath.ShouldBe("/docs/");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: unmatched requests should flow to downstream middleware")]
+    public async Task E2E_UnmatchedRequest_ShouldFlowDownstream()
+    {
+        // Arrange — a downstream marker middleware owns everything static files declines.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("app.css", "body{}"));
+
+        await using var factory = new WebApplicationTestFactory();
+        factory.Application.UseStaticFiles(site, options => options.RequestPath = new HttpPath("/static"));
+        factory.Application.Use(async (context, next) =>
+        {
+            context.Response.StatusCode = HttpStatusCode.Forbidden;
+            await context.Response.Body.WriteAsync("downstream"u8.ToArray(), context.RequestCancelled);
+        });
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        using HttpResponseMessage served = await client.GetAsync("/static/app.css", cancellation.Token);
+        using HttpResponseMessage unmatched = await client.GetAsync("/api/data", cancellation.Token);
+
+        // Assert
+        served.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        unmatched.StatusCode.ShouldBe(NetHttpStatusCode.Forbidden);
+        (await unmatched.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("downstream");
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesMiddlewareTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesMiddlewareTests.cs
@@ -1,0 +1,818 @@
+using System;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+using Shouldly;
+
+using Xunit;
+
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Tests;
+
+/// <summary>
+/// Middleware-level coverage over a fake <see cref="IHttpContext"/>: raw hostile paths an
+/// <c>HttpClient</c> would normalize away, plus precise header semantics for conditional GET,
+/// ranges, default documents, content types, and precompressed siblings.
+/// </summary>
+public class StaticFilesMiddlewareTests
+{
+    private static async Task<TestHttpContext> RunAsync(
+        IFileSystem fileSystem,
+        string path,
+        HttpMethod method,
+        Action<StaticFilesOptions>? configure = null,
+        Action<TestHttpContext>? prepare = null,
+        bool[]? passedThrough = null)
+    {
+        var builder = new TestPipelineBuilder();
+        builder.UseStaticFiles(fileSystem, configure);
+        builder.Use((context, next) =>
+        {
+            if (passedThrough is not null)
+            {
+                passedThrough[0] = true;
+            }
+            return Task.CompletedTask;
+        });
+
+        IWebApplicationPipeline pipeline = builder.Build();
+        var context = new TestHttpContext(path, method);
+        prepare?.Invoke(context);
+
+        await pipeline.ExecuteAsync(context);
+        return context;
+    }
+
+    private static string Header(TestHttpContext context, HttpHeaderKey key)
+        => context.Response.Headers.TryGetValue(key, out HttpHeaderValue value) ? (string)value : string.Empty;
+
+    // ---------------------------------------------------------------- serving basics
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: GET existing file should serve 200 with entity headers")]
+    public async Task Invoke_GetExistingFile_ShouldServe200WithEntityHeaders()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("site.html", "<html>hello</html>"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/site.html", HttpMethod.Get);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("<html>hello</html>");
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/html");
+        Header(context, HttpHeaderKey.ContentLength).ShouldBe("18");
+        Header(context, HttpHeaderKey.AcceptRanges).ShouldBe("bytes");
+        Header(context, HttpHeaderKey.ETag).ShouldStartWith("\"");
+        HttpDate.TryParse(Header(context, HttpHeaderKey.LastModified), out _).ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: non-GET/HEAD methods should pass through")]
+    public async Task Invoke_PostMethod_ShouldPassThrough()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("site.html", "content"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(site, "/site.html", HttpMethod.Post, passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a missing file should pass through")]
+    public async Task Invoke_MissingFile_ShouldPassThrough()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("site.html", "content"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(site, "/missing.html", HttpMethod.Get, passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    // ---------------------------------------------------------------- request-path prefix
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: prefixed mount should serve under the prefix")]
+    public async Task Invoke_PrefixedMount_ShouldServeUnderPrefix()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("app.css", "body{}"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/static/app.css", HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"));
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("body{}");
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/css");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a path outside the prefix should pass through")]
+    public async Task Invoke_PathOutsidePrefix_ShouldPassThrough()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("app.css", "body{}"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(
+            site, "/other/app.css", HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"),
+            passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: prefix matching should be segment-aligned")]
+    public async Task Invoke_PrefixSharingTextButNotSegment_ShouldPassThrough()
+    {
+        // Arrange — "/staticfiles" shares the "/static" text but is a different segment.
+        using InMemoryFileSystem site = StaticSite.Create(("app.css", "body{}"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(
+            site, "/staticfiles/app.css", HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"),
+            passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    // ---------------------------------------------------------------- path traversal defense
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: dot-segment traversal should be rejected with 404")]
+    [InlineData("/static/../secret.txt")]
+    [InlineData("/static/../../secret.txt")]
+    [InlineData("/static/nested/../../secret.txt")]
+    [InlineData("/static/./secret.txt")]
+    [InlineData("/static/..")]
+    public async Task Invoke_DotSegmentTraversal_ShouldRespond404(string path)
+    {
+        // Arrange — dot-segment paths must be rejected outright, not resolved: even
+        // "/static/./secret.txt" (which canonicalizes to a file that exists in the mount) gets
+        // a 404, and nothing under the prefix ever reaches a downstream handler.
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("public.txt", "public"),
+            ("secret.txt", "top-secret"));
+        bool[] passedThrough = [false];
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, path, HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"),
+            passedThrough: passedThrough);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        context.ReadResponseBody().ShouldNotContain("top-secret");
+        passedThrough[0].ShouldBeFalse();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: percent-encoded traversal on HTTP/1.1 should be rejected with 404")]
+    [InlineData("/static/%2e%2e/secret.txt")]
+    [InlineData("/static/%2E%2E/secret.txt")]
+    [InlineData("/static/..%2fsecret.txt")]
+    [InlineData("/static/..%5csecret.txt")]
+    public async Task Invoke_EncodedTraversalOnHttp11_ShouldRespond404(string path)
+    {
+        // Arrange — the HTTP/1.1 transport surfaces the raw request-target text, so the
+        // middleware's own decode step must expose these as dot segments before the gate runs
+        // (the fake context reports HttpVersion.Http11).
+        using InMemoryFileSystem site = StaticSite.Create(("public.txt", "public"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, path, HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"));
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: percent-encoded names on HTTP/1.1 should resolve to the decoded file")]
+    public async Task Invoke_EncodedNameOnHttp11_ShouldResolveDecodedFile()
+    {
+        // Arrange — the same decode step serves correctness, not just defense: a space-encoded
+        // request must reach the file whose name actually contains the space.
+        using InMemoryFileSystem site = StaticSite.Create(("my file.txt", "spaced"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/my%20file.txt", HttpMethod.Get);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("spaced");
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/plain");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: backslash traversal should be rejected with 404")]
+    [InlineData("/static/..\\secret.txt")]
+    [InlineData("/static/nested\\..\\..\\secret.txt")]
+    public async Task Invoke_BackslashTraversal_ShouldRespond404(string path)
+    {
+        // Arrange — transports decode %5C to a literal backslash, which FileSystemPath treats
+        // as a separator; the gate must see through it.
+        using InMemoryFileSystem site = StaticSite.Create(("public.txt", "public"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, path, HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"));
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: colon and NUL paths should be rejected with 404")]
+    [InlineData("/static/c:/windows/win.ini")]
+    [InlineData("/static/file.txt::$DATA")]
+    [InlineData("/static/file\0.txt")]
+    public async Task Invoke_ColonOrNulPath_ShouldRespond404(string path)
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("file.txt", "content"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, path, HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"));
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ---------------------------------------------------------------- default documents
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: the mount root should serve the first default document")]
+    public async Task Invoke_RootRequest_ShouldServeDefaultDocument()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("index.html", "<html>home</html>"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/", HttpMethod.Get);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("<html>home</html>");
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/html");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: default documents should probe in configured order")]
+    public async Task Invoke_DefaultDocuments_ShouldProbeInOrder()
+    {
+        // Arrange — only the second default name exists.
+        using InMemoryFileSystem site = StaticSite.Create(("docs/index.htm", "second choice"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/docs/", HttpMethod.Get);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("second choice");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a directory without a trailing slash should 301 to the slash form")]
+    public async Task Invoke_DirectoryWithoutTrailingSlash_ShouldRedirectAppendingSlash()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("docs/index.html", "docs home"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/docs", HttpMethod.Get);
+
+        // Assert — canonicalize before serving so relative links inside the document resolve.
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.MovedPermanently);
+        Header(context, HttpHeaderKey.Location).ShouldBe("/docs/");
+        context.ReadResponseBody().ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: the exact mount prefix should 301 to its slash form")]
+    public async Task Invoke_ExactPrefixWithoutSlash_ShouldRedirectAppendingSlash()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("index.html", "home"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/static", HttpMethod.Get,
+            options => options.RequestPath = new HttpPath("/static"));
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.MovedPermanently);
+        Header(context, HttpHeaderKey.Location).ShouldBe("/static/");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a directory with no default document should pass through")]
+    public async Task Invoke_DirectoryWithoutDefaultDocument_ShouldPassThrough()
+    {
+        // Arrange — directory browsing is a deferred follow-up, so a bare directory is not servable.
+        using InMemoryFileSystem site = StaticSite.Create(("docs/page.html", "page"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(site, "/docs/", HttpMethod.Get, passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: clearing DefaultDocuments should disable default documents")]
+    public async Task Invoke_DefaultDocumentsCleared_ShouldPassThrough()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("index.html", "home"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(
+            site, "/", HttpMethod.Get,
+            options => options.DefaultDocuments.Clear(),
+            passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    // ---------------------------------------------------------------- content types
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: an unmapped extension should pass through by default")]
+    public async Task Invoke_UnknownExtension_ShouldPassThroughByDefault()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.xyzzy", "mystery"));
+        bool[] passedThrough = [false];
+
+        // Act
+        await RunAsync(site, "/data.xyzzy", HttpMethod.Get, passedThrough: passedThrough);
+
+        // Assert
+        passedThrough[0].ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: ServeUnknownContentTypes should serve the fallback type")]
+    public async Task Invoke_UnknownExtensionWithFallback_ShouldServeFallbackType()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.xyzzy", "mystery"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.xyzzy", HttpMethod.Get,
+            options => options.ServeUnknownContentTypes = true);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("application/octet-stream");
+        context.ReadResponseBody().ShouldBe("mystery");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: content-type overlays should override the default map")]
+    public async Task Invoke_ContentTypeOverlay_ShouldOverrideDefaultMap()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("model.gltf", "{}"),
+            ("page.html", "<html/>"));
+
+        // Act
+        TestHttpContext gltf = await RunAsync(
+            site, "/model.gltf", HttpMethod.Get,
+            options =>
+            {
+                options.ContentTypeMappings["gltf"] = "model/gltf+json";
+                options.ContentTypeMappings[".html"] = "application/xhtml+xml";
+            });
+        TestHttpContext html = await RunAsync(
+            site, "/page.html", HttpMethod.Get,
+            options => options.ContentTypeMappings[".html"] = "application/xhtml+xml");
+
+        // Assert — a new mapping lights up and an existing default is replaceable.
+        Header(gltf, HttpHeaderKey.ContentType).ShouldBe("model/gltf+json");
+        Header(html, HttpHeaderKey.ContentType).ShouldBe("application/xhtml+xml");
+    }
+
+    // ---------------------------------------------------------------- cache control
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a configured Cache-Control should be emitted on 200 and 304")]
+    public async Task Invoke_CacheControlConfigured_ShouldEmitOn200And304()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("app.js", "let x;"));
+        const string cacheControl = "public, max-age=3600, immutable";
+
+        // Act
+        TestHttpContext first = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            options => options.CacheControl = cacheControl);
+        string etag = Header(first, HttpHeaderKey.ETag);
+
+        TestHttpContext second = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            options => options.CacheControl = cacheControl,
+            prepare: context => context.Request.Headers[HttpHeaderKey.IfNoneMatch] = etag);
+
+        // Assert
+        Header(first, HttpHeaderKey.CacheControl).ShouldBe(cacheControl);
+        second.Response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        Header(second, HttpHeaderKey.CacheControl).ShouldBe(cacheControl);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - UseStaticFiles: an invalid Cache-Control should throw at composition")]
+    public void UseStaticFiles_InvalidCacheControl_ShouldThrowAtComposition()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("app.js", "let x;"));
+        var builder = new TestPipelineBuilder();
+
+        // Act / Assert — configuration typos surface at composition time, not per request.
+        Should.Throw<ArgumentException>(() =>
+            builder.UseStaticFiles(site, options => options.CacheControl = "max-age=,,,"));
+    }
+
+    // ---------------------------------------------------------------- conditional GET
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a matching If-None-Match should respond 304 without a body")]
+    public async Task Invoke_IfNoneMatchMatching_ShouldRespond304WithoutBody()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+        TestHttpContext first = await RunAsync(site, "/page.html", HttpMethod.Get);
+        string etag = Header(first, HttpHeaderKey.ETag);
+
+        // Act
+        TestHttpContext second = await RunAsync(
+            site, "/page.html", HttpMethod.Get,
+            prepare: context => context.Request.Headers[HttpHeaderKey.IfNoneMatch] = etag);
+
+        // Assert — validators re-emitted for cache updating; no content headers or body.
+        second.Response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        second.ReadResponseBody().ShouldBeEmpty();
+        Header(second, HttpHeaderKey.ETag).ShouldBe(etag);
+        second.Response.Headers.ContainsKey(HttpHeaderKey.ContentLength).ShouldBeFalse();
+        second.Response.Headers.ContainsKey(HttpHeaderKey.ContentType).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: an unchanged If-Modified-Since should respond 304")]
+    public async Task Invoke_IfModifiedSinceUnchanged_ShouldRespond304()
+    {
+        // Arrange — replay the emitted Last-Modified, the way a real cache revalidates.
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+        TestHttpContext first = await RunAsync(site, "/page.html", HttpMethod.Get);
+        string lastModified = Header(first, HttpHeaderKey.LastModified);
+
+        // Act
+        TestHttpContext second = await RunAsync(
+            site, "/page.html", HttpMethod.Get,
+            prepare: context => context.Request.Headers[HttpHeaderKey.IfModifiedSince] = lastModified);
+
+        // Assert
+        second.Response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: If-None-Match should take precedence over If-Modified-Since")]
+    public async Task Invoke_IfNoneMatchMismatch_ShouldSuppressIfModifiedSince()
+    {
+        // Arrange — the tag mismatches (so If-None-Match says "send it") while the date alone
+        // would have produced a 304; RFC 9110 §13.1.3 says the date must then be ignored.
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+        TestHttpContext first = await RunAsync(site, "/page.html", HttpMethod.Get);
+        string lastModified = Header(first, HttpHeaderKey.LastModified);
+
+        // Act
+        TestHttpContext second = await RunAsync(
+            site, "/page.html", HttpMethod.Get,
+            prepare: context =>
+            {
+                context.Request.Headers[HttpHeaderKey.IfNoneMatch] = "\"different\"";
+                context.Request.Headers[HttpHeaderKey.IfModifiedSince] = lastModified;
+            });
+
+        // Assert
+        second.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        second.ReadResponseBody().ShouldBe("content");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a failed If-Unmodified-Since should respond 412")]
+    public async Task Invoke_IfUnmodifiedSinceInPast_ShouldRespond412()
+    {
+        // Arrange — a guard date well before the file's actual modification time.
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/page.html", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.IfUnmodifiedSince] = "Sat, 01 Jan 2000 00:00:00 GMT");
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+        context.ReadResponseBody().ShouldBeEmpty();
+    }
+
+    // ---------------------------------------------------------------- byte ranges
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a single byte range should respond 206 with Content-Range")]
+    public async Task Invoke_SingleByteRange_ShouldRespond206WithContentRange()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=2-5");
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PartialContent);
+        context.ReadResponseBody().ShouldBe("2345");
+        Header(context, HttpHeaderKey.ContentRange).ShouldBe("bytes 2-5/10");
+        Header(context, HttpHeaderKey.ContentLength).ShouldBe("4");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a suffix range should serve the final bytes")]
+    public async Task Invoke_SuffixRange_ShouldServeFinalBytes()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=-3");
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PartialContent);
+        context.ReadResponseBody().ShouldBe("789");
+        Header(context, HttpHeaderKey.ContentRange).ShouldBe("bytes 7-9/10");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: an unsatisfiable range should respond 416 with bytes */N")]
+    public async Task Invoke_UnsatisfiableRange_ShouldRespond416()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=100-200");
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.RequestedRangeNotSatisfiable);
+        Header(context, HttpHeaderKey.ContentRange).ShouldBe("bytes */10");
+        context.ReadResponseBody().ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a multi-range set should fall back to the full 200")]
+    public async Task Invoke_MultiRange_ShouldFallBackToFull200()
+    {
+        // Arrange — multipart/byteranges is out of scope; the whole representation is honest.
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=0-1,4-5");
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("0123456789");
+        context.Response.Headers.ContainsKey(HttpHeaderKey.ContentRange).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a stale If-Range validator should serve the full 200")]
+    public async Task Invoke_IfRangeMismatch_ShouldServeFull200()
+    {
+        // Arrange — the client's stored validator no longer matches, so the range is ignored
+        // and the whole current representation is sent (RFC 9110 §13.1.5).
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx =>
+            {
+                ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=0-4";
+                ctx.Request.Headers[HttpHeaderKey.IfRange] = "\"stale-etag\"";
+            });
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("0123456789");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: a current If-Range validator should honor the range")]
+    public async Task Invoke_IfRangeMatching_ShouldHonorRange()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+        TestHttpContext first = await RunAsync(site, "/data.txt", HttpMethod.Get);
+        string etag = Header(first, HttpHeaderKey.ETag);
+
+        // Act
+        TestHttpContext second = await RunAsync(
+            site, "/data.txt", HttpMethod.Get,
+            prepare: ctx =>
+            {
+                ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=0-4";
+                ctx.Request.Headers[HttpHeaderKey.IfRange] = etag;
+            });
+
+        // Assert
+        second.Response.StatusCode.ShouldBe(HttpStatusCode.PartialContent);
+        second.ReadResponseBody().ShouldBe("01234");
+    }
+
+    // ---------------------------------------------------------------- HEAD
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: HEAD should emit the GET header section without a body")]
+    public async Task Invoke_HeadRequest_ShouldEmitHeadersWithoutBody()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("page.html", "content"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/page.html", HttpMethod.Head);
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBeEmpty();
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/html");
+        Header(context, HttpHeaderKey.ContentLength).ShouldBe("7");
+        Header(context, HttpHeaderKey.ETag).ShouldStartWith("\"");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: Range on HEAD should be ignored")]
+    public async Task Invoke_RangeOnHead_ShouldBeIgnored()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("data.txt", "0123456789"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/data.txt", HttpMethod.Head,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=0-4");
+
+        // Assert — the full representation's metadata, no partial semantics.
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        Header(context, HttpHeaderKey.ContentLength).ShouldBe("10");
+        context.Response.Headers.ContainsKey(HttpHeaderKey.ContentRange).ShouldBeFalse();
+    }
+
+    // ---------------------------------------------------------------- precompressed siblings
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: Accept-Encoding br should serve the .br sibling")]
+    public async Task Invoke_AcceptEncodingBr_ShouldServeBrotliSibling()
+    {
+        // Arrange — sibling content stands in for real brotli bytes; the middleware never
+        // inspects the payload, it only negotiates which file to stream.
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"),
+            ("app.js.gz", "gzip-bytes"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "gzip, br");
+
+        // Assert — server preference (br first) breaks the client tie; the media type stays
+        // the logical file's, and the length/body are the sibling's.
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+        context.ReadResponseBody().ShouldBe("brotli-bytes");
+        Header(context, HttpHeaderKey.ContentEncoding).ShouldBe("br");
+        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/javascript");
+        Header(context, HttpHeaderKey.ContentLength).ShouldBe("12");
+        Header(context, HttpHeaderKey.Vary).ShouldBe("Accept-Encoding");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: gzip preference should serve the .gz sibling")]
+    public async Task Invoke_AcceptEncodingGzipOnly_ShouldServeGzipSibling()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.gz", "gzip-bytes"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "gzip");
+
+        // Assert
+        context.ReadResponseBody().ShouldBe("gzip-bytes");
+        Header(context, HttpHeaderKey.ContentEncoding).ShouldBe("gzip");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: identity clients still get Vary when siblings exist")]
+    public async Task Invoke_NoAcceptEncodingWithSiblings_ShouldServeIdentityWithVary()
+    {
+        // Arrange — the URL's response varies by Accept-Encoding even when this client gets
+        // identity; caches must know that.
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"));
+
+        // Act
+        TestHttpContext context = await RunAsync(site, "/app.js", HttpMethod.Get);
+
+        // Assert
+        context.ReadResponseBody().ShouldBe("identity-js");
+        context.Response.Headers.ContainsKey(HttpHeaderKey.ContentEncoding).ShouldBeFalse();
+        Header(context, HttpHeaderKey.Vary).ShouldBe("Accept-Encoding");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: no siblings means no Vary and no Content-Encoding")]
+    public async Task Invoke_NoSiblings_ShouldNotEmitVary()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(("app.js", "identity-js"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "br, gzip");
+
+        // Assert
+        context.ReadResponseBody().ShouldBe("identity-js");
+        context.Response.Headers.ContainsKey(HttpHeaderKey.Vary).ShouldBeFalse();
+        context.Response.Headers.ContainsKey(HttpHeaderKey.ContentEncoding).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: disabling precompression should always serve identity")]
+    public async Task Invoke_PrecompressionDisabled_ShouldServeIdentity()
+    {
+        // Arrange
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            options => options.ServePrecompressedAssets = false,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "br");
+
+        // Assert
+        context.ReadResponseBody().ShouldBe("identity-js");
+        context.Response.Headers.ContainsKey(HttpHeaderKey.Vary).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: each encoding is its own representation with its own ETag")]
+    public async Task Invoke_PrecompressedSibling_ShouldCarryDistinctETag()
+    {
+        // Arrange — distinct representations must not share a strong validator (RFC 9110 §8.8.3).
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"));
+
+        // Act
+        TestHttpContext identity = await RunAsync(site, "/app.js", HttpMethod.Get);
+        TestHttpContext brotli = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            prepare: ctx => ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "br");
+
+        // Assert
+        Header(brotli, HttpHeaderKey.ContentEncoding).ShouldBe("br");
+        Header(identity, HttpHeaderKey.ETag).ShouldNotBe(Header(brotli, HttpHeaderKey.ETag));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: ranges should apply to the negotiated representation")]
+    public async Task Invoke_RangeWithPrecompressedSibling_ShouldSliceSiblingBytes()
+    {
+        // Arrange — RFC 9110 §14.2: the range addresses the selected representation, which is
+        // the encoded sibling when negotiation picks it.
+        using InMemoryFileSystem site = StaticSite.Create(
+            ("app.js", "identity-js"),
+            ("app.js.br", "brotli-bytes"));
+
+        // Act
+        TestHttpContext context = await RunAsync(
+            site, "/app.js", HttpMethod.Get,
+            prepare: ctx =>
+            {
+                ctx.Request.Headers[HttpHeaderKey.AcceptEncoding] = "br";
+                ctx.Request.Headers[HttpHeaderKey.Range] = "bytes=0-5";
+            });
+
+        // Assert
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PartialContent);
+        context.ReadResponseBody().ShouldBe("brotli");
+        Header(context, HttpHeaderKey.ContentRange).ShouldBe("bytes 0-5/12");
+        Header(context, HttpHeaderKey.ContentEncoding).ShouldBe("br");
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/TestObjects/StaticFilesTestHarness.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/TestObjects/StaticFilesTestHarness.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.FileSystem;
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.StaticFiles.Tests;
+
+/// <summary>
+/// Builds populated <see cref="InMemoryFileSystem"/> content roots for static-file tests.
+/// </summary>
+internal static class StaticSite
+{
+    public static InMemoryFileSystem Create(params (string Path, string Content)[] files)
+    {
+        var fileSystem = new InMemoryFileSystem(new InMemoryFileSystemOptions
+        {
+            Name = "static-site",
+        });
+
+        foreach ((string path, string content) in files)
+        {
+            IFileSystemFile file = fileSystem.CreateFile(path);
+            using Stream stream = file.Open(FileMode.Open, FileAccess.Write);
+            byte[] payload = Encoding.UTF8.GetBytes(content);
+            stream.Write(payload, 0, payload.Length);
+        }
+
+        return fileSystem;
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IWebApplicationPipelineBuilder"/> that composes middleware in registration
+/// order — the same shape the real <c>WebApplication</c> builder produces — without pulling in
+/// the hosting/DI stack. Mirrors the Web.Health test harness.
+/// </summary>
+internal sealed class TestPipelineBuilder : IWebApplicationPipelineBuilder
+{
+    private readonly List<Func<WebApplicationMiddleware, WebApplicationMiddleware>> _middleware = new();
+
+    public IWebApplicationPipelineBuilder Use(Func<WebApplicationMiddleware, WebApplicationMiddleware> middleware)
+    {
+        _middleware.Add(middleware);
+        return this;
+    }
+
+    public IWebApplicationPipelineBuilder Use(IWebApplicationMiddleware middleware)
+        => Use(next => context => middleware.InvokeAsync(context, next));
+
+    public IWebApplicationPipelineBuilder Use(Func<IWebApplicationContext, WebApplicationMiddleware, WebApplicationMiddleware> middleware)
+        => throw new NotSupportedException();
+
+    public IWebApplicationPipeline Build()
+    {
+        WebApplicationMiddleware pipeline = _ => Task.CompletedTask;
+        for (int i = _middleware.Count - 1; i >= 0; i--)
+        {
+            pipeline = _middleware[i].Invoke(pipeline);
+        }
+
+        return new TestPipeline(pipeline);
+    }
+
+    private sealed class TestPipeline : IWebApplicationPipeline
+    {
+        private readonly WebApplicationMiddleware _middleware;
+
+        public TestPipeline(WebApplicationMiddleware middleware) => _middleware = middleware;
+
+        public Task ExecuteAsync(IHttpContext context, CancellationToken cancellationToken = default)
+            => _middleware.Invoke(context);
+    }
+}
+
+/// <summary>
+/// A configurable <see cref="IHttpContext"/> test double with a readable response body, for
+/// driving the middleware with raw paths an <see cref="System.Net.Http.HttpClient"/> would
+/// normalize away (literal dot segments, backslashes).
+/// </summary>
+internal sealed class TestHttpContext : IHttpContext
+{
+    public TestHttpContext(string path, HttpMethod method)
+    {
+        Request = new TestHttpRequest(this, path, method);
+        Response = new TestHttpResponse(this);
+    }
+
+    public HttpVersion Version => HttpVersion.Http11;
+    public IHttpRequest Request { get; }
+    public IHttpResponse Response { get; }
+    public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
+    public IHttpFeatureCollection Features { get; } = new HttpFeatureCollection();
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+    public CancellationToken RequestCancelled => CancellationToken.None;
+    public void Cancel() { }
+    public Task CancelAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public string ReadResponseBody()
+    {
+        var stream = (MemoryStream)Response.Body;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+}
+
+internal sealed class TestHttpRequest : IHttpRequest
+{
+    public TestHttpRequest(IHttpContext context, string path, HttpMethod method)
+    {
+        HttpContext = context;
+        Path = new HttpPath(path);
+        Method = method;
+    }
+
+    public HttpHost Host => HttpHost.Empty;
+    public HttpPath Path { get; }
+    public HttpMethod Method { get; }
+    public HttpScheme Scheme => HttpScheme.Http;
+    public IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body => Stream.Null;
+}
+
+internal sealed class TestHttpResponse : IHttpResponse
+{
+    public TestHttpResponse(IHttpContext context) => HttpContext = context;
+
+    public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body { get; set; } = new MemoryStream();
+}

--- a/resources/Web/Assimalign.Cohesion.Web.slnx
+++ b/resources/Web/Assimalign.Cohesion.Web.slnx
@@ -161,6 +161,17 @@
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Sessions/tests/">
 		<Project Path="Assimalign.Cohesion.Web.Sessions/tests/Assimalign.Cohesion.Web.Sessions.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.StaticFiles/" />
+	<Folder Name="/Web/Assimalign.Cohesion.Web.StaticFiles/docs/">
+		<File Path="Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md" />
+		<File Path="Assimalign.Cohesion.Web.StaticFiles/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.StaticFiles/src/">
+		<Project Path="Assimalign.Cohesion.Web.StaticFiles/src/Assimalign.Cohesion.Web.StaticFiles.csproj" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.StaticFiles/tests/">
+		<Project Path="Assimalign.Cohesion.Web.StaticFiles/tests/Assimalign.Cohesion.Web.StaticFiles.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Testing/">
 		<File Path="Assimalign.Cohesion.Web.Testing/README.md" />
 	</Folder>

--- a/resources/Web/README.md
+++ b/resources/Web/README.md
@@ -73,6 +73,7 @@ A new `Assimalign.Cohesion.Web.<Feature>` project is not done until all of these
 | `Assimalign.Cohesion.Web.Authentication` / `.Cookie` / `.Bearer` | Scheme model + builder surface, and the handler packages that graft their scheme verbs onto it |
 | `Assimalign.Cohesion.Web.Authorization` | Authorization contracts (in design) |
 | `Assimalign.Cohesion.Web.CookiePolicy` / `.Cors` / `.Forms` / `.Sessions` / `.Health` | Request-pipeline feature libraries over their `Http.*` counterparts |
+| `Assimalign.Cohesion.Web.StaticFiles` | Static file serving over an `IFileSystem` mount: conditional GET, single byte ranges, default documents, content-type mapping, precompressed `.br`/`.gz` negotiation |
 | `Assimalign.Cohesion.Web.Testing` | In-memory test factory for the runtime (sanctioned Web.Hosting reference) |
 | `Assimalign.Cohesion.Web.ApplicationModel` | Placeholder awaiting the ApplicationModel Phase-4 rebuild |
 


### PR DESCRIPTION
## Summary

Builds `resources/Web/Assimalign.Cohesion.Web.StaticFiles` — static file serving over the FileSystem library as a middleware-first feature package (issue [L03.01.01.06]): a `UseStaticFiles(IFileSystem, ...)` verb on `IWebApplicationPipelineBuilder` plus an internal `IWebApplicationMiddleware` that writes responses imperatively (no result types, per the 2026-07-10 middleware-first direction; the #864 edge was dropped with IResult).

The package is a composer of the merged protocol primitives — no RFC semantics are re-derived locally:

- **Conditional GET (#792):** strong `ETag` from `Size`+`UpdatedOn`, `Last-Modified`, `If-None-Match`/`If-Modified-Since` → `304`, `If-Match`/`If-Unmodified-Since` → `412` via `HttpConditionalRequest.Evaluate` (RFC 9110 §13.2.2).
- **Byte ranges (#792):** single satisfiable range → `206` + `Content-Range`; multi-range set → full `200` fallback; unsatisfiable → `416` with `bytes */N`; `If-Range` gates application — all via `HttpRangeSelector`/`HttpIfRange`. `Accept-Ranges: bytes` advertised.
- **Content types (#771):** `HttpContentTypes` frozen map with builder-time overlays; unknown extensions pass through by default (opt-in `ServeUnknownContentTypes` + fallback type).
- **Precompressed siblings (#771):** on-disk `.br`/`.gz` siblings negotiate against `Accept-Encoding` (`HttpContentNegotiation.TrySelectEncoding`, server prefers `br`); served with the logical file's `Content-Type`, the sibling's bytes/validators, `Content-Encoding`, and `Vary: Accept-Encoding` whenever a sibling exists (including identity responses). Preconditions/ranges evaluate against the *negotiated* representation.
- **Builder-time options:** request-path prefix (segment-aligned), default documents with `301` append-slash canonicalization, `Cache-Control` (validated via `HttpCacheControl.TryParse` at composition), content-type overlays, precompression toggle. No DI, no request-time service location.
- **HEAD:** full GET header section (incl. `Content-Length`), no body.

### Path-traversal defense (hard requirement)

Two layers over the decoded path: an explicit gate rejecting dot segments (split on both `/` and `\`), `:` (Windows drive/ADS shapes), and NUL with a terminal `404`; then `FileSystemPath.Parse`, which independently throws on interior dot segments and illegal characters. The mount boundary itself is the backstop — the middleware cannot express a lookup outside the `IFileSystem` root. E2E tests drive encoded attacks (`%2e%2e`, `..%5c`) over the real wire using `DangerousDisablePathAndQueryCanonicalization`.

**Transport gap discovered:** h2/h3 percent-decode the request path at the transport (`HttpPath.FromUriComponent`), but the HTTP/1.1 reader surfaces the raw request-target text — so `%2e%2e` would read as a literal segment on h1 and as `..` on h2/h3. The middleware ships a version-gated decode-once compensation (documented in `docs/DESIGN.md`); the transport parity work is filed as #895 (`[L01.01.11.43]`, under the Http epic), which must remove the compensation in the same change. #895 stays open — the transport fix lands separately.

### Wiring (per `.claude/rules/web-area.md`)

- `frameworks/Assimalign.Cohesion.App.props` — added to the `App.Web` ItemGroup; validated with `dotnet pack` of `App.Web.Runtime` (collection target green). FileSystem deps already ship in the base `App` framework.
- `.github/workflows/resource-web.yml` — added to the CI matrix.
- Both solution files (`resources/Web/...Web.slnx` + root `Assimalign.Cohesion.slnx`).
- `resources/Web/README.md` project-map row; project `docs/OVERVIEW.md` + `docs/DESIGN.md`.
- Hosting isolation holds: references are `Web` root + `Http` + `FileSystem` only (COHRES001/002 guards ran in the full `Web.slnx` build).

### Tests

87 passing (`Assimalign.Cohesion.Web.StaticFiles.Tests`): unit coverage over a fake h1 context (raw `../`, `..\`, encoded forms, prefix alignment, conditional/range/HEAD header semantics, default documents, overlays, Vary behavior, per-representation ETags) plus end-to-end over `WebApplicationTestFactory` (real HTTP/1.1 wire: serve, 304 revalidation, 206/416, HEAD, encoded traversal, precompressed negotiation, redirect-then-serve, downstream pass-through). Full `Assimalign.Cohesion.Web.slnx` build is green.

Deferred (per issue): directory browsing; fingerprinted-asset manifests (behind #28).

### Follow-up filed during this work (stays open)

- #895 `[L01.01.11.43]` HTTP/1.1 request-target percent-decode parity with h2/h3 — the transport-side fix; deletes this package's version-gated decode compensation when it lands.

> Note for sibling Batch-4a sessions: this PR adds one line each to `Assimalign.Cohesion.App.props` and the `resource-web.yml` matrix — trivial rebase if another lands first.

## Work items
Closes #777

<!-- creep: 1 item discovered out-of-scope and filed as follow-up (#895, kept open) -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
