### PR TITLE
[L03.01.01.18] RFC 10008 server-side QUERY handling: Content-Type validation, method-preserving redirects, conditional QUERY

### DIFF
--- a/.github/workflows/resource-web.yml
+++ b/.github/workflows/resource-web.yml
@@ -32,6 +32,7 @@ jobs:
             'Assimalign.Cohesion.Web.Health',
             'Assimalign.Cohesion.Web.Hosting',
             'Assimalign.Cohesion.Web.ProblemDetails',
+            'Assimalign.Cohesion.Web.Query',
             'Assimalign.Cohesion.Web.Routing',
             'Assimalign.Cohesion.Web.Sessions',
             'Assimalign.Cohesion.Web.Testing'

--- a/Assimalign.Cohesion.slnx
+++ b/Assimalign.Cohesion.slnx
@@ -2072,6 +2072,17 @@
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.ProblemDetails/tests/">
 		<Project Path="resources/Web/Assimalign.Cohesion.Web.ProblemDetails/tests/Assimalign.Cohesion.Web.ProblemDetails.Tests.csproj" />
 	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Query/" />
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Query/docs/">
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Query/docs/DESIGN.md" />
+		<File Path="resources/Web/Assimalign.Cohesion.Web.Query/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Query/src/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Query/src/Assimalign.Cohesion.Web.Query.csproj" />
+	</Folder>
+	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Query/tests/">
+		<Project Path="resources/Web/Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj" />
+	</Folder>
 	<Folder Name="/cohesion/resources/Web/Assimalign.Cohesion.Web.Routing/">
 		<File Path="resources/Web/Assimalign.Cohesion.Web.Routing/README.md" />
 	</Folder>

--- a/frameworks/Assimalign.Cohesion.App.props
+++ b/frameworks/Assimalign.Cohesion.App.props
@@ -164,6 +164,7 @@
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Health" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Hosting" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.ProblemDetails" />
+        <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Query" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Routing" />
         <CohesionFrameworkAssembly Include="Assimalign.Cohesion.Web.Sessions" />
 

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/docs/DESIGN.md
@@ -1,0 +1,96 @@
+# Assimalign.Cohesion.Http.ClientFactory — Design
+
+## Design intent
+
+Solve the classic `HttpClient` lifetime trade-off once, in one place: callers may freely
+`using`-dispose the clients they receive (no ephemeral-port exhaustion), while the underlying
+`SocketsHttpHandler` — and therefore the connection pool and DNS/TLS session state — is shared
+per name and refreshed on a bounded rotation. The factory is deliberately a small, DI-free
+builder + factory pair: composition happens at build time on `HttpClientFactoryBuilder`, and the
+`*.Hosting` layer (not this library) decides how the factory is surfaced to applications.
+
+## Why this shape and not another
+
+- **Rotating handler pool, not per-call handlers.** A handler per `Create` call exhausts
+  sockets; a process-lifetime singleton pins DNS results and TLS sessions forever. The pool
+  gives each name one active handler inside a lifetime window (`HandlerLifetime`, default two
+  minutes): every `Create` inside the window reuses it, and rotation bounds how stale
+  resolution state can get. Rotation is compare-and-swap over a `ConcurrentDictionary` with a
+  per-name lock so handler construction is single-flight under load.
+- **`LifetimeTrackingHttpMessageHandler` wrappers, not reference counting.** Each returned
+  `HttpClient` owns a lightweight wrapper (`disposeHandler: true`) that does *not* propagate
+  disposal to the shared inner handler. Expired handlers are kept on an expired list and
+  disposed only when garbage collection proves no wrapper (and so no client) still references
+  them — no manual release call for consumers to forget.
+- **Builder + options objects, not a DI container.** Named registration is a dictionary of
+  `NamedHttpClientOptions` captured at `Build()`. This matches the repo-wide rule that only
+  `*.Hosting` modules integrate DI; everything here is plain values and delegates, AOT-safe.
+
+## Redirect policy is factory-owned (RFC 10008 § 2.5)
+
+Automatic redirect following lives in the factory's own `RedirectHttpMessageHandler`
+(a `DelegatingHandler` wrapped around the pooled inner handler), not in
+`SocketsHttpHandler.AllowAutoRedirect` — which the factory always forces **off** so exactly one
+layer acts.
+
+**Why own it rather than delegate to the BCL:**
+
+- **The method semantics are load-bearing.** RFC 10008 § 2.5 requires that a redirected QUERY
+  be re-issued as a QUERY with its original content on `301`/`302`/`307`/`308` — never silently
+  rewritten to GET — while § 2.5.3 sanctions exactly one method switch: `303 See Other` is
+  fulfilled with a GET on the Location URI. Owning the layer makes those semantics an explicit,
+  tested contract of this library rather than an implementation detail of whatever inner
+  handler happens to be pooled.
+- **Uniformity across inner handlers.** `HandlerFactory`-injected handlers (tests, custom
+  stacks) get the same redirect behavior as the default `SocketsHttpHandler` path, and the
+  policy is unit-testable with a scripted terminal handler — no wire, no sockets.
+- **One switch.** `NamedHttpClientOptions.AllowAutoRedirect` / `MaxAutomaticRedirections` are
+  the only redirect knobs. Configuring redirects through `ConfigureHandler` is documented as
+  ineffective (the inner value is forced off after the callback runs) — the alternative, honoring
+  the inner setting, would mean two layers that can silently double-follow.
+
+**The rules the handler implements** (mirroring RFC 9110 § 15.4 and the BCL's safety posture):
+
+| Status | Behavior |
+|---|---|
+| `301` / `302` | Re-issue with method + content preserved; the historical POST→GET rewrite is preserved for POST only |
+| `303` | Re-issue as GET, content dropped (the one sanctioned switch — RFC 10008 § 2.5.3) |
+| `307` / `308` | Re-issue with method + content preserved (the statuses forbid rewriting) |
+| `300` | Never followed — choosing among alternatives is the caller's decision |
+
+Plus: relative `Location` values resolve against the current request URI; an `https`→`http`
+downgrade is never followed (the raw `3xx` surfaces); the `Authorization` field is dropped on
+every hop; exceeding `MaxAutomaticRedirections` stops following and returns the last `3xx`;
+intermediate responses are disposed.
+
+**Accepted constraint:** a followed redirect re-serializes the same `HttpContent` instance, so
+buffered contents (`ByteArrayContent`, `StringContent`, `JsonContent`) ride redirects while
+one-shot contents (`StreamContent` over a non-seekable stream) cannot — the same constraint the
+BCL's built-in redirect handling carries. The factory does not buffer request bodies on the
+caller's behalf.
+
+## Lifecycle pattern
+
+The factory is `IDisposable`/`IAsyncDisposable` and owns every pooled handler: disposal at
+application shutdown disposes the active and expired handlers. The redirect wrapper participates
+naturally — `DelegatingHandler.Dispose` propagates to the inner handler it wraps, and the
+per-client lifetime-tracking wrapper never propagates disposal inward.
+
+## Error model
+
+No library-specific exception types. Misuse throws BCL exceptions from the guard clauses
+(`ArgumentException`, `InvalidOperationException`, `ObjectDisposedException`); wire and protocol
+failures surface as the BCL's `HttpRequestException` family, untranslated.
+
+## AOT posture
+
+No reflection, no dynamic code, no serialization — plain delegates and BCL types end to end.
+
+## Non-goals
+
+- **No request resilience** (retries, circuit breaking, hedging): compose a policy handler via
+  `HandlerFactory`/`ConfigureHandler`; the factory stays a lifetime manager.
+- **No cookie-jar or cache management**: those belong to the inner handler's configuration.
+- **No automatic `300 Multiple Choices` navigation** and **no fragment inheritance** on
+  redirects — both are user-agent decisions, not client-library mechanics.
+- **No DI surface**: hosting layers own how factories reach application code.

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/docs/OVERVIEW.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/docs/OVERVIEW.md
@@ -1,0 +1,48 @@
+# Assimalign.Cohesion.Http.ClientFactory — Overview
+
+A lifecycle-managed factory for named `System.Net.Http.HttpClient` instances. Applications
+register named clients on `HttpClientFactoryBuilder` (base address, timeout, default headers,
+handler tuning), build an `IHttpClientFactory`, and call `Create(name)` wherever a client is
+needed — disposing the returned client freely without exhausting ephemeral ports.
+
+## Scope
+
+- **Named client registration** — per-name `NamedHttpClientOptions`: `BaseAddress`,
+  `RequestTimeout`, `ConfigureDefaultHeaders`, `ConfigureHandler` (SocketsHttpHandler tuning),
+  `HandlerFactory` (test/stub injection), and the redirect policy
+  (`AllowAutoRedirect`, `MaxAutomaticRedirections`).
+- **Handler pooling and rotation** — one shared `HttpMessageHandler` per name inside a lifetime
+  window (`HandlerLifetime`, default two minutes); rotation refreshes DNS/TLS state, and expired
+  handlers are disposed once no client references them.
+- **Automatic redirects** — a factory-owned redirect layer with RFC 10008 § 2.5 method
+  semantics: QUERY (and every non-POST method) is re-issued with its content on
+  `301`/`302`/`307`/`308`; `303 See Other` is fulfilled with a GET; the historical POST→GET
+  rewrite on `301`/`302` is preserved.
+
+## Dependencies
+
+`Assimalign.Cohesion.Http` (the protocol core) plus the BCL `System.Net.Http` stack the clients
+ride. This is a client-side library: it does not depend on the server transport
+(`Http.Connections`) or any Web-area project.
+
+## Usage
+
+```csharp
+IHttpClientFactory factory = new HttpClientFactoryBuilder()
+    .AddClient("search", options =>
+    {
+        options.BaseAddress = new Uri("https://api.example.com");
+        options.RequestTimeout = TimeSpan.FromSeconds(10);
+    })
+    .Build();
+
+using HttpClient client = factory.Create("search");
+using var query = new HttpRequestMessage(new HttpMethod("QUERY"), "/items")
+{
+    Content = new StringContent("{\"q\":\"cohesion\"}", Encoding.UTF8, "application/json"),
+};
+using HttpResponseMessage response = await client.SendAsync(query, cancellationToken);
+```
+
+Design rationale (handler pooling shape, redirect-policy ownership, non-goals) lives in
+[DESIGN.md](DESIGN.md).

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/Internal/HttpClientFactory.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/Internal/HttpClientFactory.cs
@@ -193,7 +193,17 @@ internal sealed class HttpClientFactory : IHttpClientFactory, IDisposable, IAsyn
         {
             var sockets = new SocketsHttpHandler();
             clientOptions.ConfigureHandler?.Invoke(sockets);
+
+            // Redirect policy is owned by the factory's redirect layer (RFC 10008 §2.5 method
+            // semantics), switched via NamedHttpClientOptions.AllowAutoRedirect — the inner
+            // handler must never double-follow, so its own following is always off.
+            sockets.AllowAutoRedirect = false;
             handler = sockets;
+        }
+
+        if (clientOptions.AllowAutoRedirect)
+        {
+            handler = new RedirectHttpMessageHandler(handler, clientOptions.MaxAutomaticRedirections);
         }
 
         return new ActiveHandlerEntry(handler, now + lifetime);

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/Internal/RedirectHttpMessageHandler.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/Internal/RedirectHttpMessageHandler.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.Internal;
+
+// The BCL message-pipeline types, not the Cohesion protocol value objects this namespace
+// otherwise surfaces — the client factory rides System.Net.Http end to end.
+using HttpMethod = System.Net.Http.HttpMethod;
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+/// <summary>
+/// The factory-owned automatic-redirect layer (RFC 9110 &#167; 15.4, RFC 10008 &#167; 2.5).
+/// Follows <c>301</c>/<c>302</c>/<c>303</c>/<c>307</c>/<c>308</c> responses, re-issuing the
+/// request with its method and content preserved except where the protocol sanctions a switch:
+/// <c>303 See Other</c> is fulfilled with a GET (the one intended method change for QUERY,
+/// RFC 10008 &#167; 2.5.3), and the historical POST&#8594;GET rewrite is preserved for POST on
+/// <c>301</c>/<c>302</c>. Every other method — QUERY in particular — is never downgraded to GET.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Owning the policy here (rather than on the inner <see cref="SocketsHttpHandler"/>) makes the
+/// redirect semantics uniform across every handler the factory pools — including test-injected
+/// ones — and testable without a wire. The factory disables the inner handler's own redirect
+/// following so exactly one layer acts.
+/// </para>
+/// <para>
+/// Mirrored safety behavior: the <c>Authorization</c> field is dropped on every hop (credentials
+/// are not forwarded across an automatic redirect), an <c>https</c>&#8594;<c>http</c> downgrade is
+/// never followed, a hop past the configured cap stops following and surfaces the last <c>3xx</c>,
+/// and <c>300 Multiple Choices</c> is never followed automatically (choosing among alternatives
+/// is the caller's decision). Preserved content is re-serialized from the same
+/// <see cref="HttpContent"/> instance, so one-shot contents (e.g. <see cref="StreamContent"/>)
+/// cannot ride an automatic redirect — the same constraint the BCL's built-in handling carries.
+/// </para>
+/// </remarks>
+internal sealed class RedirectHttpMessageHandler : DelegatingHandler
+{
+    private readonly int _maxAutomaticRedirections;
+
+    public RedirectHttpMessageHandler(HttpMessageHandler innerHandler, int maxAutomaticRedirections)
+        : base(innerHandler)
+    {
+        _maxAutomaticRedirections = maxAutomaticRedirections;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        int redirectCount = 0;
+        Uri? location;
+        while ((location = GetRedirectTarget(request, response)) is not null)
+        {
+            if (++redirectCount > _maxAutomaticRedirections)
+            {
+                // Stop following; the caller receives the redirect it can act on itself.
+                break;
+            }
+
+            HttpStatusCode statusCode = response.StatusCode;
+            response.Dispose();
+
+            request.RequestUri = location;
+
+            // RFC 9110 §15.4 — credentials are not forwarded across an automatic redirect.
+            request.Headers.Authorization = null;
+
+            if (RequiresForceGet(statusCode, request.Method))
+            {
+                request.Method = HttpMethod.Get;
+                request.Content = null;
+                if (request.Headers.TransferEncodingChunked == true)
+                {
+                    request.Headers.TransferEncodingChunked = false;
+                }
+            }
+
+            response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    private static Uri? GetRedirectTarget(HttpRequestMessage request, HttpResponseMessage response)
+    {
+        switch ((int)response.StatusCode)
+        {
+            case 301 or 302 or 303 or 307 or 308:
+                break;
+            default:
+                return null;
+        }
+
+        Uri? location = response.Headers.Location;
+        Uri? requestUri = request.RequestUri;
+        if (location is null || requestUri is null)
+        {
+            return null;
+        }
+
+        if (!location.IsAbsoluteUri)
+        {
+            location = new Uri(requestUri, location);
+        }
+
+        // Never step down from https to http on the caller's behalf.
+        if (string.Equals(requestUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(location.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return location;
+    }
+
+    private static bool RequiresForceGet(HttpStatusCode statusCode, HttpMethod method)
+        => statusCode switch
+        {
+            // RFC 9110 §15.4.4 — 303 See Other is fulfilled with a GET on the Location URI; for
+            // QUERY this is the one sanctioned method switch (RFC 10008 §2.5.3).
+            HttpStatusCode.SeeOther => method != HttpMethod.Get && method != HttpMethod.Head,
+
+            // RFC 9110 §15.4.2 / §15.4.3 — the historical rewrite on 301/302 applies to POST
+            // only. Every other method — QUERY per RFC 10008 §2.5 — keeps method and content.
+            HttpStatusCode.Moved or HttpStatusCode.Found => method == HttpMethod.Post,
+
+            _ => false,
+        };
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/NamedHttpClientOptions.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/src/NamedHttpClientOptions.cs
@@ -25,10 +25,54 @@ namespace Assimalign.Cohesion.Http;
 /// </remarks>
 public sealed class NamedHttpClientOptions
 {
+    private int _maxAutomaticRedirections = 50;
+
     /// <summary>
     /// Optional base address applied to every <see cref="HttpClient"/> created for this name.
     /// </summary>
     public Uri? BaseAddress { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether clients created for this name follow <c>3xx</c> redirects
+    /// automatically. Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property is the single owner of redirect policy for the name: the factory follows
+    /// redirects in its own handler layer — with RFC 10008 &#167; 2.5 method semantics (QUERY is
+    /// re-issued with its original content on <c>301</c>/<c>302</c>/<c>307</c>/<c>308</c> and
+    /// switched to GET only by <c>303 See Other</c>; the historical POST&#8594;GET rewrite on
+    /// <c>301</c>/<c>302</c> is preserved) — and always disables
+    /// <see cref="System.Net.Http.SocketsHttpHandler.AllowAutoRedirect"/> on the pooled inner
+    /// handler so exactly one layer acts. Set this to <see langword="false"/> to surface raw
+    /// <c>3xx</c> responses; configuring redirects through <see cref="ConfigureHandler"/> instead
+    /// has no effect.
+    /// </para>
+    /// <para>
+    /// A followed redirect re-serializes the same <see cref="System.Net.Http.HttpContent"/>
+    /// instance, so buffered contents (<see cref="System.Net.Http.ByteArrayContent"/>,
+    /// <see cref="System.Net.Http.StringContent"/>, &#8230;) ride redirects while one-shot
+    /// contents (e.g. <see cref="System.Net.Http.StreamContent"/>) cannot — the same constraint
+    /// the BCL's built-in redirect handling carries.
+    /// </para>
+    /// </remarks>
+    public bool AllowAutoRedirect { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of redirects followed per request when
+    /// <see cref="AllowAutoRedirect"/> is enabled. Exceeding the cap stops following and returns
+    /// the last <c>3xx</c> response. Defaults to 50.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a non-positive value.</exception>
+    public int MaxAutomaticRedirections
+    {
+        get => _maxAutomaticRedirections;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _maxAutomaticRedirections = value;
+        }
+    }
 
     /// <summary>
     /// Optional request timeout applied to every <see cref="HttpClient"/> created for this
@@ -58,7 +102,11 @@ public sealed class NamedHttpClientOptions
     /// </summary>
     /// <remarks>
     /// Ignored when <see cref="HandlerFactory"/> is set &#8211; tests and consumers that
-    /// supply their own handler instance own configuration entirely.
+    /// supply their own handler instance own configuration entirely. Redirect policy is the one
+    /// setting this callback cannot own: the factory forces the inner handler's
+    /// <see cref="System.Net.Http.SocketsHttpHandler.AllowAutoRedirect"/> off after the callback
+    /// runs and follows redirects in its own layer &#8212; configure redirects through
+    /// <see cref="AllowAutoRedirect"/> / <see cref="MaxAutomaticRedirections"/> instead.
     /// </remarks>
     public Action<System.Net.Http.SocketsHttpHandler>? ConfigureHandler { get; set; }
 
@@ -67,5 +115,10 @@ public sealed class NamedHttpClientOptions
     /// the default <see cref="System.Net.Http.SocketsHttpHandler"/>. Tests inject this to
     /// substitute a stub or counting handler; production code rarely needs it.
     /// </summary>
+    /// <remarks>
+    /// The factory's redirect layer wraps the returned handler while
+    /// <see cref="AllowAutoRedirect"/> is enabled; a supplied handler that performs its own
+    /// redirect following should disable one or the other so exactly one layer acts.
+    /// </remarks>
     public Func<HttpMessageHandler>? HandlerFactory { get; set; }
 }

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/tests/RedirectHandlingTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/tests/RedirectHandlingTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.ClientFactory.Tests;
+
+// The BCL pipeline types — the enclosing Assimalign.Cohesion.Http namespace would otherwise
+// shadow them with the Cohesion protocol value objects.
+using HttpMethod = System.Net.Http.HttpMethod;
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+/// <summary>
+/// RFC 10008 &#167; 2.5 / RFC 9110 &#167; 15.4 compliance tests for the factory-owned automatic
+/// redirect layer: QUERY is re-issued (never rewritten to GET) with its original content on
+/// <c>301</c>/<c>302</c>/<c>307</c>/<c>308</c>, <c>303 See Other</c> is fulfilled with a GET,
+/// the legacy POST rewrite is preserved, and the safety rules (credential stripping, downgrade
+/// refusal, hop cap) hold.
+/// </summary>
+public class RedirectHandlingTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly HttpMethod QueryMethod = new("QUERY");
+
+    private static HttpClient CreateClient(
+        ScriptedRedirectHandler handler,
+        Action<NamedHttpClientOptions>? configure = null)
+    {
+        IHttpClientFactory factory = new HttpClientFactoryBuilder()
+            .AddClient("api", options =>
+            {
+                options.HandlerFactory = () => handler;
+                configure?.Invoke(options);
+            })
+            .Build();
+
+        return factory.Create("api");
+    }
+
+    private static HttpRequestMessage CreateQuery(string uri, string content = "{\"q\":\"cohesion\"}")
+        => new(QueryMethod, uri)
+        {
+            Content = new StringContent(content, System.Text.Encoding.UTF8, "application/json"),
+        };
+
+    [Theory(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: QUERY is re-issued with its content on 301/302/307/308 (RFC 10008 §2.5)")]
+    [InlineData(HttpStatusCode.Moved)]
+    [InlineData(HttpStatusCode.Found)]
+    [InlineData(HttpStatusCode.RedirectKeepVerb)]
+    [InlineData(HttpStatusCode.PermanentRedirect)]
+    public async Task SendAsync_QueryRedirected_ShouldReissueQueryWithContent(HttpStatusCode statusCode)
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(statusCode, "https://origin.example/search-v2")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert — the follow-up hop is a QUERY carrying the original content to the Location URI.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[1].Method.ShouldBe("QUERY");
+        handler.Requests[1].Uri.ShouldBe(new Uri("https://origin.example/search-v2"));
+        handler.Requests[1].Content.ShouldBe("{\"q\":\"cohesion\"}");
+        handler.Requests[1].ContentType.ShouldNotBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: 303 See Other switches QUERY to a GET without content (RFC 10008 §2.5.3)")]
+    public async Task SendAsync_QueryRedirectedWith303_ShouldFollowWithGetWithoutContent()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.SeeOther, "https://origin.example/results/42")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert — the one sanctioned method switch: GET on the Location URI, no content.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[1].Method.ShouldBe("GET");
+        handler.Requests[1].Uri.ShouldBe(new Uri("https://origin.example/results/42"));
+        handler.Requests[1].Content.ShouldBeNull();
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: the legacy POST rewrite to GET on 301/302 is preserved")]
+    [InlineData(HttpStatusCode.Moved)]
+    [InlineData(HttpStatusCode.Found)]
+    public async Task SendAsync_PostRedirected_ShouldRewriteToGet(HttpStatusCode statusCode)
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(statusCode, "https://origin.example/moved")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/form")
+        {
+            Content = new StringContent("a=1"),
+        };
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — RFC 9110 §15.4.2/§15.4.3: the historical rewrite applies to POST alone.
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[1].Method.ShouldBe("GET");
+        handler.Requests[1].Content.ShouldBeNull();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: 307 preserves POST with content")]
+    public async Task SendAsync_PostRedirectedWith307_ShouldPreservePost()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.RedirectKeepVerb, "https://origin.example/retry")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/form")
+        {
+            Content = new StringContent("a=1"),
+        };
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[1].Method.ShouldBe("POST");
+        handler.Requests[1].Content.ShouldBe("a=1");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: a relative Location resolves against the request URI")]
+    public async Task SendAsync_RelativeLocation_ShouldResolveAgainstRequestUri()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.RedirectKeepVerb, "/search-v2?page=1")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/api/search"), cancellation.Token);
+
+        // Assert
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[1].Uri.ShouldBe(new Uri("https://origin.example/search-v2?page=1"));
+        handler.Requests[1].Method.ShouldBe("QUERY");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: an https to http downgrade is not followed")]
+    public async Task SendAsync_HttpsToHttpRedirect_ShouldNotFollow()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.RedirectKeepVerb, "http://origin.example/insecure");
+        using HttpClient client = CreateClient(handler);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert — the raw redirect surfaces; only the original request was sent.
+        response.StatusCode.ShouldBe(HttpStatusCode.RedirectKeepVerb);
+        handler.Requests.Count.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: the Authorization field is dropped on the redirected hop")]
+    public async Task SendAsync_RedirectWithAuthorization_ShouldDropCredential()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.RedirectKeepVerb, "https://elsewhere.example/search")
+            .EnqueueOk();
+        using HttpClient client = CreateClient(handler);
+        HttpRequestMessage request = CreateQuery("https://origin.example/search");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        handler.Requests.Count.ShouldBe(2);
+        handler.Requests[0].HasAuthorization.ShouldBeTrue();
+        handler.Requests[1].HasAuthorization.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: exceeding MaxAutomaticRedirections returns the last redirect")]
+    public async Task SendAsync_RedirectChainPastCap_ShouldReturnLastRedirect()
+    {
+        // Arrange — three redirects with a cap of two: the third 3xx surfaces to the caller.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.Moved, "https://origin.example/1")
+            .EnqueueRedirect(HttpStatusCode.Moved, "https://origin.example/2")
+            .EnqueueRedirect(HttpStatusCode.Moved, "https://origin.example/3");
+        using HttpClient client = CreateClient(handler, options => options.MaxAutomaticRedirections = 2);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Moved);
+        handler.Requests.Count.ShouldBe(3);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: AllowAutoRedirect=false surfaces the raw 3xx")]
+    public async Task SendAsync_AutoRedirectDisabled_ShouldReturnRawRedirect()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.PermanentRedirect, "https://origin.example/search-v2");
+        using HttpClient client = CreateClient(handler, options => options.AllowAutoRedirect = false);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.PermanentRedirect);
+        response.Headers.Location.ShouldBe(new Uri("https://origin.example/search-v2"));
+        handler.Requests.Count.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: a 3xx without a Location field is not followed")]
+    public async Task SendAsync_RedirectWithoutLocation_ShouldNotFollow()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        var handler = new ScriptedRedirectHandler()
+            .EnqueueRedirect(HttpStatusCode.Found, location: null);
+        using HttpClient client = CreateClient(handler);
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("https://origin.example/search"), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        handler.Requests.Count.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.ClientFactory] - Redirect: MaxAutomaticRedirections rejects non-positive values")]
+    public void MaxAutomaticRedirections_NonPositive_ShouldThrow()
+    {
+        var options = new NamedHttpClientOptions();
+
+        Should.Throw<ArgumentOutOfRangeException>(() => options.MaxAutomaticRedirections = 0);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/tests/TestObjects/ScriptedRedirectHandler.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.ClientFactory/tests/TestObjects/ScriptedRedirectHandler.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Http.ClientFactory.Tests;
+
+// The BCL pipeline types — the enclosing Assimalign.Cohesion.Http namespace would otherwise
+// shadow them with the Cohesion protocol value objects.
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+/// <summary>
+/// A request observed by <see cref="ScriptedRedirectHandler"/>, snapshotted at send time —
+/// the redirect layer mutates the live <see cref="HttpRequestMessage"/> between hops, so each
+/// hop's method, target, content, and credential presence must be captured as it happens.
+/// </summary>
+internal sealed record RecordedRequest(
+    string Method,
+    Uri? Uri,
+    string? Content,
+    string? ContentType,
+    bool HasAuthorization);
+
+/// <summary>
+/// A scripted terminal <see cref="HttpMessageHandler"/>: answers each send with the next queued
+/// response and records every request it observes. Stands in for the wire under the factory's
+/// redirect layer.
+/// </summary>
+internal sealed class ScriptedRedirectHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _script = new();
+
+    public List<RecordedRequest> Requests { get; } = new();
+
+    public ScriptedRedirectHandler Enqueue(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _script.Enqueue(responder);
+        return this;
+    }
+
+    public ScriptedRedirectHandler EnqueueRedirect(HttpStatusCode statusCode, string? location)
+        => Enqueue(_ =>
+        {
+            var response = new HttpResponseMessage(statusCode);
+            if (location is not null)
+            {
+                response.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+            }
+            return response;
+        });
+
+    public ScriptedRedirectHandler EnqueueOk()
+        => Enqueue(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        string? content = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        Requests.Add(new RecordedRequest(
+            request.Method.Method,
+            request.RequestUri,
+            content,
+            request.Content?.Headers.ContentType?.ToString(),
+            request.Headers.Authorization is not null));
+
+        Func<HttpRequestMessage, HttpResponseMessage> responder = _script.Count > 0
+            ? _script.Dequeue()
+            : static _ => new HttpResponseMessage(HttpStatusCode.OK);
+
+        return responder.Invoke(request);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1RequestBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1RequestBodyStream.cs
@@ -123,7 +123,11 @@ internal sealed class Http1RequestBodyStream : Stream
         _timeProvider = timeProvider;
         _connectionToken = connectionToken;
         _trailers = trailers;
-        _completed = framing.Mode == Http1RequestBodyMode.None;
+        // A `Content-Length: 0` body is born fully read: without this, the first read would issue
+        // a zero-length wire read that blocks for octets the peer never sends, until the data-rate
+        // gate reclaims the exchange (408) — for a request that is perfectly healthy.
+        _completed = framing.Mode == Http1RequestBodyMode.None
+            || (framing.Mode == Http1RequestBodyMode.ContentLength && framing.ContentLength == 0);
     }
 
     /// <summary>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http1RequestBodyDataRateTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http1RequestBodyDataRateTests.cs
@@ -80,6 +80,28 @@ public class Http1RequestBodyDataRateTests
         (await reader.ReadToEndAsync()).ShouldBe("hello");
     }
 
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http1 DataRate: A Content-Length of zero should read as an already-empty body")]
+    public async Task Http1_WithZeroContentLength_ShouldReadAsEmptyBody()
+    {
+        // A `Content-Length: 0` body is born fully read. Before the fix, the first read issued a
+        // zero-length wire read that blocked for octets the peer never sends until the data-rate
+        // gate reclaimed the exchange — with an aggressive rate configured, this read must still
+        // complete immediately and empty.
+        byte[] head = Encoding.ASCII.GetBytes(
+            "QUERY /search HTTP/1.1\r\nHost: api.test\r\nContent-Length: 0\r\n\r\n");
+        HttpConnectionListenerOptions options = new();
+        TestConnection connection = new(head, completeInput: false);
+        options.UseHttp1(new TestConnectionListener(connection), http1 =>
+            http1.Limits.MinRequestBodyDataRate = new HttpMinDataRate(bytesPerSecond: 1000, gracePeriod: TimeSpan.FromMilliseconds(100)));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext context = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        IHttpContext httpContext = await ReadSingleContextAsync(context);
+
+        using StreamReader reader = new(httpContext.Request.Body);
+        (await reader.ReadToEndAsync().WaitAsync(TimeSpan.FromSeconds(10))).ShouldBe(string.Empty);
+    }
+
     private static async Task<IHttpContext> ReadSingleContextAsync(IHttpConnectionContext context)
     {
         await using IAsyncEnumerator<IHttpContext> enumerator = context.ReceiveAsync().GetAsyncEnumerator();

--- a/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http/docs/DESIGN.md
@@ -673,8 +673,12 @@ beside `Http.Sessions`/`Http.Forms`:
   then `If-Modified-Since` only when `If-None-Match` is absent and the method is
   a read). This encodes the two rules the feature calls out: `If-None-Match`
   takes precedence over `If-Modified-Since`, and a failed read precondition is
-  `304` for GET/HEAD but `412` otherwise. Resource existence (for the `*`
-  wildcard) is inferred from a supplied validator, with an explicit
+  `304` for the read methods but `412` otherwise. The read methods are GET and
+  HEAD plus QUERY: RFC 10008 §2.6 requires a conditional QUERY to be evaluated
+  exactly as the equivalent conditional GET (same selected representation, `304`
+  where a GET would produce one), so the method classification lives here in the
+  evaluator rather than being re-derived by each consumer. Resource existence
+  (for the `*` wildcard) is inferred from a supplied validator, with an explicit
   `HasCurrentRepresentation` escape hatch for the rare validator-less resource.
 
 ### Why value objects and static helpers, not interfaces

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpConditionalRequest.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpConditionalRequest.cs
@@ -20,8 +20,11 @@ namespace Assimalign.Cohesion.Http;
 /// <para>
 /// The ordering encodes two rules the acceptance criteria call out: <c>If-None-Match</c> takes
 /// precedence over <c>If-Modified-Since</c> (a present <c>If-None-Match</c> suppresses the
-/// <c>If-Modified-Since</c> check), and a failed read precondition yields <c>304</c> for
-/// <c>GET</c>/<c>HEAD</c> but <c>412</c> for any other method.
+/// <c>If-Modified-Since</c> check), and a failed read precondition yields <c>304</c> for the read
+/// methods but <c>412</c> for any other method. The read methods are <c>GET</c> and <c>HEAD</c>
+/// (RFC 9110 &#167; 13.1.2) plus <c>QUERY</c> — RFC 10008 &#167; 2.6 requires a conditional QUERY to
+/// be evaluated exactly as the equivalent conditional GET, selecting the same representation and
+/// producing <c>304</c> where a GET would.
 /// </para>
 /// </remarks>
 public static class HttpConditionalRequest
@@ -84,5 +87,5 @@ public static class HttpConditionalRequest
     }
 
     private static bool IsReadMethod(HttpMethod method)
-        => method == HttpMethod.Get || method == HttpMethod.Head;
+        => method == HttpMethod.Get || method == HttpMethod.Head || method == HttpMethod.Query;
 }

--- a/libraries/Http/Assimalign.Cohesion.Http/src/HttpConditionalRequestContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/src/HttpConditionalRequestContext.cs
@@ -17,8 +17,9 @@ namespace Assimalign.Cohesion.Http;
 public readonly struct HttpConditionalRequestContext
 {
     /// <summary>
-    /// Gets the request method. <c>GET</c> and <c>HEAD</c> are the read methods for which a failed
-    /// <c>If-None-Match</c> / <c>If-Modified-Since</c> yields <c>304</c> rather than <c>412</c>.
+    /// Gets the request method. <c>GET</c>, <c>HEAD</c>, and <c>QUERY</c> (RFC 10008 &#167; 2.6) are
+    /// the read methods for which a failed <c>If-None-Match</c> / <c>If-Modified-Since</c> yields
+    /// <c>304</c> rather than <c>412</c>.
     /// </summary>
     public required HttpMethod Method { get; init; }
 

--- a/libraries/Http/Assimalign.Cohesion.Http/tests/Caching/HttpConditionalRequestTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http/tests/Caching/HttpConditionalRequestTests.cs
@@ -248,4 +248,76 @@ public class HttpConditionalRequestTests
 
         HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.Proceed);
     }
+
+    // ============================================================================
+    // Conditional QUERY behaves like conditional GET (RFC 10008 §2.6)
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpConditionalRequest: If-None-Match match on QUERY is 304 (RFC 10008 §2.6)")]
+    public void Evaluate_IfNoneMatchMatchesOnQuery_ShouldBeNotModified()
+    {
+        // QUERY is a read method: a matching If-None-Match yields 304 exactly as it would for the
+        // equivalent GET — not the 412 a non-read method receives.
+        var context = new HttpConditionalRequestContext
+        {
+            Method = HttpMethod.Query,
+            ETag = CurrentTag,
+            IfNoneMatch = HttpEntityTagCondition.Parse("\"v2\""),
+        };
+
+        HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.NotModified);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpConditionalRequest: If-Modified-Since not modified on QUERY is 304 (RFC 10008 §2.6)")]
+    public void Evaluate_IfModifiedSinceNotModifiedOnQuery_ShouldBeNotModified()
+    {
+        // Step 4 applies to read methods only; QUERY qualifies per RFC 10008 §2.6.
+        var context = new HttpConditionalRequestContext
+        {
+            Method = HttpMethod.Query,
+            LastModified = LastModified,
+            IfModifiedSince = LastModified,
+        };
+
+        HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.NotModified);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpConditionalRequest: If-Match no match on QUERY is 412")]
+    public void Evaluate_IfMatchNoMatchOnQuery_ShouldBePreconditionFailed()
+    {
+        var context = new HttpConditionalRequestContext
+        {
+            Method = HttpMethod.Query,
+            ETag = CurrentTag,
+            IfMatch = HttpEntityTagCondition.Parse("\"v1\""),
+        };
+
+        HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.PreconditionFailed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpConditionalRequest: If-Unmodified-Since modified on QUERY is 412")]
+    public void Evaluate_IfUnmodifiedSinceModifiedOnQuery_ShouldBePreconditionFailed()
+    {
+        var context = new HttpConditionalRequestContext
+        {
+            Method = HttpMethod.Query,
+            LastModified = LastModified,
+            IfUnmodifiedSince = LastModified.AddSeconds(-60),
+        };
+
+        HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.PreconditionFailed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http] - HttpConditionalRequest: QUERY no-match If-None-Match proceeds")]
+    public void Evaluate_IfNoneMatchNoMatchOnQuery_ShouldProceed()
+    {
+        var context = new HttpConditionalRequestContext
+        {
+            Method = HttpMethod.Query,
+            ETag = CurrentTag,
+            IfNoneMatch = HttpEntityTagCondition.Parse("\"v1\""),
+        };
+
+        HttpConditionalRequest.Evaluate(context).ShouldBe(HttpPreconditionOutcome.Proceed);
+    }
 }

--- a/resources/Web/Assimalign.Cohesion.Web.Query/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/docs/DESIGN.md
@@ -1,0 +1,137 @@
+# Assimalign.Cohesion.Web.Query — Design
+
+## Design intent
+
+RFC 10008 splits cleanly along the repo's delineation rule (`libraries/Http/…/docs/DESIGN.md`,
+*"mechanisms live at the lowest level that can observe what they need; decisions live at the
+application level"*). The mechanisms — the method token and its classification, the
+`Accept-Query` field model, media-range matching, the § 13.2.2 precondition evaluator — are core
+`Assimalign.Cohesion.Http` value objects (#746, #771, #755/#792). What remained of the RFC's
+MUST-level server rules are *decisions*: which status rejects an untyped query, what a resource
+accepts and produces, how a redirect is shaped, whether a precondition resolves the exchange.
+This package is where those decisions live, as Web middleware and imperative response helpers.
+
+## The interceptor-vs-middleware decision (§ 2.1 / § 2.3 enforcement)
+
+The umbrella work item left open whether the *generic* refusal — "query content MUST declare a
+Content-Type" — should ride a parse-time `IHttpExchangeInterceptor` (throwing the typed
+`HttpRequestRejectedException`) with only the per-resource negotiation as middleware. **Decided:
+both halves are one Web middleware (`UseQueryValidation`); no transport interceptor.** Why:
+
+- **A rejection is not proportionate here.** `HttpRequestRejectedException` answers with a
+  minimal response and then **closes the connection** — by contract, because a parse-path
+  rejection leaves the wire state indeterminate. A QUERY with a missing or malformed
+  `Content-Type` is *well-framed*: the transport knows exactly where the message ends, nothing
+  about the exchange is hazardous, and killing an HTTP/1.1 keep-alive (or forcing h2 stream
+  churn) for a routine `4xx` punishes conforming clients sharing the connection.
+- **The two halves share one policy.** "Missing type → 400 or 415" is configurable per
+  resource, and "type outside the accepted set → 415" *is* the per-resource half. Splitting
+  them across a listener-wide transport seam and a per-app middleware would put one 400/415
+  line in two places with two scopes.
+- **The delineation rule points the same way.** Refusing to process a parseable, well-framed
+  request is a policy about the *application's* resources, not a wire-conformance mechanism.
+  Interceptors are for what must be observed at parse time (limits, digests, framing); nothing
+  here needs parse-time observation — the headers are all still there at dispatch.
+
+The middleware short-circuits **without reading the request body**; realigning or retiring the
+connection around an unread body is the transport's existing responsibility (it drains or
+closes as needed — covered by an end-to-end test that reuses the client after a rejection).
+
+## Validation semantics (the exact checks, in order)
+
+For QUERY requests only (everything else passes through untouched):
+
+1. **Advertise** — when `AcceptedMediaTypes` is configured (and `AdvertiseAcceptQuery` is on),
+   stamp the serialized `Accept-Query` field on the response up front (RFC 10008 § 3), so
+   every response from the resource — rejections included — signals QUERY support. Stamped
+   before `next`, so an application handler can still override it.
+2. **Declared `Content-Type` is validated whenever present** — malformed → `400`/`415` per
+   `InvalidContentTypeStatusCode`; parseable but outside the `Accept-Query` set (RFC 9110
+   § 12.5.1 `Includes` matching via `HttpAcceptQuery.Accepts`) → `415`. Validating the header
+   independently of body detection is what keeps HTTP/2+ honest (see below).
+3. **Missing `Content-Type` with detected content** → `400`/`415` per policy. Content is
+   detected from message metadata only: `Content-Length` when declared, then
+   `Transfer-Encoding`, then a buffered body's observable length. **Accepted limitation:** an
+   HTTP/2+ request that *streams* content with no `Content-Length` is not detectable at head
+   time without consuming the body — such a request passes through, and a conformant client's
+   `Content-Type` was already validated by step 2. On HTTP/1.1 detection is exact (RFC 9112
+   § 6: no framing headers, no body).
+4. **Response negotiation** — when `SupportedResponseMediaTypes` is configured, the request's
+   `Accept` is negotiated via the core `HttpContentNegotiation`; no acceptable representation →
+   `406`. A missing `Accept` accepts everything (RFC 9110 § 12.5.1).
+
+A **bodiless QUERY passes through**: § 2.3's MUST attaches to request content, and whether an
+empty query is meaningful is the application's call.
+
+**`422 Unprocessable Content` is deliberately not emitted here.** A parseable, accepted
+`Content-Type` whose *content* turns out semantically invalid (a malformed JSONPath, an
+unbindable filter) is an application judgment made while interpreting the query — middleware
+cannot know it generically. Applications answer `422` themselves at that point.
+
+## Options snapshot at `Use` time
+
+`UseQueryValidation` snapshots `WebQueryValidationOptions` into the middleware when it runs —
+the accepted set becomes an immutable `HttpAcceptQuery` (serialized once), the response set an
+array. Mutating the options object afterwards has no effect, matching the Web pipeline's
+builder-time composition model (the same freeze posture as route groups). The
+`InvalidContentTypeStatusCode` setter validates `400`/`415` at assignment, so a bad policy fails
+at composition, not per request.
+
+## Redirect helpers never emit 301/302 for a query (§ 2.5)
+
+`RedirectQuery` chooses `307 Temporary Redirect` / `308 Permanent Redirect`; `RedirectQueryToGet`
+is the explicit `303 See Other` hand-off (§ 2.5.3, e.g. to a stored result resource). `301`/`302`
+are deliberately unavailable through this surface: user agents historically rewrite them to GET
+(the legacy POST behavior RFC 9110 § 15.4.2/§ 15.4.3 records), which silently drops the query
+content — the "implied GET downgrade" the RFC warns about. The helpers are method-agnostic
+mechanically (status + `Location` only, no body) but exist so redirecting a QUERY is
+correct-by-construction. The client half of § 2.5 — a redirect-following client that re-issues
+QUERY with its original content and switches methods only on `303` — is
+`Assimalign.Cohesion.Http.ClientFactory`'s factory-owned redirect layer (see its `DESIGN.md`).
+
+## Conditional QUERY reuses the core evaluator (§ 2.6)
+
+§ 2.6's rule is *"evaluate as the equivalent conditional GET"* — so the method classification
+lives in the core evaluator itself: `HttpConditionalRequest` treats QUERY as a read method
+(GET/HEAD/QUERY), the same layer that owns the § 13.2.2 ordering. This package adds only what
+the core deliberately leaves to consumers (its "reading the fields is the consumer's job"
+posture): parsing `If-Match`/`If-None-Match`/`If-Modified-Since`/`If-Unmodified-Since` off the
+request (malformed fields are ignored, the § 13.1.3 posture), building the evaluation context,
+and shaping the outcome — `304` carrying the validators the `200` would have (RFC 9110
+§ 15.4.5), `412` bare, both bodiless.
+
+Two surfaces, one evaluation path:
+
+- **`EvaluateQueryPreconditions` / `TryHandleQueryPreconditions`** (context helpers) — for
+  handlers, which typically learn the resource's validators mid-flight. Call before executing
+  the query; a `true` from the try-form means `304`/`412` was written and the query must not
+  run (RFC 9110 § 13.1.2).
+- **`UseQueryConditionals(provider)`** (middleware) — for resources whose validators are cheap
+  to resolve up front. The `WebQueryResourceValidatorsProvider` returns `null` when validators
+  are unknown (pass through, no evaluation). On `Proceed` the middleware stamps
+  `ETag`/`Last-Modified` onto the response — app-overridable — so clients can condition their
+  next query; this is also the seam the future server output cache composes with.
+
+The middleware touches QUERY requests only. Conditional GET/HEAD shaping belongs to the features
+that own those flows (static files, output caching), not to this package.
+
+## Error model
+
+No new exception types. Rejections are imperative status writes; option misuse throws BCL
+argument exceptions at composition time.
+
+## AOT posture
+
+Value objects, delegates, and span-based parsing from the core — no reflection, no dynamic
+code, no serialization.
+
+## Non-goals
+
+- **No `422` emission** (application judgment — above).
+- **No request-body inspection** of any kind: validation is header/metadata-only by design.
+- **No general-purpose redirect or conditional-GET surface** — this package is scoped to the
+  QUERY method; a general conditional feature would lift the same core primitives.
+- **No `OPTIONS` handling or standalone `Accept-Query` advertisement endpoint** — the
+  advertisement rides the responses of the resource itself.
+- **No DI, no configuration binding, no request-time service location** — options and
+  delegates only, per the Web-area feature-package rules.

--- a/resources/Web/Assimalign.Cohesion.Web.Query/docs/OVERVIEW.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/docs/OVERVIEW.md
@@ -1,0 +1,55 @@
+# Assimalign.Cohesion.Web.Query — Overview
+
+Server-side handling for the RFC 10008 HTTP **QUERY** method in the Cohesion Web pipeline. The
+core value-object layer (`HttpMethod.Query`, its safe/idempotent/cacheable classification, and
+the `Accept-Query` field model `HttpAcceptQuery`) ships in `Assimalign.Cohesion.Http`; this
+package adds the *application decisions* the RFC's MUST-level server rules call for —
+middleware-first, every response written imperatively.
+
+## Scope
+
+- **Request-content validation (RFC 10008 § 2.1 / § 2.3)** — `UseQueryValidation(...)`:
+  query content must declare a parseable `Content-Type` (else `400`, or `415` per policy); the
+  declared type must fall within the resource's advertised `Accept-Query` set (else `415`, with
+  the accepted set advertised on the rejection); the request's `Accept` field must be
+  satisfiable against the resource's producible representations (else `406`). Configured
+  through `WebQueryValidationOptions`.
+- **Method-preserving redirects (RFC 10008 § 2.5)** — `response.RedirectQuery(location,
+  permanent)` emits `307`/`308` (never `301`/`302`, whose legacy GET rewrite would drop the
+  query content), and `response.RedirectQueryToGet(location)` emits the one sanctioned method
+  switch, `303 See Other`. The client half — a redirect-following client that re-issues QUERY
+  with its content — lives in `Assimalign.Cohesion.Http.ClientFactory`.
+- **Conditional QUERY (RFC 10008 § 2.6)** — `UseQueryConditionals(provider)` and the
+  `EvaluateQueryPreconditions` / `TryHandleQueryPreconditions` context helpers evaluate the
+  `If-*` precondition fields exactly as for the equivalent conditional GET — reusing the core
+  `HttpConditionalRequest` evaluator — and answer `304` / `412` without executing the query.
+
+## Dependencies
+
+`Assimalign.Cohesion.Web` (the pipeline seams) and, through it, `Assimalign.Cohesion.Http`
+(the QUERY/media-type/conditional primitives). No DI, no configuration binding, no reference to
+`Web.Hosting` — the package follows the Web-area dependency rule.
+
+## Usage
+
+```csharp
+app.UseQueryValidation(options =>
+{
+    options.AcceptedMediaTypes.Add(HttpMediaType.Parse("application/json"));
+    options.SupportedResponseMediaTypes.Add(HttpMediaType.Parse("application/json"));
+});
+
+app.UseQueryConditionals(async context =>
+    await catalog.TryGetValidatorsAsync(context.Request.Path) is { } current
+        ? new WebQueryResourceValidators { ETag = current.ETag, LastModified = current.LastModified }
+        : null);
+
+app.Use(async (context, next) =>
+{
+    // ... execute the query; or hand the client a stored result to GET:
+    context.Response.RedirectQueryToGet($"/results/{resultId}");
+});
+```
+
+Design rationale (why middleware and not a transport interceptor, snapshot semantics, status
+choices, non-goals) lives in [DESIGN.md](DESIGN.md).

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Assimalign.Cohesion.Web.Query.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Assimalign.Cohesion.Web.Query.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Assimalign.Cohesion.Web.Query</RootNamespace>
+		<Description>Server-side handling for the RFC 10008 HTTP QUERY method in the Cohesion Web pipeline: request Content-Type validation and Accept-Query negotiation (400/415/406), method-preserving redirect helpers (307/308, 303), and conditional-QUERY evaluation (304/412) over the core HttpConditionalRequest primitives. Middleware-first — every response is written imperatively; no DI, no configuration binding.</Description>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Delegates/WebQueryResourceValidatorsProvider.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Delegates/WebQueryResourceValidatorsProvider.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Resolves the target resource's current validators for a conditional QUERY evaluation —
+/// the ETag / Last-Modified of the representation the equivalent GET request would select
+/// (RFC 10008 &#167; 2.6).
+/// </summary>
+/// <param name="context">The exchange whose target resource's validators are requested.</param>
+/// <returns>
+/// The resource's current validators, or <see langword="null"/> when they are unknown for this
+/// request — in which case the conditional middleware performs no precondition evaluation and
+/// passes the request through.
+/// </returns>
+public delegate ValueTask<WebQueryResourceValidators?> WebQueryResourceValidatorsProvider(IHttpContext context);

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/HttpContextQueryExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/HttpContextQueryExtensions.cs
@@ -1,0 +1,125 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Conditional-QUERY helpers (RFC 10008 &#167; 2.6): evaluate a QUERY request's precondition
+/// fields exactly as for the equivalent conditional GET, reusing the core
+/// <see cref="HttpConditionalRequest"/> evaluator, and shape the <c>304</c> / <c>412</c> outcome
+/// imperatively onto the response.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The helpers read the four header preconditions (<c>If-Match</c>, <c>If-None-Match</c>,
+/// <c>If-Modified-Since</c>, <c>If-Unmodified-Since</c>) off the request, hand them to
+/// <see cref="HttpConditionalRequest.Evaluate"/> together with the supplied resource validators,
+/// and — because the core evaluator classifies QUERY as a read method per RFC 10008 &#167; 2.6 —
+/// obtain <c>304 Not Modified</c> where the equivalent GET would, and
+/// <c>412 Precondition Failed</c> otherwise. A malformed precondition field is ignored (treated
+/// as absent), matching the RFC 9110 &#167; 13.1.3 posture the core date parsing already encodes.
+/// </para>
+/// <para>
+/// Call these <em>before</em> executing the query: a precondition that yields <c>304</c> or
+/// <c>412</c> means the method must not be performed (RFC 9110 &#167; 13.1.2).
+/// </para>
+/// </remarks>
+public static class HttpContextQueryExtensions
+{
+    extension(IHttpContext context)
+    {
+        /// <summary>
+        /// Evaluates the request's precondition fields against <paramref name="validators"/> per
+        /// RFC 9110 &#167; 13.2.2, with QUERY treated as a read method (RFC 10008 &#167; 2.6).
+        /// </summary>
+        /// <param name="validators">The target resource's current validators.</param>
+        /// <returns>
+        /// <see cref="HttpPreconditionOutcome.Proceed"/> when the query should run,
+        /// <see cref="HttpPreconditionOutcome.NotModified"/> when a <c>304</c> should be sent, or
+        /// <see cref="HttpPreconditionOutcome.PreconditionFailed"/> when a <c>412</c> should be sent.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
+        public HttpPreconditionOutcome EvaluateQueryPreconditions(in WebQueryResourceValidators validators)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            IHttpHeaderCollection headers = context.Request.Headers;
+
+            var evaluation = new HttpConditionalRequestContext
+            {
+                Method = context.Request.Method,
+                ETag = validators.ETag,
+                LastModified = validators.LastModified,
+                HasCurrentRepresentation = validators.HasCurrentRepresentation,
+                IfMatch = ParseEntityTagCondition(headers, HttpHeaderKey.IfMatch),
+                IfNoneMatch = ParseEntityTagCondition(headers, HttpHeaderKey.IfNoneMatch),
+                IfModifiedSince = ParseDate(headers, HttpHeaderKey.IfModifiedSince),
+                IfUnmodifiedSince = ParseDate(headers, HttpHeaderKey.IfUnmodifiedSince),
+            };
+
+            return HttpConditionalRequest.Evaluate(in evaluation);
+        }
+
+        /// <summary>
+        /// Evaluates the request's preconditions and, when they resolve the exchange, writes the
+        /// outcome: <c>304 Not Modified</c> carrying the supplied validators, or
+        /// <c>412 Precondition Failed</c>. The response body is left untouched — both statuses are
+        /// bodiless by this helper's construction.
+        /// </summary>
+        /// <param name="validators">The target resource's current validators.</param>
+        /// <returns>
+        /// <see langword="true"/> when a <c>304</c> or <c>412</c> was written and the caller must
+        /// not execute the query; <see langword="false"/> when the query should proceed.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
+        public bool TryHandleQueryPreconditions(in WebQueryResourceValidators validators)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            switch (context.EvaluateQueryPreconditions(in validators))
+            {
+                case HttpPreconditionOutcome.NotModified:
+                    context.Response.StatusCode = HttpStatusCode.NotModified;
+                    // RFC 9110 §15.4.5: a 304 carries the validator fields the 200 would have.
+                    SetValidatorHeaders(context.Response, in validators);
+                    return true;
+
+                case HttpPreconditionOutcome.PreconditionFailed:
+                    context.Response.StatusCode = HttpStatusCode.PreconditionFailed;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stamps the resource's validator fields (<c>ETag</c>, <c>Last-Modified</c>) onto the
+    /// response so clients can issue subsequent conditional requests.
+    /// </summary>
+    /// <param name="response">The response to stamp.</param>
+    /// <param name="validators">The validators to emit; absent members are skipped.</param>
+    internal static void SetValidatorHeaders(IHttpResponse response, in WebQueryResourceValidators validators)
+    {
+        if (validators.ETag is { } etag)
+        {
+            response.Headers[HttpHeaderKey.ETag] = etag.ToString();
+        }
+        if (validators.LastModified is { } lastModified)
+        {
+            response.Headers[HttpHeaderKey.LastModified] = HttpDate.Format(lastModified);
+        }
+    }
+
+    private static HttpEntityTagCondition? ParseEntityTagCondition(IHttpHeaderCollection headers, HttpHeaderKey key)
+        => headers.TryGetValue(key, out HttpHeaderValue value) && HttpEntityTagCondition.TryParse(value.Value, out HttpEntityTagCondition condition)
+            ? condition
+            : null;
+
+    private static DateTimeOffset? ParseDate(IHttpHeaderCollection headers, HttpHeaderKey key)
+        => headers.TryGetValue(key, out HttpHeaderValue value) && HttpDate.TryParse(value.Value, out DateTimeOffset date)
+            ? date
+            : null;
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/HttpResponseQueryRedirectExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/HttpResponseQueryRedirectExtensions.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Redirect helpers that preserve the QUERY method across a redirect (RFC 10008 &#167; 2.5):
+/// a redirected query re-targets with its method and content intact, and the one sanctioned
+/// method switch is the explicit <c>303 See Other</c> hand-off to GET (&#167; 2.5.3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The helpers deliberately never emit <c>301 Moved Permanently</c> or <c>302 Found</c> for a
+/// query: user agents historically rewrite those to GET (the legacy POST behavior RFC 9110
+/// &#167; 15.4.2 / &#167; 15.4.3 notes), which would silently drop the query content. The
+/// method-preserving statuses <c>307 Temporary Redirect</c> and <c>308 Permanent Redirect</c>
+/// (RFC 9110 &#167; 15.4.8 / &#167; 15.4.9) forbid that rewrite, so a redirected QUERY is
+/// re-issued as a QUERY with the original content.
+/// </para>
+/// <para>
+/// The helpers write the status and <c>Location</c> field only; they attach no response body.
+/// They are safe on any request method — the chosen statuses are method-agnostic — but exist so
+/// that redirecting a QUERY never implies a GET downgrade.
+/// </para>
+/// </remarks>
+public static class HttpResponseQueryRedirectExtensions
+{
+    extension(IHttpResponse response)
+    {
+        /// <summary>
+        /// Redirects the query to <paramref name="location"/> preserving the request method and
+        /// content: <c>307 Temporary Redirect</c>, or <c>308 Permanent Redirect</c> when
+        /// <paramref name="permanent"/> is <see langword="true"/>.
+        /// </summary>
+        /// <param name="location">The redirect target — an absolute URI or a relative reference, emitted as the <c>Location</c> field.</param>
+        /// <param name="permanent"><see langword="true"/> to emit <c>308</c>; otherwise <c>307</c>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="response"/> or <paramref name="location"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="location"/> is empty.</exception>
+        public void RedirectQuery(string location, bool permanent = false)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            ArgumentException.ThrowIfNullOrEmpty(location);
+
+            response.StatusCode = permanent ? HttpStatusCode.PermanentRedirect : HttpStatusCode.RedirectKeepVerb;
+            response.Headers[HttpHeaderKey.Location] = location;
+        }
+
+        /// <summary>
+        /// Redirects the client to fetch <paramref name="location"/> with a GET —
+        /// <c>303 See Other</c>, the one intentional method switch RFC 10008 &#167; 2.5.3
+        /// sanctions for a query (for example, handing off to a stored result resource).
+        /// </summary>
+        /// <param name="location">The resource to retrieve with GET, emitted as the <c>Location</c> field.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="response"/> or <paramref name="location"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="location"/> is empty.</exception>
+        public void RedirectQueryToGet(string location)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+            ArgumentException.ThrowIfNullOrEmpty(location);
+
+            response.StatusCode = HttpStatusCode.SeeOther;
+            response.Headers[HttpHeaderKey.Location] = location;
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/WebApplicationExtensions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Web;
+using Assimalign.Cohesion.Web.Query.Internal;
+
+/// <summary>
+/// Pipeline-builder verbs for the RFC 10008 QUERY server-side rules: request-content validation
+/// (<see cref="WebApplicationExtensions.UseQueryValidation"/>) and conditional-QUERY evaluation
+/// (<see cref="WebApplicationExtensions.UseQueryConditionals"/>). Both compose against the root
+/// pipeline seam with dependency-free registration — options and delegates only, no service
+/// container.
+/// </summary>
+public static class WebApplicationExtensions
+{
+    extension(IWebApplicationPipelineBuilder builder)
+    {
+        /// <summary>
+        /// Adds middleware that enforces the RFC 10008 &#167; 2.1 / &#167; 2.3 QUERY
+        /// request-content rules: query content must declare a parseable <c>Content-Type</c>
+        /// (rejected with 400 or 415 per <see cref="WebQueryValidationOptions.InvalidContentTypeStatusCode"/>),
+        /// the declared type must fall within the resource's
+        /// <see cref="WebQueryValidationOptions.AcceptedMediaTypes"/> when configured (else 415),
+        /// and the request's <c>Accept</c> field must be satisfiable against
+        /// <see cref="WebQueryValidationOptions.SupportedResponseMediaTypes"/> when configured
+        /// (else 406). Non-QUERY requests pass through untouched.
+        /// </summary>
+        /// <param name="configure">An optional callback that configures the validation options; the middleware snapshots the options here — later mutation has no effect.</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+        public IWebApplicationPipelineBuilder UseQueryValidation(Action<WebQueryValidationOptions>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            var options = new WebQueryValidationOptions();
+            configure?.Invoke(options);
+
+            return builder.Use(new WebQueryValidationMiddleware(options));
+        }
+
+        /// <summary>
+        /// Adds middleware that evaluates a conditional QUERY exactly as the equivalent
+        /// conditional GET (RFC 10008 &#167; 2.6): the resource's current validators are resolved
+        /// through <paramref name="validatorsProvider"/> <em>before</em> the query executes, the
+        /// precondition fields are evaluated via the core <c>HttpConditionalRequest</c> primitives,
+        /// and a resolved precondition answers <c>304</c> / <c>412</c> without running the rest of
+        /// the pipeline. Non-QUERY requests — and queries for which the provider returns
+        /// <see langword="null"/> — pass through untouched.
+        /// </summary>
+        /// <param name="validatorsProvider">Resolves the target resource's current validators (the same selected representation the equivalent GET would use).</param>
+        /// <returns>The same pipeline builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="validatorsProvider"/> is <see langword="null"/>.</exception>
+        public IWebApplicationPipelineBuilder UseQueryConditionals(WebQueryResourceValidatorsProvider validatorsProvider)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(validatorsProvider);
+
+            return builder.Use(new WebQueryConditionalMiddleware(validatorsProvider));
+        }
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Internal/WebQueryConditionalMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Internal/WebQueryConditionalMiddleware.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Query.Internal;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+/// <summary>
+/// Evaluates a conditional QUERY exactly as the equivalent conditional GET (RFC 10008 &#167; 2.6):
+/// resolves the target resource's current validators through the registered provider, evaluates
+/// the request's precondition fields via the core <see cref="HttpConditionalRequest"/> evaluator,
+/// and answers <c>304 Not Modified</c> / <c>412 Precondition Failed</c> without executing the
+/// query. On <see cref="HttpPreconditionOutcome.Proceed"/> the validators are stamped onto the
+/// response (so clients can condition their next query) and the pipeline continues. Requests with
+/// any other method — and queries whose validators the provider does not know — pass through
+/// untouched.
+/// </summary>
+internal sealed class WebQueryConditionalMiddleware : IWebApplicationMiddleware
+{
+    private readonly WebQueryResourceValidatorsProvider _validatorsProvider;
+
+    public WebQueryConditionalMiddleware(WebQueryResourceValidatorsProvider validatorsProvider)
+    {
+        _validatorsProvider = validatorsProvider;
+    }
+
+    public async Task InvokeAsync(IHttpContext context, WebApplicationMiddleware next)
+    {
+        if (context.Request.Method != HttpMethod.Query)
+        {
+            await next.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        WebQueryResourceValidators? resolved = await _validatorsProvider.Invoke(context).ConfigureAwait(false);
+        if (resolved is not { } validators)
+        {
+            await next.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        if (context.TryHandleQueryPreconditions(in validators))
+        {
+            // 304 / 412 written — the query is not performed (RFC 9110 §13.1.2).
+            return;
+        }
+
+        HttpContextQueryExtensions.SetValidatorHeaders(context.Response, in validators);
+        await next.Invoke(context).ConfigureAwait(false);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/Internal/WebQueryValidationMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/Internal/WebQueryValidationMiddleware.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Assimalign.Cohesion.Web.Query.Internal;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+/// <summary>
+/// Enforces the RFC 10008 &#167; 2.1 / &#167; 2.3 QUERY request-content rules: query content must
+/// declare a parseable <c>Content-Type</c> (else 400/415 per policy), the declared type must fall
+/// within the resource's advertised <c>Accept-Query</c> set (else 415), and — when the resource
+/// declares its producible representations — the request's <c>Accept</c> field must be
+/// satisfiable (else 406, RFC 9110 &#167; 12.5.1). Requests with any other method pass through
+/// untouched.
+/// </summary>
+/// <remarks>
+/// The middleware holds a builder-time snapshot of <see cref="WebQueryValidationOptions"/>; a
+/// rejection sets the status imperatively and short-circuits without reading the request body
+/// (the transport is responsible for the unread remainder of the exchange).
+/// </remarks>
+internal sealed class WebQueryValidationMiddleware : IWebApplicationMiddleware
+{
+    private readonly HttpAcceptQuery _acceptQuery;
+    private readonly string? _acceptQueryField;
+    private readonly HttpMediaType[] _responseMediaTypes;
+    private readonly HttpStatusCode _invalidContentTypeStatusCode;
+
+    public WebQueryValidationMiddleware(WebQueryValidationOptions options)
+    {
+        _acceptQuery = options.AcceptedMediaTypes.Count == 0
+            ? HttpAcceptQuery.Empty
+            : new HttpAcceptQuery(options.AcceptedMediaTypes);
+        _acceptQueryField = options.AdvertiseAcceptQuery && !_acceptQuery.IsEmpty
+            ? _acceptQuery.Serialize()
+            : null;
+        _responseMediaTypes = [.. options.SupportedResponseMediaTypes];
+        _invalidContentTypeStatusCode = options.InvalidContentTypeStatusCode;
+    }
+
+    public async Task InvokeAsync(IHttpContext context, WebApplicationMiddleware next)
+    {
+        if (context.Request.Method != HttpMethod.Query)
+        {
+            await next.Invoke(context).ConfigureAwait(false);
+            return;
+        }
+
+        IHttpResponse response = context.Response;
+
+        // RFC 10008 §3 — advertise the accepted query formats up front so every response from
+        // this resource (rejections included) signals QUERY support; the application can still
+        // override the field before the head commits.
+        if (_acceptQueryField is not null)
+        {
+            response.Headers[HttpHeaderKey.AcceptQuery] = _acceptQueryField;
+        }
+
+        // §2.1/§2.3 — the declared Content-Type is validated whenever present (a malformed
+        // declaration is defective with or without content); when absent, content detected from
+        // the message's length metadata makes the omission a MUST violation.
+        if (context.Request.Headers.TryGetValue(HttpHeaderKey.ContentType, out HttpHeaderValue contentTypeField))
+        {
+            if (!HttpMediaType.TryParse(contentTypeField.Value, out HttpMediaType contentType))
+            {
+                response.StatusCode = _invalidContentTypeStatusCode;
+                return;
+            }
+
+            if (!_acceptQuery.IsEmpty && !_acceptQuery.Accepts(contentType))
+            {
+                response.StatusCode = HttpStatusCode.UnsupportedMediaType;
+                return;
+            }
+        }
+        else if (HasDeclaredContent(context.Request))
+        {
+            response.StatusCode = _invalidContentTypeStatusCode;
+            return;
+        }
+
+        // §2.1 — negotiate the response representation when the resource declares what it can
+        // produce; a missing Accept accepts everything (RFC 9110 §12.5.1).
+        if (_responseMediaTypes.Length > 0
+            && !HttpContentNegotiation.TryNegotiateMediaType(
+                context.Request.Headers.GetValue(HttpHeaderKey.Accept),
+                _responseMediaTypes,
+                out _))
+        {
+            response.StatusCode = HttpStatusCode.NotAcceptable;
+            return;
+        }
+
+        await next.Invoke(context).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Detects request content from the message metadata without consuming the body:
+    /// <c>Content-Length</c> when declared, then <c>Transfer-Encoding</c> (HTTP/1.1 chunked), then
+    /// a buffered body's observable length. An HTTP/2+ request that streams content with no
+    /// <c>Content-Length</c> is not detectable at head time without reading — such a request
+    /// passes through here, and its (conformant) <c>Content-Type</c> was already validated above.
+    /// </summary>
+    private static bool HasDeclaredContent(IHttpRequest request)
+    {
+        if (request.Headers.TryGetValue(HttpHeaderKey.ContentLength, out HttpHeaderValue contentLength))
+        {
+            // An unparseable Content-Length is the transport's problem (it rejects ambiguous
+            // framing before dispatch); treat a parseable declaration authoritatively.
+            return !long.TryParse(contentLength.Value, NumberStyles.None, CultureInfo.InvariantCulture, out long length)
+                || length > 0;
+        }
+
+        if (request.Headers.ContainsKey(HttpHeaderKey.TransferEncoding))
+        {
+            return true;
+        }
+
+        // No length metadata: HTTP/1.1 has no body by definition (RFC 9112 §6); a buffered
+        // HTTP/2+ body still betrays its length through the seekable stream.
+        Stream body = request.Body;
+        return body.CanSeek && body.Length > 0;
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/WebQueryResourceValidators.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/WebQueryResourceValidators.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Http;
+
+/// <summary>
+/// The target resource's current validators for a conditional QUERY evaluation
+/// (RFC 10008 &#167; 2.6): the entity-tag and last-modified timestamp of the representation the
+/// equivalent GET would select, plus the existence flag the <c>*</c> wildcard preconditions
+/// consult.
+/// </summary>
+/// <remarks>
+/// Supplying either validator already implies the resource has a current representation;
+/// <see cref="HasCurrentRepresentation"/> exists for the rare resource that exists without
+/// carrying a validator (mirroring <see cref="HttpConditionalRequestContext"/>).
+/// </remarks>
+public readonly struct WebQueryResourceValidators
+{
+    /// <summary>
+    /// Gets the current entity-tag of the representation the equivalent GET would select, or
+    /// <see langword="null"/> when the resource has none.
+    /// </summary>
+    public HttpEntityTag? ETag { get; init; }
+
+    /// <summary>
+    /// Gets the current last-modified timestamp of the selected representation, or
+    /// <see langword="null"/> when unknown.
+    /// </summary>
+    public DateTimeOffset? LastModified { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the target resource currently has a representation. Only
+    /// consulted by the <c>*</c> wildcard of <c>If-Match</c> / <c>If-None-Match</c>; supplying a
+    /// validator already implies existence.
+    /// </summary>
+    public bool HasCurrentRepresentation { get; init; }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/src/WebQueryValidationOptions.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/src/WebQueryValidationOptions.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Web.Query;
+
+using Assimalign.Cohesion.Http;
+
+/// <summary>
+/// Options for the QUERY request-validation middleware (see <c>UseQueryValidation</c>):
+/// the resource's advertised <c>Accept-Query</c> set, the representations it can produce,
+/// and the status-code policy for a missing or malformed <c>Content-Type</c>.
+/// </summary>
+/// <remarks>
+/// The middleware snapshots these options when <c>UseQueryValidation</c> runs — mutations after
+/// registration have no effect, matching the builder-time composition model of the Web pipeline.
+/// </remarks>
+public sealed class WebQueryValidationOptions
+{
+    private HttpStatusCode _invalidContentTypeStatusCode = HttpStatusCode.BadRequest;
+
+    /// <summary>
+    /// Gets the query-format media ranges the resource accepts as QUERY request content — the
+    /// resource's <c>Accept-Query</c> set (RFC 10008 &#167; 3). When non-empty, a QUERY whose
+    /// <c>Content-Type</c> no advertised range includes is rejected with
+    /// <c>415 Unsupported Media Type</c>. When empty (the default), any syntactically valid
+    /// <c>Content-Type</c> is allowed through and no acceptance check is performed.
+    /// </summary>
+    public IList<HttpMediaType> AcceptedMediaTypes { get; } = new List<HttpMediaType>();
+
+    /// <summary>
+    /// Gets the media types the resource can produce as QUERY responses, in server preference
+    /// order. When non-empty, the request's <c>Accept</c> field is negotiated against this set
+    /// (RFC 9110 &#167; 12.5.1) and an unsatisfiable <c>Accept</c> is rejected with
+    /// <c>406 Not Acceptable</c>. When empty (the default), no response negotiation is performed.
+    /// </summary>
+    public IList<HttpMediaType> SupportedResponseMediaTypes { get; } = new List<HttpMediaType>();
+
+    /// <summary>
+    /// Gets or sets the status code used to reject a QUERY whose content carries a missing or
+    /// malformed <c>Content-Type</c> (RFC 10008 &#167; 2.1 / &#167; 2.3). Either
+    /// <see cref="HttpStatusCode.BadRequest"/> (the default — the request itself is defective) or
+    /// <see cref="HttpStatusCode.UnsupportedMediaType"/> (treat an undeclared type as an
+    /// unsupported one).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when set to a status other than <c>400</c> or <c>415</c>.
+    /// </exception>
+    public HttpStatusCode InvalidContentTypeStatusCode
+    {
+        get => _invalidContentTypeStatusCode;
+        set
+        {
+            if (value.Value is not (400 or 415))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value.Value,
+                    "A missing or malformed QUERY Content-Type is rejected with 400 Bad Request or 415 Unsupported Media Type.");
+            }
+            _invalidContentTypeStatusCode = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the middleware advertises the
+    /// <see cref="AcceptedMediaTypes"/> set on responses via the <c>Accept-Query</c> response
+    /// field (RFC 10008 &#167; 3), signaling that the resource supports the QUERY method.
+    /// Defaults to <see langword="true"/>; a no-op while <see cref="AcceptedMediaTypes"/> is
+    /// empty. The field is written before the rest of the pipeline runs, so an application
+    /// handler can still override it.
+    /// </summary>
+    public bool AdvertiseAcceptQuery { get; set; } = true;
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Query" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Web.Testing" />
+		<CohesionProjectReference Include="Assimalign.Cohesion.Http" />
+		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
+		<CohesionPackageReference Include="Shouldly" />
+		<CohesionPackageReference Include="xunit" />
+		<CohesionPackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+</Project>

--- a/resources/Web/Assimalign.Cohesion.Web.Query/tests/QueryRedirectTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/tests/QueryRedirectTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+using NetHttpMethod = System.Net.Http.HttpMethod;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Query.Tests;
+
+/// <summary>
+/// RFC 10008 &#167; 2.5 tests for the QUERY redirect helpers: the raw response shaping
+/// (307/308/303 + <c>Location</c>, unit level) and the end-to-end flow over the in-memory
+/// transport — a redirected QUERY is re-issued as a QUERY with its content, and the
+/// <c>303 See Other</c> hand-off is re-issued as a bodiless GET.
+/// </summary>
+public class QueryRedirectTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly NetHttpMethod QueryMethod = new("QUERY");
+
+    // ============================================================================
+    // Response shaping (unit level — the raw 3xx the helper writes)
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Redirect: RedirectQuery emits 307 with the Location field")]
+    public void RedirectQuery_Temporary_ShouldEmit307WithLocation()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+
+        // Act
+        context.Response.RedirectQuery("/search-v2");
+
+        // Assert — 307 preserves method + content by definition (RFC 9110 §15.4.8).
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.RedirectKeepVerb);
+        context.Response.Headers.GetValue(HttpHeaderKey.Location).ShouldBe("/search-v2");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Redirect: RedirectQuery permanent emits 308 with the Location field")]
+    public void RedirectQuery_Permanent_ShouldEmit308WithLocation()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+
+        // Act
+        context.Response.RedirectQuery("https://origin.example/search-v2", permanent: true);
+
+        // Assert — 308 is the permanent method-preserving redirect (RFC 9110 §15.4.9).
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PermanentRedirect);
+        context.Response.Headers.GetValue(HttpHeaderKey.Location).ShouldBe("https://origin.example/search-v2");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Redirect: RedirectQueryToGet emits 303 with the Location field")]
+    public void RedirectQueryToGet_ShouldEmit303WithLocation()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+
+        // Act
+        context.Response.RedirectQueryToGet("/results/42");
+
+        // Assert — the one sanctioned method switch (RFC 10008 §2.5.3).
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.SeeOther);
+        context.Response.Headers.GetValue(HttpHeaderKey.Location).ShouldBe("/results/42");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Redirect: an empty location is rejected")]
+    public void RedirectQuery_EmptyLocation_ShouldThrow()
+    {
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+
+        Should.Throw<ArgumentException>(() => context.Response.RedirectQuery(string.Empty));
+        Should.Throw<ArgumentException>(() => context.Response.RedirectQueryToGet(string.Empty));
+    }
+
+    // ============================================================================
+    // End to end — the redirected QUERY is re-issued with method + content preserved
+    // ============================================================================
+
+    private static async Task<(WebApplicationTestFactory Factory, HttpClient Client)> CreateRedirectAppAsync(
+        bool permanent,
+        bool toGet,
+        CancellationToken cancellationToken)
+    {
+        var factory = new WebApplicationTestFactory();
+
+        factory.Application.Use(async (context, next) =>
+        {
+            if (context.Request.Path.ToString() == "/search")
+            {
+                // The resource moved: shape the redirect with the QUERY-preserving helper.
+                if (toGet)
+                {
+                    context.Response.RedirectQueryToGet("/search-v2");
+                }
+                else
+                {
+                    context.Response.RedirectQuery("/search-v2", permanent);
+                }
+                return;
+            }
+
+            await next.Invoke(context);
+        });
+        factory.Application.Use(async (context, next) =>
+        {
+            // Terminal echo at the redirect target: reveals the re-issued method and content.
+            string body;
+            using (var reader = new System.IO.StreamReader(context.Request.Body, Encoding.UTF8))
+            {
+                body = await reader.ReadToEndAsync(context.RequestCancelled);
+            }
+
+            context.Response.StatusCode = HttpStatusCode.Ok;
+            byte[] payload = Encoding.UTF8.GetBytes($"{context.Request.Method.Value}:{body}");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        await factory.StartAsync(cancellationToken);
+        return (factory, factory.CreateClient());
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Web.Query] - Redirect: a redirected QUERY lands as a QUERY with its content (RFC 10008 §2.5)")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RedirectQuery_EndToEnd_ShouldReissueQueryWithContent(bool permanent)
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateRedirectAppAsync(
+            permanent, toGet: false, cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":\"cohesion\"}", Encoding.UTF8, "application/json"),
+        };
+
+        // Act — the BCL client auto-follows the 307/308; both preserve method + content.
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — the target observed a QUERY carrying the original content: no GET downgrade.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("QUERY:{\"q\":\"cohesion\"}");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Redirect: the 303 hand-off lands as a bodiless GET (RFC 10008 §2.5.3)")]
+    public async Task RedirectQueryToGet_EndToEnd_ShouldReissueAsGetWithoutContent()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateRedirectAppAsync(
+            permanent: false, toGet: true, cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":\"cohesion\"}", Encoding.UTF8, "application/json"),
+        };
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — the one intended method switch: GET on the Location URI, content dropped.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("GET:");
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/tests/TestObjects/WebQueryTestHarness.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/tests/TestObjects/WebQueryTestHarness.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web;
+
+using HttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+
+namespace Assimalign.Cohesion.Web.Query.Tests;
+
+/// <summary>
+/// A configurable <see cref="IHttpContext"/> test double for unit-level middleware and helper
+/// tests: writable request headers, a settable request body, and a readable response. Mirrors the
+/// Web.Health test harness shape.
+/// </summary>
+internal sealed class TestHttpContext : IHttpContext
+{
+    public TestHttpContext(string path, HttpMethod method)
+    {
+        Request = new TestHttpRequest(this, path, method);
+        Response = new TestHttpResponse(this);
+    }
+
+    public HttpVersion Version => HttpVersion.Http11;
+    public IHttpRequest Request { get; }
+    public IHttpResponse Response { get; }
+    public IHttpConnectionInfo ConnectionInfo => HttpConnectionInfo.Empty;
+    public IHttpFeatureCollection Features { get; } = new HttpFeatureCollection();
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+    public CancellationToken RequestCancelled => CancellationToken.None;
+    public void Cancel() { }
+    public Task CancelAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public TestHttpRequest TypedRequest => (TestHttpRequest)Request;
+}
+
+internal sealed class TestHttpRequest : IHttpRequest
+{
+    public TestHttpRequest(IHttpContext context, string path, HttpMethod method)
+    {
+        HttpContext = context;
+        Path = new HttpPath(path);
+        Method = method;
+    }
+
+    public HttpHost Host => HttpHost.Empty;
+    public HttpPath Path { get; }
+    public HttpMethod Method { get; }
+    public HttpScheme Scheme => HttpScheme.Http;
+    public IHttpQueryCollection Query { get; } = new HttpQueryCollection();
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body { get; set; } = Stream.Null;
+}
+
+internal sealed class TestHttpResponse : IHttpResponse
+{
+    public TestHttpResponse(IHttpContext context) => HttpContext = context;
+
+    public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Ok;
+    public IHttpHeaderCollection Headers { get; } = new HttpHeaderCollection();
+    public IHttpContext HttpContext { get; }
+    public Stream Body { get; set; } = new MemoryStream();
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/tests/WebQueryConditionalTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/tests/WebQueryConditionalTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http;
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpMethod = Assimalign.Cohesion.Http.HttpMethod;
+using NetHttpMethod = System.Net.Http.HttpMethod;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Query.Tests;
+
+/// <summary>
+/// RFC 10008 &#167; 2.6 tests for conditional QUERY handling: the precondition helpers parse the
+/// request's <c>If-*</c> fields and reuse the core <c>HttpConditionalRequest</c> evaluator, and
+/// <c>UseQueryConditionals</c> answers <c>304</c> / <c>412</c> end to end without executing the
+/// query — exactly as the equivalent conditional GET.
+/// </summary>
+public class WebQueryConditionalTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly NetHttpMethod QueryMethod = new("QUERY");
+    private static readonly DateTimeOffset LastModified = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    // ============================================================================
+    // Helper surface (unit level — header parsing + outcome shaping)
+    // ============================================================================
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: a matching If-None-Match evaluates NotModified on QUERY")]
+    public void EvaluateQueryPreconditions_IfNoneMatchMatches_ShouldBeNotModified()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+        context.Request.Headers[HttpHeaderKey.IfNoneMatch] = "\"v2\"";
+
+        var validators = new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") };
+
+        // Act + Assert
+        context.EvaluateQueryPreconditions(in validators).ShouldBe(HttpPreconditionOutcome.NotModified);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: a malformed precondition field is ignored")]
+    public void EvaluateQueryPreconditions_MalformedIfNoneMatch_ShouldProceed()
+    {
+        // Arrange — an unparseable If-None-Match is treated as absent (the RFC 9110 §13.1.3
+        // posture the core date parsing encodes), not as a failed precondition.
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+        context.Request.Headers[HttpHeaderKey.IfNoneMatch] = "not-an-entity-tag";
+
+        var validators = new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") };
+
+        // Act + Assert
+        context.EvaluateQueryPreconditions(in validators).ShouldBe(HttpPreconditionOutcome.Proceed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: TryHandleQueryPreconditions writes 304 with the validators")]
+    public void TryHandleQueryPreconditions_NotModified_ShouldWrite304WithValidators()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+        context.Request.Headers[HttpHeaderKey.IfNoneMatch] = "\"v2\"";
+
+        var validators = new WebQueryResourceValidators
+        {
+            ETag = HttpEntityTag.Strong("v2"),
+            LastModified = LastModified,
+        };
+
+        // Act
+        bool handled = context.TryHandleQueryPreconditions(in validators);
+
+        // Assert — RFC 9110 §15.4.5: the 304 carries the validator fields the 200 would have.
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        context.Response.Headers.GetValue(HttpHeaderKey.ETag).ShouldBe("\"v2\"");
+        context.Response.Headers.GetValue(HttpHeaderKey.LastModified).ShouldBe(HttpDate.Format(LastModified));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: TryHandleQueryPreconditions writes 412 on a failed If-Match")]
+    public void TryHandleQueryPreconditions_FailedIfMatch_ShouldWrite412()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+        context.Request.Headers[HttpHeaderKey.IfMatch] = "\"v1\"";
+
+        var validators = new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") };
+
+        // Act
+        bool handled = context.TryHandleQueryPreconditions(in validators);
+
+        // Assert
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: no preconditions proceed without writing")]
+    public void TryHandleQueryPreconditions_NoPreconditions_ShouldProceed()
+    {
+        // Arrange
+        var context = new TestHttpContext("/search", CohesionHttpMethod.Query);
+        var validators = new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") };
+
+        // Act + Assert
+        context.TryHandleQueryPreconditions(in validators).ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
+    }
+
+    // ============================================================================
+    // UseQueryConditionals — end to end over the in-memory transport
+    // ============================================================================
+
+    private static async Task<(WebApplicationTestFactory Factory, HttpClient Client, StrongBox<bool> QueryExecuted)> CreateConditionalAppAsync(
+        WebQueryResourceValidators? validators,
+        CancellationToken cancellationToken)
+    {
+        var factory = new WebApplicationTestFactory();
+        var executed = new StrongBox<bool>();
+
+        factory.Application.UseQueryConditionals(_ => ValueTask.FromResult(validators));
+        factory.Application.Use(async (context, next) =>
+        {
+            executed.Value = true;
+            context.Response.StatusCode = HttpStatusCode.Ok;
+            byte[] payload = Encoding.UTF8.GetBytes("results");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        await factory.StartAsync(cancellationToken);
+        return (factory, factory.CreateClient(), executed);
+    }
+
+    private sealed class StrongBox<T>
+    {
+        public T? Value;
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: a matching If-None-Match answers 304 without executing the query (RFC 10008 §2.6)")]
+    public async Task UseQueryConditionals_IfNoneMatchMatches_ShouldAnswer304WithoutExecuting()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2"), LastModified = LastModified },
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("If-None-Match", "\"v2\"").ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — 304 with the validators; the query never ran.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.NotModified);
+        response.Headers.ETag.ShouldNotBeNull();
+        response.Headers.ETag!.Tag.ShouldBe("\"v2\"");
+        executed.Value.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: an If-Modified-Since date in the future answers 304 on QUERY")]
+    public async Task UseQueryConditionals_IfModifiedSinceNotModified_ShouldAnswer304()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            new WebQueryResourceValidators { LastModified = LastModified },
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("If-Modified-Since", HttpDate.Format(LastModified)).ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.NotModified);
+        executed.Value.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: a failed If-Match answers 412 without executing the query")]
+    public async Task UseQueryConditionals_FailedIfMatch_ShouldAnswer412WithoutExecuting()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") },
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("If-Match", "\"v1\"").ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.PreconditionFailed);
+        executed.Value.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: an unconditional QUERY runs and its 200 carries the validators")]
+    public async Task UseQueryConditionals_UnconditionalQuery_ShouldExecuteAndStampValidators()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2"), LastModified = LastModified },
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"),
+        };
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — the query ran, and the response advertises the validators for the client's
+        // next conditional query.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("results");
+        response.Headers.ETag.ShouldNotBeNull();
+        executed.Value.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: unknown validators pass the query through untouched")]
+    public async Task UseQueryConditionals_ProviderReturnsNull_ShouldPassThrough()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            validators: null,
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(QueryMethod, "/search")
+        {
+            Content = new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("If-None-Match", "\"v2\"").ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — no validators, no precondition evaluation: the query runs.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        executed.Value.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Conditional: non-QUERY requests pass through untouched")]
+    public async Task UseQueryConditionals_NonQueryMethod_ShouldPassThrough()
+    {
+        // Arrange — a GET with a matching If-None-Match is not this middleware's decision.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client, var executed) = await CreateConditionalAppAsync(
+            new WebQueryResourceValidators { ETag = HttpEntityTag.Strong("v2") },
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(NetHttpMethod.Get, "/search");
+        request.Headers.TryAddWithoutValidation("If-None-Match", "\"v2\"").ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        executed.Value.ShouldBeTrue();
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Query/tests/WebQueryValidationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Query/tests/WebQueryValidationTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Web.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using CohesionHttpStatusCode = Assimalign.Cohesion.Http.HttpStatusCode;
+using CohesionMediaType = Assimalign.Cohesion.Http.HttpMediaType;
+using NetHttpMethod = System.Net.Http.HttpMethod;
+using NetHttpStatusCode = System.Net.HttpStatusCode;
+
+namespace Assimalign.Cohesion.Web.Query.Tests;
+
+/// <summary>
+/// RFC 10008 &#167; 2.1 / &#167; 2.3 compliance tests for <c>UseQueryValidation</c>, driven end to
+/// end over the in-memory transport (real client, real HTTP/1.1 exchange, real dispatch): the
+/// missing / malformed / unaccepted <c>Content-Type</c> refusals (400/415), the <c>Accept</c>
+/// negotiation refusal (406), the <c>Accept-Query</c> advertisement, and the pass-through paths.
+/// </summary>
+public class WebQueryValidationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly NetHttpMethod QueryMethod = new("QUERY");
+
+    private static async Task<(WebApplicationTestFactory Factory, HttpClient Client)> CreateEchoAppAsync(
+        Action<WebQueryValidationOptions>? configure = null,
+        CancellationToken cancellationToken = default)
+    {
+        var factory = new WebApplicationTestFactory();
+
+        factory.Application.UseQueryValidation(configure);
+        factory.Application.Use(async (context, next) =>
+        {
+            string body;
+            using (var reader = new System.IO.StreamReader(context.Request.Body, Encoding.UTF8))
+            {
+                body = await reader.ReadToEndAsync(context.RequestCancelled);
+            }
+
+            context.Response.StatusCode = CohesionHttpStatusCode.Ok;
+            byte[] payload = Encoding.UTF8.GetBytes($"{context.Request.Method.Value}:{body}");
+            await context.Response.Body.WriteAsync(payload, context.RequestCancelled);
+        });
+
+        await factory.StartAsync(cancellationToken);
+        return (factory, factory.CreateClient());
+    }
+
+    private static HttpRequestMessage CreateQuery(string uri, HttpContent? content)
+        => new(QueryMethod, uri) { Content = content };
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: QUERY content without a Content-Type is rejected 400 (RFC 10008 §2.3)")]
+    public async Task UseQueryValidation_BodyWithoutContentType_ShouldRejectBadRequest()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(cancellationToken: cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // ByteArrayContent carries no default Content-Type — the wire request declares none.
+        var content = new ByteArrayContent("{\"q\":1}"u8.ToArray());
+        content.Headers.ContentType.ShouldBeNull();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(CreateQuery("/search", content), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: the missing-Content-Type status is 415 when policy selects it")]
+    public async Task UseQueryValidation_BodyWithoutContentTypeAndUnsupportedMediaTypePolicy_ShouldReject415()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.InvalidContentTypeStatusCode = CohesionHttpStatusCode.UnsupportedMediaType,
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("/search", new ByteArrayContent("{\"q\":1}"u8.ToArray())), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: a malformed Content-Type is rejected 400 (RFC 10008 §2.1)")]
+    public async Task UseQueryValidation_MalformedContentType_ShouldRejectBadRequest()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(cancellationToken: cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        var content = new ByteArrayContent("{\"q\":1}"u8.ToArray());
+        content.Headers.TryAddWithoutValidation("Content-Type", "not-a-media-type").ShouldBeTrue();
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(CreateQuery("/search", content), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: a Content-Type outside the Accept-Query set is rejected 415 with the advertisement")]
+    public async Task UseQueryValidation_ContentTypeOutsideAcceptedSet_ShouldReject415WithAcceptQuery()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.AcceptedMediaTypes.Add(CohesionMediaType.Parse("application/json")),
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("/search", new StringContent("name eq 'x'", Encoding.UTF8, "text/plain")), cancellation.Token);
+
+        // Assert — 415, and the rejection advertises what the resource does accept (RFC 10008 §3).
+        response.StatusCode.ShouldBe(NetHttpStatusCode.UnsupportedMediaType);
+        response.Headers.TryGetValues("Accept-Query", out var acceptQuery).ShouldBeTrue();
+        string.Join(",", acceptQuery!).ShouldContain("application/json");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: an accepted Content-Type proceeds unchanged and the 200 advertises Accept-Query")]
+    public async Task UseQueryValidation_AcceptedContentType_ShouldProceedUnchanged()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.AcceptedMediaTypes.Add(CohesionMediaType.Parse("application/json")),
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("/search", new StringContent("{\"q\":1}", Encoding.UTF8, "application/json")), cancellation.Token);
+
+        // Assert — the query reached the terminal middleware with its content intact.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("QUERY:{\"q\":1}");
+        response.Headers.TryGetValues("Accept-Query", out var acceptQuery).ShouldBeTrue();
+        string.Join(",", acceptQuery!).ShouldContain("application/json");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: an unsatisfiable Accept is rejected 406 (RFC 9110 §12.5.1)")]
+    public async Task UseQueryValidation_UnsatisfiableAccept_ShouldReject406()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.SupportedResponseMediaTypes.Add(CohesionMediaType.Parse("application/json")),
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        HttpRequestMessage request = CreateQuery("/search", new StringContent("{\"q\":1}", Encoding.UTF8, "application/json"));
+        request.Headers.Accept.ParseAdd("text/csv");
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.NotAcceptable);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: a missing Accept accepts every representation")]
+    public async Task UseQueryValidation_MissingAccept_ShouldProceed()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.SupportedResponseMediaTypes.Add(CohesionMediaType.Parse("application/json")),
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(
+            CreateQuery("/search", new StringContent("{\"q\":1}", Encoding.UTF8, "application/json")), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: a bodiless QUERY passes through")]
+    public async Task UseQueryValidation_BodilessQuery_ShouldProceed()
+    {
+        // Arrange
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(cancellationToken: cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act — no content at all: nothing to type, nothing to reject.
+        using HttpResponseMessage response = await client.SendAsync(CreateQuery("/search", content: null), cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("QUERY:");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: non-QUERY requests pass through untouched")]
+    public async Task UseQueryValidation_NonQueryMethod_ShouldPassThroughUntouched()
+    {
+        // Arrange — a POST with an untyped body would fail QUERY validation; it must not be touched.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(
+            options => options.AcceptedMediaTypes.Add(CohesionMediaType.Parse("application/json")),
+            cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        using var request = new HttpRequestMessage(NetHttpMethod.Post, "/search")
+        {
+            Content = new ByteArrayContent("a=1"u8.ToArray()),
+        };
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request, cancellation.Token);
+
+        // Assert — reached the terminal echo, and no Accept-Query advertisement was stamped.
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("POST:a=1");
+        response.Headers.TryGetValues("Accept-Query", out _).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: a rejected exchange does not wedge the client's next request")]
+    public async Task UseQueryValidation_RejectionWithUnreadBody_ShouldNotWedgeSubsequentRequest()
+    {
+        // Arrange — the 400 short-circuits without reading the request body; the transport owns
+        // the unread remainder, and the client's next request must still complete.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        (WebApplicationTestFactory factory, HttpClient client) = await CreateEchoAppAsync(cancellationToken: cancellation.Token);
+        await using WebApplicationTestFactory ownedFactory = factory;
+        using HttpClient ownedClient = client;
+
+        // Act
+        using HttpResponseMessage rejected = await client.SendAsync(
+            CreateQuery("/search", new ByteArrayContent(new byte[2048])), cancellation.Token);
+        using HttpResponseMessage ok = await client.SendAsync(
+            CreateQuery("/search", new StringContent("{\"q\":1}", Encoding.UTF8, "application/json")), cancellation.Token);
+
+        // Assert
+        rejected.StatusCode.ShouldBe(NetHttpStatusCode.BadRequest);
+        ok.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.Query] - Validation: InvalidContentTypeStatusCode rejects statuses other than 400/415")]
+    public void InvalidContentTypeStatusCode_OutOfPolicy_ShouldThrow()
+    {
+        var options = new WebQueryValidationOptions();
+
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => options.InvalidContentTypeStatusCode = CohesionHttpStatusCode.NotAcceptable);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.slnx
+++ b/resources/Web/Assimalign.Cohesion.Web.slnx
@@ -142,6 +142,17 @@
 	<Folder Name="/Web/Assimalign.Cohesion.Web.ProblemDetails/tests/">
 		<Project Path="Assimalign.Cohesion.Web.ProblemDetails/tests/Assimalign.Cohesion.Web.ProblemDetails.Tests.csproj" />
 	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Query/" />
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Query/docs/">
+		<File Path="Assimalign.Cohesion.Web.Query/docs/DESIGN.md" />
+		<File Path="Assimalign.Cohesion.Web.Query/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Query/src/">
+		<Project Path="Assimalign.Cohesion.Web.Query/src/Assimalign.Cohesion.Web.Query.csproj" />
+	</Folder>
+	<Folder Name="/Web/Assimalign.Cohesion.Web.Query/tests/">
+		<Project Path="Assimalign.Cohesion.Web.Query/tests/Assimalign.Cohesion.Web.Query.Tests.csproj" />
+	</Folder>
 	<Folder Name="/Web/Assimalign.Cohesion.Web.Routing/">
 		<File Path="Assimalign.Cohesion.Web.Routing/README.md" />
 	</Folder>

--- a/resources/Web/README.md
+++ b/resources/Web/README.md
@@ -70,6 +70,7 @@ A new `Assimalign.Cohesion.Web.<Feature>` project is not done until all of these
 | `Assimalign.Cohesion.Web.Routing` | Router, route patterns/constraints, endpoint metadata bag, link generation |
 | `Assimalign.Cohesion.Web.Api` | Endpoint mapping sugar (`Map`/`MapGet`) over the router — the fluent `.Use(...)` / `IWebApplicationMiddleware` composition model |
 | `Assimalign.Cohesion.Web.ProblemDetails` | The RFC 9457 problem+json payload (model + AOT-safe writer + `WriteProblemDetailsAsync`) |
+| `Assimalign.Cohesion.Web.Query` | RFC 10008 QUERY server rules: request Content-Type validation / Accept-Query negotiation (400/415/406), method-preserving redirect helpers (307/308, 303), conditional QUERY (304/412) |
 | `Assimalign.Cohesion.Web.Authentication` / `.Cookie` / `.Bearer` | Scheme model + builder surface, and the handler packages that graft their scheme verbs onto it |
 | `Assimalign.Cohesion.Web.Authorization` | Authorization contracts (in design) |
 | `Assimalign.Cohesion.Web.CookiePolicy` / `.Cors` / `.Forms` / `.Sessions` / `.Health` | Request-pipeline feature libraries over their `Http.*` counterparts |


### PR DESCRIPTION
## Summary

Implements the umbrella **#877** and all three sub-tasks in one PR (sanctioned batch — one coherent rule-set in one code area, per the plan's §4 row): server-side enforcement of the RFC 10008 QUERY MUST-level rules deferred from #746, consuming the merged #771 media-type primitives, the #755/#792 validator primitives, and the #762 Web runtime. Application/pipeline decisions land middleware-first in the Web runtime per the Http core `DESIGN.md` delineation rule; responses are written imperatively.

### New feature package: `resources/Web/Assimalign.Cohesion.Web.Query`

**#878 — Content-Type validation (§2.1/§2.3):** `UseQueryValidation(options)`
- Query content with a **missing or malformed `Content-Type` → 400** (or **415** via the `InvalidContentTypeStatusCode` policy knob — validated to 400/415 at assignment).
- A parseable type **outside the resource's `Accept-Query` set → 415**, with the accepted set advertised on the rejection (and on pass-through responses) via `HttpAcceptQuery.Serialize()` (RFC 10008 §3).
- An **unsatisfiable `Accept` against the resource's producible representations → 406** (`HttpContentNegotiation`, RFC 9110 §12.5.1; missing `Accept` accepts everything).
- Bodiless QUERYs and non-QUERY methods pass through untouched; options are snapshotted at `Use` time.
- **The generic-vs-per-resource split is decided and documented** (per the #878 AC) in the package `DESIGN.md`: both halves are **one Web middleware — no parse-time `IHttpExchangeInterceptor`**. A `HttpRequestRejectedException` rejection closes the connection by contract; that is disproportionate for a well-framed request, the 400/415 policy is per-resource anyway, and the delineation rule places refusal-to-process decisions at the application level. `422` is deliberately left to applications (semantic invalidity of a parseable query is an application judgment).

**#879 — QUERY preserved across redirects (§2.5):**
- *Server half:* `response.RedirectQuery(location, permanent)` emits **307/308 only** — never 301/302, whose legacy GET rewrite is the "implied GET downgrade" the RFC warns about — and `response.RedirectQueryToGet(location)` emits the one sanctioned method switch, **303 See Other** (§2.5.3).
- *Client half (Http.ClientFactory):* a **factory-owned redirect layer** (`RedirectHttpMessageHandler` + `AllowAutoRedirect`/`MaxAutomaticRedirections` on `NamedHttpClientOptions`; the pooled `SocketsHttpHandler`'s own following is always disabled so exactly one layer acts). QUERY is **re-issued with its original content on 301/302/307/308** and switched to **GET only by 303**; the historical POST→GET rewrite on 301/302 is preserved; `Authorization` is dropped per hop, `https`→`http` downgrades are refused, and exceeding the hop cap surfaces the last 3xx. First `docs/OVERVIEW.md`/`docs/DESIGN.md` for the ClientFactory library (was undocumented).

**#880 — Conditional QUERY evaluates like conditional GET (§2.6):**
- **Core semantic:** `HttpConditionalRequest` now classifies **QUERY as a read method** (GET/HEAD/QUERY) — §2.6 requires the preconditions to evaluate exactly as for the equivalent GET, so a matching `If-None-Match`/`If-Modified-Since` yields **304**, not the 412 a non-read method receives. No consumer re-derivation.
- **Web surface:** `UseQueryConditionals(provider)` middleware (provider returns the resource's validators, or null to pass through) plus `EvaluateQueryPreconditions`/`TryHandleQueryPreconditions` context helpers for handlers — If-* fields parsed off the request (malformed fields ignored per the §13.1.3 posture), evaluated through the core primitives, **304 carrying the validators** (RFC 9110 §15.4.5) / **412** written without executing the query; on Proceed the validators are stamped onto the response for the client's next conditional query.

### Transport fix discovered by the E2E suite

`Content-Length: 0` request bodies were unreadable: `Http1RequestBodyStream` treated CL:0 as an in-progress body, so the first read issued a zero-length wire read that blocked until the min-data-rate gate reclaimed the exchange (408 + connection teardown) — for a perfectly healthy request (the BCL client sends `CL: 0` for a contentless QUERY). Fixed one line in the stream constructor (a zero-length body is born fully read) + a transport regression test. Called out here rather than filed separately because the E2E acceptance tests cannot pass without it.

### Tests (all green)

- **Web.Query 29/29** — Shouldly unit + full-pipeline E2E over the `WebApplicationTestFactory` in-memory transport: every status path (400/415/406, policy knob, advertisement header, pass-throughs, post-rejection connection reuse), raw 307/308/303 shaping + end-to-end redirect flows (the BCL client re-issues QUERY with content over the real wire; 303 lands as a bodiless GET), and 304/412/stamping conditional flows including query-never-executed assertions.
- **Http.ClientFactory 28/28** — 13 new redirect tests (QUERY preserved on 301/302/307/308 with content, 303→GET, POST legacy rewrite, relative Location, https downgrade refusal, credential stripping, hop cap, disable switch) + the existing lifecycle suite unchanged under the wrapper.
- **Http core 1146/1146** — including 5 new §2.6 evaluator rows; **Http.Connections 414/414** — including the CL:0 regression test; **Web.Hosting 46/46**, **Web.Testing 12/12**.

### Wiring (new-Web-project checklist)

`frameworks/Assimalign.Cohesion.App.props` (App.Web ItemGroup — validated by packing `App.Web.Runtime`, which resolves and collects `Assimalign.Cohesion.Web.Query.dll`), `.github/workflows/resource-web.yml` matrix, both slnx files, `resources/Web/README.md` project map row, `docs/OVERVIEW.md` + `docs/DESIGN.md`. The package references only `Assimalign.Cohesion.Web` — hosting-isolation (COHRES001/002) holds by construction. *(Heads-up: sibling Batch-4a PRs touch the same App.props/CI-matrix lines — trivial rebase expected for whoever lands second.)*

Closes #877
Closes #878
Closes #879
Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)