### PR TITLE
feat(content): configurable TextTokenizer over SequenceReader<char> in Content.Text [L01.01.05.10.04]

### DIFF
--- a/.github/workflows/library-content.yml
+++ b/.github/workflows/library-content.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         projects: [
-            'Assimalign.Cohesion.Content'
+            'Assimalign.Cohesion.Content',
+            'Assimalign.Cohesion.Content.Text'
         ]
     steps:
       - uses: actions/checkout@v4

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/README.md
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/README.md
@@ -1,8 +1,9 @@
 # Assimalign.Cohesion.Content.Text
 
 The shared text layer of the Content family: Unicode encoding detection, text content over any
-`IContent`, and line-oriented reading with terminator fidelity. Text-derived formats (Markdown, YAML)
-build on this package.
+`IContent`, line-oriented reading with terminator fidelity, and a configurable literal tokenizer
+(`TextTokenizer`) for building text-format parsers. Text-derived formats (Markdown, YAML) build on
+this package.
 
 - [docs/OVERVIEW.md](./docs/OVERVIEW.md) — purpose, scope, and usage
-- [docs/DESIGN.md](./docs/DESIGN.md) — retained encoding scope, detection, and line-model decisions
+- [docs/DESIGN.md](./docs/DESIGN.md) — retained encoding scope, detection, line-model, and tokenizer decisions

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/docs/DESIGN.md
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/docs/DESIGN.md
@@ -3,9 +3,10 @@
 ## Design intent
 
 The shared text layer of the Content family: how encoded bytes become characters (`ITextContent`,
-`TextEncodingDetector`) and how characters become lines (`TextLineReader`). Text-derived format
-packages (Markdown, YAML) and services that serve or inspect text build on this layer instead of each
-re-implementing encoding detection and line handling.
+`TextEncodingDetector`), how characters become lines (`TextLineReader`), and how characters become
+tokens (`TextTokenizer`). Text-derived format packages (Markdown, YAML) and services that serve or
+inspect text build on this layer instead of each re-implementing encoding detection, line handling,
+and delimiter scanning.
 
 ## Retained encoding scope
 
@@ -44,14 +45,60 @@ and which terminator ended the line (`\n`, `\r\n`, lone `\r`, or none at end of 
 - Empty input yields zero lines, and a trailing terminator does not create a phantom final line —
   `"a\n"` is one line, matching how line-oriented specifications count lines.
 
+## Tokenizer
+
+`TextTokenizer` is the base scanning primitive format parsers build on (the Markdown parser, #468,
+is the first consumer; the static content engine follows): a stack-only `ref struct` over
+`SequenceReader<char>` that splits text into `TextToken` values — matches of caller-registered
+literal tokens, and the runs of text between them, every value a zero-copy slice of the input.
+
+- **A literal token table, not rules or regular expressions.** `TextTokenizerOptions.Tokens` holds
+  `TextTokenDefinition` values: exact texts with a caller-assigned `Id` for parser dispatch and a
+  `TextTokenKind` category. Matching is ordinal, leftmost, and longest-first among definitions
+  sharing a first character (`**` beats `*`), so delimiter-run counting stays a parser concern
+  (CommonMark-style) while the tokenizer stays predictable and vectorizable — text runs advance via
+  `TryAdvanceToAny` over the definitions' first characters. Lexical rules (numbers, identifiers)
+  are a parser-layer concern applied to text runs.
+- **The defaults are the three line terminators as removable definitions** (`\r\n`, `\n`, lone
+  `\r` — the same recognition set as `TextLineReader`). Overriding the defaults *is* editing the
+  list: with default options tokenization degenerates to the line model (text runs separated by
+  `NewLine` tokens with terminator fidelity); removing a terminator lets it flow through text runs.
+- **Whitespace runs are a rule, not a literal** — a run of one-or-more spaces/tabs cannot be
+  expressed as an exact text. `TokenizeWhitespace` opts in; definitions win over runs, including
+  literals that start with whitespace mid-run. Scope is ASCII space and tab: Unicode whitespace
+  classes are a format decision.
+- **Positions are physical and table-independent.** Emitted values are scanned for `\n`/`\r\n`/lone
+  `\r` (a carriage return carries across value and segment boundaries so a split `\r\n` counts
+  once), so `TextPosition` (one-based line/column, zero-based char offset) stays correct even when
+  the new-line defaults are removed and terminators travel inside text runs. A `\n` completing a
+  carriage return across a token boundary reports at the start of the new line; the break still
+  counts once. Columns count UTF-16 code units. Positions exist to feed parser diagnostics
+  (`ContentFormatException.Position`); the tokenizer itself never throws for input — it has no
+  notion of malformed text.
+- **Ref struct out, plain structs in flight.** The tokenizer is stack-only, but `TextToken` holds a
+  `ReadOnlySequence<char>` slice and is an ordinary struct parsers can store and materialize
+  (`ToString()`) on demand. Text runs are emitted before the match that terminated them (the match
+  is held internally), so consumers always see document order.
+- **Construction compiles the table.** The options snapshot (grouped by first character, longest
+  first) happens in the constructor — construct one tokenizer per text, not per line; later options
+  mutations don't affect live tokenizers. Invalid tables (null entries, duplicate texts) throw
+  `ArgumentException` at construction, never during reads.
+
 ## AOT posture
 
 `<IsAotCompatible>true</IsAotCompatible>` (inherited). Pure decoding over BCL `Encoding`/
-`StreamReader`; no reflection, no dynamic code.
+`StreamReader` and span/sequence scanning; no reflection, no dynamic code.
 
 ## Non-goals
 
 - Legacy (non-Unicode) encodings and charset conversion.
 - Unicode normalization (NFC/NFD) — a format- or service-level decision.
 - Grapheme/word segmentation — nothing in the family needs it yet; add when a consumer exists.
+- Rule- or regex-based token definitions and Unicode whitespace classes — the literal table plus
+  the whitespace rule cover structural delimiters; richer lexing belongs to format parsers.
+- A UTF-8 byte-level tokenizer (`SequenceReader<byte>`) — worth adding only when a consumer parses
+  encoded bytes directly instead of decoded text.
+- Streaming/incremental tokenization over `TextReader` — the tokenizer consumes an in-memory
+  `ReadOnlySequence<char>`; buffered bridging from streams is the shared-primitives feature
+  (#438).
 - The Markdown document model — that builds *on* this layer in `Content.Markdown` (#468).

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/docs/OVERVIEW.md
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/docs/OVERVIEW.md
@@ -1,8 +1,9 @@
 # Assimalign.Cohesion.Content.Text — Overview
 
 The shared text layer of the Content family: Unicode encoding detection (UTF-8/16/32 by byte order
-mark or null-byte pattern), text content over any `IContent` (`ITextContent`), and line-oriented
-reading with terminator fidelity (`TextLineReader`).
+mark or null-byte pattern), text content over any `IContent` (`ITextContent`), line-oriented reading
+with terminator fidelity (`TextLineReader`), and configurable literal tokenization
+(`TextTokenizer`) as the base scanning primitive for text-derived format parsers.
 
 ## Scope
 
@@ -10,6 +11,10 @@ reading with terminator fidelity (`TextLineReader`).
 - `TextContentFactory` — text content from strings, from content with a known encoding, or from
   content with detection.
 - `TextLineReader` / `TextLine` / `TextLineEnding` — lines with one-based numbers and exact endings.
+- `TextTokenizer` / `TextToken` / `TextTokenDefinition` / `TextTokenizerOptions` — a stack-only
+  tokenizer over `SequenceReader<char>`: caller-registered literal tokens (defaults are the three
+  line terminators, overridable), zero-copy text-run slices, optional whitespace runs, and
+  line/column/offset positions (`TextPosition`) for parser diagnostics.
 
 ## Dependencies
 
@@ -31,6 +36,19 @@ while (lines.TryReadLine(out var line))
 {
     Console.WriteLine($"{line.Number}: {line.Text} [{line.Ending}]");
 }
+
+// Tokenization for format parsers: register the literals the format cares about.
+var options = new TextTokenizerOptions();
+options.Tokens.Add(new TextTokenDefinition("#", id: 1));
+options.Tokens.Add(new TextTokenDefinition("**", id: 2));
+
+var tokenizer = new TextTokenizer("# Title\n**bold**", options);
+while (tokenizer.TryRead(out var token))
+{
+    // Text runs between matches arrive as TextTokenKind.Text; new-lines keep their exact
+    // terminator; token.Value slices the input without copying.
+    Console.WriteLine($"{token.Position} {token.Kind} '{token}'");
+}
 ```
 
-See [DESIGN.md](./DESIGN.md) for the retained encoding scope and line-model decisions.
+See [DESIGN.md](./DESIGN.md) for the retained encoding scope, line-model, and tokenizer decisions.

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/Internal/TextTokenizerTable.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/Internal/TextTokenizerTable.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// The compiled form of <see cref="TextTokenizerOptions"/>: definitions grouped by first character
+/// and ordered longest-first within each group, plus the candidate-character set the tokenizer
+/// scans for. Compilation snapshots the options — later mutations do not affect this table.
+/// </summary>
+internal sealed class TextTokenizerTable
+{
+    private readonly Dictionary<char, TextTokenDefinition[]> _groups;
+
+    private TextTokenizerTable(
+        Dictionary<char, TextTokenDefinition[]> groups,
+        char[] candidates,
+        bool tokenizeWhitespace,
+        bool whitespaceOverlapsDefinitions)
+    {
+        _groups = groups;
+        Candidates = candidates;
+        TokenizeWhitespace = tokenizeWhitespace;
+        WhitespaceOverlapsDefinitions = whitespaceOverlapsDefinitions;
+    }
+
+    /// <summary>The table for default options: the three new-line definitions, no whitespace runs.</summary>
+    public static TextTokenizerTable Default { get; } = Create(new TextTokenizerOptions());
+
+    /// <summary>Every character that can start a token: definition first characters, plus space and tab when whitespace runs are tokenized.</summary>
+    public char[] Candidates { get; }
+
+    /// <summary>Whether runs of space and tab characters are emitted as whitespace tokens.</summary>
+    public bool TokenizeWhitespace { get; }
+
+    /// <summary>Whether any definition starts with a space or tab, requiring per-character definition checks inside whitespace runs.</summary>
+    public bool WhitespaceOverlapsDefinitions { get; }
+
+    /// <summary>
+    /// Compiles options into a match table, validating the definition list.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the definition list contains a null entry or two definitions with the same text.</exception>
+    public static TextTokenizerTable Create(TextTokenizerOptions options)
+    {
+        var byFirstChar = new Dictionary<char, List<TextTokenDefinition>>();
+        var texts = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var definition in options.Tokens)
+        {
+            if (definition is null)
+            {
+                throw new ArgumentException("Token definitions must not be null.", nameof(options));
+            }
+
+            if (!texts.Add(definition.Text))
+            {
+                throw new ArgumentException($"Duplicate token definition text '{Escape(definition.Text)}'.", nameof(options));
+            }
+
+            var first = definition.Text[0];
+            if (!byFirstChar.TryGetValue(first, out var group))
+            {
+                byFirstChar[first] = group = [];
+            }
+
+            group.Add(definition);
+        }
+
+        var groups = new Dictionary<char, TextTokenDefinition[]>(byFirstChar.Count);
+        foreach (var (first, group) in byFirstChar)
+        {
+            // Longest first, so the longest literal sharing a first character wins ("**" over "*").
+            group.Sort(static (a, b) => b.Text.Length.CompareTo(a.Text.Length));
+            groups[first] = [.. group];
+        }
+
+        var candidateCount = groups.Count;
+        var tokenizeWhitespace = options.TokenizeWhitespace;
+        if (tokenizeWhitespace)
+        {
+            candidateCount += (groups.ContainsKey(' ') ? 0 : 1) + (groups.ContainsKey('\t') ? 0 : 1);
+        }
+
+        var candidates = new char[candidateCount];
+        var index = 0;
+        foreach (var first in groups.Keys)
+        {
+            candidates[index++] = first;
+        }
+
+        if (tokenizeWhitespace)
+        {
+            if (!groups.ContainsKey(' '))
+            {
+                candidates[index++] = ' ';
+            }
+
+            if (!groups.ContainsKey('\t'))
+            {
+                candidates[index] = '\t';
+            }
+        }
+
+        var whitespaceOverlaps = tokenizeWhitespace && (groups.ContainsKey(' ') || groups.ContainsKey('\t'));
+        return new TextTokenizerTable(groups, candidates, tokenizeWhitespace, whitespaceOverlaps);
+    }
+
+    /// <summary>
+    /// Tries to match a definition at the reader's current position, testing the longest literal
+    /// first among definitions sharing the current character.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the candidate character.</param>
+    /// <param name="advancePast"><see langword="true"/> to consume the matched literal; <see langword="false"/> to test without consuming.</param>
+    /// <param name="definition">The matched definition, when one matched.</param>
+    /// <returns><see langword="true"/> when a definition matched.</returns>
+    public bool TryMatch(ref SequenceReader<char> reader, bool advancePast, [NotNullWhen(true)] out TextTokenDefinition? definition)
+    {
+        if (reader.TryPeek(out var first) && _groups.TryGetValue(first, out var group))
+        {
+            foreach (var candidate in group)
+            {
+                if (reader.IsNext(candidate.Text.AsSpan(), advancePast))
+                {
+                    definition = candidate;
+                    return true;
+                }
+            }
+        }
+
+        definition = null;
+        return false;
+    }
+
+    private static string Escape(string text)
+        => text.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextPosition.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextPosition.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// A position within text: a one-based line number, a one-based character column, and a zero-based
+/// character offset from the start of the text.
+/// </summary>
+/// <remarks>
+/// Lines are physical: <c>\n</c>, <c>\r\n</c>, and lone <c>\r</c> each advance the line by one,
+/// matching the package line model. Columns and offsets count UTF-16 code units — a tab is one
+/// column, and characters outside the basic multilingual plane count two.
+/// </remarks>
+/// <param name="line">The one-based line number.</param>
+/// <param name="column">The one-based character column within the line.</param>
+/// <param name="offset">The zero-based character offset from the start of the text.</param>
+public readonly struct TextPosition(int line, int column, long offset) : IEquatable<TextPosition>
+{
+    /// <summary>Gets the position of the first character of text: line one, column one, offset zero.</summary>
+    public static TextPosition Start { get; } = new(1, 1, 0);
+
+    /// <summary>Gets the one-based line number.</summary>
+    public int Line { get; } = line;
+
+    /// <summary>Gets the one-based character column within the line.</summary>
+    public int Column { get; } = column;
+
+    /// <summary>Gets the zero-based character offset from the start of the text.</summary>
+    public long Offset { get; } = offset;
+
+    /// <summary>
+    /// Determines whether this position equals another.
+    /// </summary>
+    /// <param name="other">The position to compare with.</param>
+    /// <returns><see langword="true"/> when line, column, and offset are all equal.</returns>
+    public bool Equals(TextPosition other) => Line == other.Line && Column == other.Column && Offset == other.Offset;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is TextPosition other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Line, Column, Offset);
+
+    /// <summary>
+    /// Determines whether two positions are equal.
+    /// </summary>
+    /// <param name="left">The first position.</param>
+    /// <param name="right">The second position.</param>
+    /// <returns><see langword="true"/> when the positions are equal.</returns>
+    public static bool operator ==(TextPosition left, TextPosition right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two positions are unequal.
+    /// </summary>
+    /// <param name="left">The first position.</param>
+    /// <param name="right">The second position.</param>
+    /// <returns><see langword="true"/> when the positions differ.</returns>
+    public static bool operator !=(TextPosition left, TextPosition right) => !left.Equals(right);
+
+    /// <summary>Returns the position as <c>(line,column)</c>.</summary>
+    /// <returns>The formatted position.</returns>
+    public override string ToString() => $"({Line},{Column})";
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextToken.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextToken.cs
@@ -1,0 +1,38 @@
+using System.Buffers;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// A token produced by <see cref="TextTokenizer"/>: its kind, the definition that matched (when one
+/// did), its value as a slice of the tokenized text, and the position of its first character.
+/// </summary>
+/// <remarks>
+/// The value is a slice of the input sequence — no characters are copied, and the token remains an
+/// ordinary struct that parsers may store, unlike the stack-only tokenizer that produced it. The
+/// slice is valid as long as the memory backing the tokenized sequence is.
+/// </remarks>
+/// <param name="kind">The structural kind of the token.</param>
+/// <param name="definition">The definition that produced the token, or <see langword="null"/> for implicit text and whitespace runs.</param>
+/// <param name="value">The token value as a slice of the tokenized text.</param>
+/// <param name="position">The position of the token's first character.</param>
+public readonly struct TextToken(TextTokenKind kind, TextTokenDefinition? definition, ReadOnlySequence<char> value, TextPosition position)
+{
+    /// <summary>Gets the structural kind of the token.</summary>
+    public TextTokenKind Kind { get; } = kind;
+
+    /// <summary>Gets the definition that produced the token, or <see langword="null"/> for implicit text and whitespace runs.</summary>
+    public TextTokenDefinition? Definition { get; } = definition;
+
+    /// <summary>Gets the caller-assigned identifier of the matched definition, or zero for implicit runs.</summary>
+    public int Id => Definition?.Id ?? 0;
+
+    /// <summary>Gets the token value as a slice of the tokenized text. No characters are copied.</summary>
+    public ReadOnlySequence<char> Value { get; } = value;
+
+    /// <summary>Gets the position of the token's first character.</summary>
+    public TextPosition Position { get; } = position;
+
+    /// <summary>Materializes the token value as a string.</summary>
+    /// <returns>The token value.</returns>
+    public override string ToString() => Value.ToString();
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenDefinition.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenDefinition.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// A literal token recognized by <see cref="TextTokenizer"/>: the exact text to match, an optional
+/// caller-assigned identifier for parser dispatch, and the kind matches are reported as.
+/// </summary>
+/// <remarks>
+/// Matching is ordinal and case-sensitive. When definitions share a first character the longest
+/// match wins, so registering both <c>**</c> and <c>*</c> tokenizes <c>**</c> as a single token.
+/// Definitions are immutable and safe to share across tokenizers and options instances.
+/// </remarks>
+public sealed class TextTokenDefinition
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextTokenDefinition"/> class.
+    /// </summary>
+    /// <param name="text">The exact text to match. Must be non-empty.</param>
+    /// <param name="id">An optional caller-assigned identifier carried by matching tokens for parser dispatch.</param>
+    /// <param name="kind">The kind matching tokens are reported as. <see cref="TextTokenKind.Text"/> is not permitted — text is the implicit kind of runs between matches.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="text"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="text"/> is empty, or when <paramref name="kind"/> is <see cref="TextTokenKind.Text"/> or not a defined kind.</exception>
+    public TextTokenDefinition(string text, int id = 0, TextTokenKind kind = TextTokenKind.Delimiter)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        if (kind is not (TextTokenKind.Delimiter or TextTokenKind.NewLine or TextTokenKind.Whitespace))
+        {
+            throw new ArgumentException("A definition must be a delimiter, new-line, or whitespace token; text is the implicit kind of runs between matches.", nameof(kind));
+        }
+
+        Text = text;
+        Id = id;
+        Kind = kind;
+    }
+
+    /// <summary>Gets the exact text this definition matches.</summary>
+    public string Text { get; }
+
+    /// <summary>Gets the caller-assigned identifier carried by matching tokens, or zero when unassigned.</summary>
+    public int Id { get; }
+
+    /// <summary>Gets the kind matching tokens are reported as.</summary>
+    public TextTokenKind Kind { get; }
+
+    /// <summary>Gets the definition for the carriage-return/line-feed terminator (<c>\r\n</c>).</summary>
+    public static TextTokenDefinition CarriageReturnLineFeed { get; } = new("\r\n", kind: TextTokenKind.NewLine);
+
+    /// <summary>Gets the definition for the line-feed terminator (<c>\n</c>).</summary>
+    public static TextTokenDefinition LineFeed { get; } = new("\n", kind: TextTokenKind.NewLine);
+
+    /// <summary>Gets the definition for the lone carriage-return terminator (<c>\r</c>).</summary>
+    public static TextTokenDefinition CarriageReturn { get; } = new("\r", kind: TextTokenKind.NewLine);
+
+    /// <summary>Returns the matched text of the definition.</summary>
+    /// <returns>The exact text this definition matches.</returns>
+    public override string ToString() => Text;
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenKind.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenKind.cs
@@ -1,0 +1,25 @@
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// The structural category of a <see cref="TextToken"/>.
+/// </summary>
+public enum TextTokenKind
+{
+    /// <summary>
+    /// A run of characters between recognized tokens. Text is the implicit kind — it is produced by
+    /// the tokenizer, never assigned to a <see cref="TextTokenDefinition"/>.
+    /// </summary>
+    Text = 0,
+
+    /// <summary>A match of a <see cref="TextTokenDefinition"/> categorized as a structural delimiter.</summary>
+    Delimiter,
+
+    /// <summary>A match of a <see cref="TextTokenDefinition"/> categorized as a line terminator.</summary>
+    NewLine,
+
+    /// <summary>
+    /// A run of space or tab characters (when <see cref="TextTokenizerOptions.TokenizeWhitespace"/>
+    /// is enabled), or a match of a <see cref="TextTokenDefinition"/> categorized as whitespace.
+    /// </summary>
+    Whitespace,
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenizer.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenizer.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Buffers;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// Tokenizes text into <see cref="TextToken"/> values by scanning for a configurable set of literal
+/// tokens (<see cref="TextTokenizerOptions"/>), reporting the runs of text between matches as slices
+/// of the input without copying. The tokenizer reads through <see cref="SequenceReader{T}"/>, so it
+/// works over single- and multi-segment <see cref="ReadOnlySequence{T}"/> input alike — including
+/// literals that span segment boundaries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// With default options the only recognized tokens are the line terminators (<c>\r\n</c>, <c>\n</c>,
+/// lone <c>\r</c>), so tokenization degenerates to the package line model: text runs separated by
+/// <see cref="TextTokenKind.NewLine"/> tokens with terminator fidelity. Format parsers add their own
+/// delimiters through <see cref="TextTokenizerOptions.Tokens"/>.
+/// </para>
+/// <para>
+/// Matching is ordinal and leftmost; among definitions sharing a first character the longest literal
+/// wins. Positions are physical: any <c>\n</c>, <c>\r\n</c>, or lone <c>\r</c> advances the reported
+/// line whether it was matched as a token or flowed through a text run, so positions stay correct
+/// even when the new-line defaults are removed.
+/// </para>
+/// <para>
+/// The tokenizer is a stack-only <see langword="ref"/> struct; the tokens it produces are ordinary
+/// structs that parsers may store. Constructing a tokenizer compiles the options' token table —
+/// construct one per text to tokenize, not one per line.
+/// </para>
+/// </remarks>
+public ref struct TextTokenizer
+{
+    private SequenceReader<char> _reader;
+    private readonly TextTokenizerTable _table;
+    private TextTokenKind _pendingKind;
+    private TextTokenDefinition? _pendingDefinition;
+    private ReadOnlySequence<char> _pendingValue;
+    private bool _hasPending;
+    private int _line;
+    private int _column;
+    private long _offset;
+    private bool _carriageReturnPending;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextTokenizer"/> struct over a string.
+    /// </summary>
+    /// <param name="text">The text to tokenize.</param>
+    /// <param name="options">The tokens to recognize, or <see langword="null"/> for the default new-line tokens.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="text"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options"/> contains a null definition or two definitions with the same text.</exception>
+    public TextTokenizer(string text, TextTokenizerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        _reader = new SequenceReader<char>(new ReadOnlySequence<char>(text.AsMemory()));
+        _table = options is null ? TextTokenizerTable.Default : TextTokenizerTable.Create(options);
+        _line = 1;
+        _column = 1;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextTokenizer"/> struct over a memory of characters.
+    /// </summary>
+    /// <param name="text">The text to tokenize.</param>
+    /// <param name="options">The tokens to recognize, or <see langword="null"/> for the default new-line tokens.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options"/> contains a null definition or two definitions with the same text.</exception>
+    public TextTokenizer(ReadOnlyMemory<char> text, TextTokenizerOptions? options = null)
+    {
+        _reader = new SequenceReader<char>(new ReadOnlySequence<char>(text));
+        _table = options is null ? TextTokenizerTable.Default : TextTokenizerTable.Create(options);
+        _line = 1;
+        _column = 1;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextTokenizer"/> struct over a character sequence.
+    /// </summary>
+    /// <param name="text">The text to tokenize.</param>
+    /// <param name="options">The tokens to recognize, or <see langword="null"/> for the default new-line tokens.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options"/> contains a null definition or two definitions with the same text.</exception>
+    public TextTokenizer(ReadOnlySequence<char> text, TextTokenizerOptions? options = null)
+    {
+        _reader = new SequenceReader<char>(text);
+        _table = options is null ? TextTokenizerTable.Default : TextTokenizerTable.Create(options);
+        _line = 1;
+        _column = 1;
+    }
+
+    /// <summary>Gets the position of the next token <see cref="TryRead"/> will produce, or the position after the final character once tokenization completes.</summary>
+    public readonly TextPosition Position => new(_line, _column, _offset);
+
+    /// <summary>
+    /// Reads the next token.
+    /// </summary>
+    /// <param name="token">When this method returns <see langword="true"/>, the token that was read.</param>
+    /// <returns><see langword="true"/> when a token was read; <see langword="false"/> at the end of the text.</returns>
+    public bool TryRead(out TextToken token)
+    {
+        if (_hasPending)
+        {
+            _hasPending = false;
+            token = Emit(_pendingKind, _pendingDefinition, _pendingValue);
+            return true;
+        }
+
+        if (_reader.End)
+        {
+            token = default;
+            return false;
+        }
+
+        var textStart = _reader.Position;
+        while (true)
+        {
+            if (_table.Candidates.Length == 0 || !_reader.TryAdvanceToAny(_table.Candidates, advancePastDelimiter: false))
+            {
+                // No further candidate characters: the rest of the text is one text run.
+                _reader.AdvanceToEnd();
+                break;
+            }
+
+            var candidateStart = _reader.Position;
+            if (_table.TryMatch(ref _reader, advancePast: true, out var definition))
+            {
+                var value = _reader.Sequence.Slice(candidateStart, _reader.Position);
+                token = EmitOrHold(textStart, candidateStart, definition.Kind, definition, value);
+                return true;
+            }
+
+            if (_table.TokenizeWhitespace && _reader.TryPeek(out var next) && next is ' ' or '\t')
+            {
+                var run = ReadWhitespaceRun();
+                token = EmitOrHold(textStart, candidateStart, TextTokenKind.Whitespace, definition: null, run);
+                return true;
+            }
+
+            // A candidate character that begins no token belongs to the surrounding text run.
+            _reader.Advance(1);
+        }
+
+        token = Emit(TextTokenKind.Text, definition: null, _reader.Sequence.Slice(textStart, _reader.Position));
+        return true;
+    }
+
+    /// <summary>
+    /// Consumes a run of space and tab characters. When a definition starts with a space or tab the
+    /// run is checked character by character so a literal starting mid-run still gets recognized on
+    /// the next read; otherwise the run is consumed in one vectorized advance.
+    /// </summary>
+    private ReadOnlySequence<char> ReadWhitespaceRun()
+    {
+        var start = _reader.Position;
+        if (_table.WhitespaceOverlapsDefinitions)
+        {
+            while (!_table.TryMatch(ref _reader, advancePast: false, out _)
+                && _reader.TryPeek(out var next) && next is ' ' or '\t')
+            {
+                _reader.Advance(1);
+            }
+        }
+        else
+        {
+            _reader.AdvancePastAny(' ', '\t');
+        }
+
+        return _reader.Sequence.Slice(start, _reader.Position);
+    }
+
+    /// <summary>
+    /// Emits the matched token directly when no text precedes it; otherwise holds it and emits the
+    /// preceding text run first, so callers always see text before the match that terminated it.
+    /// </summary>
+    private TextToken EmitOrHold(SequencePosition textStart, SequencePosition tokenStart, TextTokenKind kind, TextTokenDefinition? definition, in ReadOnlySequence<char> value)
+    {
+        var text = _reader.Sequence.Slice(textStart, tokenStart);
+        if (text.IsEmpty)
+        {
+            return Emit(kind, definition, value);
+        }
+
+        _pendingKind = kind;
+        _pendingDefinition = definition;
+        _pendingValue = value;
+        _hasPending = true;
+        return Emit(TextTokenKind.Text, definition: null, text);
+    }
+
+    private TextToken Emit(TextTokenKind kind, TextTokenDefinition? definition, in ReadOnlySequence<char> value)
+    {
+        var token = new TextToken(kind, definition, value, new TextPosition(_line, _column, _offset));
+        AdvancePosition(value);
+        return token;
+    }
+
+    /// <summary>
+    /// Advances the tracked position through an emitted value. Line breaks are counted physically —
+    /// <c>\n</c>, <c>\r\n</c>, and lone <c>\r</c> each advance the line once, with a carriage return
+    /// carried across value (and segment) boundaries so a split <c>\r\n</c> still counts once.
+    /// </summary>
+    private void AdvancePosition(in ReadOnlySequence<char> value)
+    {
+        foreach (var memory in value)
+        {
+            var span = memory.Span;
+            var index = 0;
+            while (index < span.Length)
+            {
+                if (_carriageReturnPending)
+                {
+                    _carriageReturnPending = false;
+                    if (span[index] == '\n')
+                    {
+                        index++;
+                        continue;
+                    }
+                }
+
+                var breakIndex = span[index..].IndexOfAny('\r', '\n');
+                if (breakIndex < 0)
+                {
+                    _column += span.Length - index;
+                    break;
+                }
+
+                _line++;
+                _column = 1;
+                _carriageReturnPending = span[index + breakIndex] == '\r';
+                index += breakIndex + 1;
+            }
+        }
+
+        _offset += value.Length;
+    }
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenizerOptions.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/src/TextTokenizerOptions.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Cohesion.Content.Text;
+
+/// <summary>
+/// Options controlling which tokens <see cref="TextTokenizer"/> recognizes.
+/// </summary>
+/// <remarks>
+/// A tokenizer compiles the options into an internal match table when it is constructed; mutations
+/// after that point affect only tokenizers constructed later. Reuse one options instance across the
+/// tokenizers of a format rather than rebuilding the list per call.
+/// </remarks>
+public sealed class TextTokenizerOptions
+{
+    /// <summary>
+    /// Gets the token definitions to recognize. The list is pre-populated with the default new-line
+    /// definitions (<see cref="TextTokenDefinition.CarriageReturnLineFeed"/>,
+    /// <see cref="TextTokenDefinition.LineFeed"/>, <see cref="TextTokenDefinition.CarriageReturn"/>);
+    /// remove or replace those entries to override the defaults, and add definitions for the tokens a
+    /// format cares about.
+    /// </summary>
+    public IList<TextTokenDefinition> Tokens { get; } = new List<TextTokenDefinition>
+    {
+        TextTokenDefinition.CarriageReturnLineFeed,
+        TextTokenDefinition.LineFeed,
+        TextTokenDefinition.CarriageReturn,
+    };
+
+    /// <summary>
+    /// Gets or sets a value indicating whether runs of space and tab characters between tokens are
+    /// emitted as <see cref="TextTokenKind.Whitespace"/> tokens instead of joining the surrounding
+    /// text runs. The default is <see langword="false"/>.
+    /// </summary>
+    public bool TokenizeWhitespace { get; set; }
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/tests/TestObjects/TestSequenceFactory.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/tests/TestObjects/TestSequenceFactory.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Buffers;
+
+namespace Assimalign.Cohesion.Content.Text.Tests;
+
+internal static class TestSequenceFactory
+{
+    public static ReadOnlySequence<char> Create(params string[] segments)
+    {
+        if (segments.Length == 1)
+        {
+            return new ReadOnlySequence<char>(segments[0].AsMemory());
+        }
+
+        var first = new Segment(segments[0].AsMemory(), 0);
+        var last = first;
+        for (var i = 1; i < segments.Length; i++)
+        {
+            last = last.Append(segments[i].AsMemory());
+        }
+
+        return new ReadOnlySequence<char>(first, 0, last, last.Memory.Length);
+    }
+
+    private sealed class Segment : ReadOnlySequenceSegment<char>
+    {
+        public Segment(ReadOnlyMemory<char> memory, long runningIndex)
+        {
+            Memory = memory;
+            RunningIndex = runningIndex;
+        }
+
+        public Segment Append(ReadOnlyMemory<char> memory)
+        {
+            var segment = new Segment(memory, RunningIndex + Memory.Length);
+            Next = segment;
+            return segment;
+        }
+    }
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Text/tests/TextTokenizerTests.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Text/tests/TextTokenizerTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Cohesion.Content.Text.Tests;
+
+public class TextTokenizerTests
+{
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: default options produce text and new-line tokens")]
+    public void TryRead_DefaultOptions_ProducesTextAndNewLineTokens()
+    {
+        var tokens = ReadAll("one\ntwo\r\nthree\rfour");
+
+        tokens.Count.ShouldBe(7);
+        tokens[0].Kind.ShouldBe(TextTokenKind.Text);
+        tokens[0].ToString().ShouldBe("one");
+        tokens[1].Kind.ShouldBe(TextTokenKind.NewLine);
+        tokens[1].Definition.ShouldBeSameAs(TextTokenDefinition.LineFeed);
+        tokens[2].ToString().ShouldBe("two");
+        tokens[3].Definition.ShouldBeSameAs(TextTokenDefinition.CarriageReturnLineFeed);
+        tokens[3].ToString().ShouldBe("\r\n");
+        tokens[4].ToString().ShouldBe("three");
+        tokens[5].Definition.ShouldBeSameAs(TextTokenDefinition.CarriageReturn);
+        tokens[5].ToString().ShouldBe("\r");
+        tokens[6].Kind.ShouldBe(TextTokenKind.Text);
+        tokens[6].ToString().ShouldBe("four");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: empty input yields no tokens")]
+    public void TryRead_EmptyInput_YieldsNoTokens()
+    {
+        ReadAll(string.Empty).ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: token-free input is one text run starting at the start position")]
+    public void TryRead_TextOnly_YieldsSingleTextToken()
+    {
+        var tokens = ReadAll("plain text");
+
+        tokens.Count.ShouldBe(1);
+        tokens[0].Kind.ShouldBe(TextTokenKind.Text);
+        tokens[0].ToString().ShouldBe("plain text");
+        tokens[0].Position.ShouldBe(TextPosition.Start);
+        tokens[0].Definition.ShouldBeNull();
+        tokens[0].Id.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a trailing terminator produces no phantom text token")]
+    public void TryRead_TrailingTerminator_NoPhantomText()
+    {
+        var tokens = ReadAll("a\n");
+
+        tokens.Count.ShouldBe(2);
+        tokens[0].ToString().ShouldBe("a");
+        tokens[1].Kind.ShouldBe(TextTokenKind.NewLine);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: custom delimiters match and carry their assigned ids")]
+    public void TryRead_CustomDelimiters_MatchAndCarryIds()
+    {
+        var options = new TextTokenizerOptions();
+        var hash = new TextTokenDefinition("#", id: 1);
+        var star = new TextTokenDefinition("*", id: 2);
+        options.Tokens.Add(hash);
+        options.Tokens.Add(star);
+
+        var tokens = ReadAll("# Title *x*", options);
+
+        tokens.Count.ShouldBe(5);
+        tokens[0].Kind.ShouldBe(TextTokenKind.Delimiter);
+        tokens[0].Definition.ShouldBeSameAs(hash);
+        tokens[0].Id.ShouldBe(1);
+        tokens[1].ToString().ShouldBe(" Title ");
+        tokens[2].Definition.ShouldBeSameAs(star);
+        tokens[3].ToString().ShouldBe("x");
+        tokens[4].Id.ShouldBe(2);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: the longest literal sharing a first character wins")]
+    public void TryRead_SharedFirstCharacter_LongestLiteralWins()
+    {
+        var options = new TextTokenizerOptions();
+        var star = new TextTokenDefinition("*", id: 1);
+        var doubleStar = new TextTokenDefinition("**", id: 2);
+        options.Tokens.Add(star);
+        options.Tokens.Add(doubleStar);
+
+        var tokens = ReadAll("**a*", options);
+
+        tokens.Count.ShouldBe(3);
+        tokens[0].Definition.ShouldBeSameAs(doubleStar);
+        tokens[1].ToString().ShouldBe("a");
+        tokens[2].Definition.ShouldBeSameAs(star);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: an unmatched candidate prefix flows into the text run")]
+    public void TryRead_UnmatchedCandidatePrefix_FlowsIntoText()
+    {
+        var options = new TextTokenizerOptions();
+        var doubleStar = new TextTokenDefinition("**");
+        options.Tokens.Add(doubleStar);
+
+        var tokens = ReadAll("*a**b", options);
+
+        tokens.Count.ShouldBe(3);
+        tokens[0].Kind.ShouldBe(TextTokenKind.Text);
+        tokens[0].ToString().ShouldBe("*a");
+        tokens[1].Definition.ShouldBeSameAs(doubleStar);
+        tokens[2].ToString().ShouldBe("b");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: overridden defaults let unlisted terminators flow into text")]
+    public void TryRead_OverriddenDefaults_UnlistedTerminatorsFlowIntoText()
+    {
+        var options = new TextTokenizerOptions();
+        options.Tokens.Clear();
+        options.Tokens.Add(TextTokenDefinition.LineFeed);
+
+        var tokens = ReadAll("a\r\nb", options);
+
+        tokens.Count.ShouldBe(3);
+        tokens[0].ToString().ShouldBe("a\r");
+        tokens[1].Definition.ShouldBeSameAs(TextTokenDefinition.LineFeed);
+        tokens[1].Position.ShouldBe(new TextPosition(2, 1, 2));
+        tokens[2].ToString().ShouldBe("b");
+        tokens[2].Position.ShouldBe(new TextPosition(2, 1, 3));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a cleared table produces one text run while lines keep counting")]
+    public void TryRead_ClearedTokens_WholeInputIsOneTextRun()
+    {
+        var options = new TextTokenizerOptions();
+        options.Tokens.Clear();
+        var tokenizer = new TextTokenizer("a\nb", options);
+
+        tokenizer.TryRead(out var token).ShouldBeTrue();
+        token.Kind.ShouldBe(TextTokenKind.Text);
+        token.ToString().ShouldBe("a\nb");
+        tokenizer.TryRead(out _).ShouldBeFalse();
+        tokenizer.Position.ShouldBe(new TextPosition(2, 2, 3));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: whitespace runs are emitted when enabled")]
+    public void TryRead_TokenizeWhitespace_EmitsWhitespaceRuns()
+    {
+        var options = new TextTokenizerOptions { TokenizeWhitespace = true };
+
+        var tokens = ReadAll("one  \ttwo three", options);
+
+        tokens.Count.ShouldBe(5);
+        tokens[0].ToString().ShouldBe("one");
+        tokens[1].Kind.ShouldBe(TextTokenKind.Whitespace);
+        tokens[1].ToString().ShouldBe("  \t");
+        tokens[1].Definition.ShouldBeNull();
+        tokens[2].ToString().ShouldBe("two");
+        tokens[3].ToString().ShouldBe(" ");
+        tokens[4].ToString().ShouldBe("three");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a literal starting with whitespace is recognized inside a run")]
+    public void TryRead_WhitespaceOverlappingDefinition_StopsRunAtLiteral()
+    {
+        var options = new TextTokenizerOptions { TokenizeWhitespace = true };
+        var dash = new TextTokenDefinition("\t-", id: 9);
+        options.Tokens.Add(dash);
+
+        var tokens = ReadAll("a \t- b", options);
+
+        tokens.Count.ShouldBe(5);
+        tokens[0].ToString().ShouldBe("a");
+        tokens[1].Kind.ShouldBe(TextTokenKind.Whitespace);
+        tokens[1].ToString().ShouldBe(" ");
+        tokens[2].Definition.ShouldBeSameAs(dash);
+        tokens[3].Kind.ShouldBe(TextTokenKind.Whitespace);
+        tokens[3].ToString().ShouldBe(" ");
+        tokens[4].ToString().ShouldBe("b");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: positions report one-based lines and columns with char offsets")]
+    public void TryRead_Positions_TrackLinesColumnsAndOffsets()
+    {
+        var options = new TextTokenizerOptions();
+        options.Tokens.Add(new TextTokenDefinition("#"));
+
+        var tokens = ReadAll("ab\n#cd", options);
+
+        tokens.Count.ShouldBe(4);
+        tokens[0].Position.ShouldBe(new TextPosition(1, 1, 0));
+        tokens[1].Position.ShouldBe(new TextPosition(1, 3, 2));
+        tokens[2].Position.ShouldBe(new TextPosition(2, 1, 3));
+        tokens[3].Position.ShouldBe(new TextPosition(2, 2, 4));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: literals match across segment boundaries")]
+    public void TryRead_MultiSegmentSequence_MatchesLiteralAcrossSegments()
+    {
+        var options = new TextTokenizerOptions();
+        var doubleStar = new TextTokenDefinition("**");
+        options.Tokens.Add(doubleStar);
+        var sequence = TestSequenceFactory.Create("ab*", "*cd");
+
+        var tokens = ReadAll(sequence, options);
+
+        tokens.Count.ShouldBe(3);
+        tokens[0].ToString().ShouldBe("ab");
+        tokens[1].Definition.ShouldBeSameAs(doubleStar);
+        tokens[1].ToString().ShouldBe("**");
+        tokens[2].ToString().ShouldBe("cd");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a terminator split across segments counts one line break")]
+    public void TryRead_MultiSegmentSequence_TracksPositionsAcrossSegments()
+    {
+        var sequence = TestSequenceFactory.Create("a\r", "\nb");
+
+        var tokens = ReadAll(sequence, options: null);
+
+        tokens.Count.ShouldBe(3);
+        tokens[0].ToString().ShouldBe("a");
+        tokens[1].Definition.ShouldBeSameAs(TextTokenDefinition.CarriageReturnLineFeed);
+        tokens[1].Position.ShouldBe(new TextPosition(1, 2, 1));
+        tokens[2].ToString().ShouldBe("b");
+        tokens[2].Position.ShouldBe(new TextPosition(2, 1, 3));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: token values slice the input rather than copying")]
+    public void TryRead_TokenValues_SliceTheInput()
+    {
+        var memory = "x*y".AsMemory();
+        var options = new TextTokenizerOptions();
+        options.Tokens.Add(new TextTokenDefinition("*"));
+        var tokenizer = new TextTokenizer(memory, options);
+
+        tokenizer.TryRead(out var token).ShouldBeTrue();
+
+        token.Value.IsSingleSegment.ShouldBeTrue();
+        var overlaps = MemoryMarshal.TryGetString(token.Value.First, out var text, out var start, out _);
+        overlaps.ShouldBeTrue();
+        text.ShouldBe("x*y");
+        start.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: duplicate definition texts are rejected")]
+    public void Constructor_DuplicateDefinitions_Throws()
+    {
+        var options = new TextTokenizerOptions();
+        options.Tokens.Add(new TextTokenDefinition("*"));
+        options.Tokens.Add(new TextTokenDefinition("*", id: 2));
+
+        Should.Throw<ArgumentException>(() => new TextTokenizer("a", options));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a null definition entry is rejected")]
+    public void Constructor_NullDefinitionEntry_Throws()
+    {
+        var options = new TextTokenizerOptions();
+        options.Tokens.Add(null!);
+
+        Should.Throw<ArgumentException>(() => new TextTokenizer("a", options));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: tokenizing a null string is rejected")]
+    public void Constructor_NullString_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new TextTokenizer((string)null!));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: definitions reject empty text and the implicit text kind")]
+    public void Definition_InvalidArguments_Throw()
+    {
+        Should.Throw<ArgumentNullException>(() => new TextTokenDefinition(null!));
+        Should.Throw<ArgumentException>(() => new TextTokenDefinition(string.Empty));
+        Should.Throw<ArgumentException>(() => new TextTokenDefinition("x", kind: TextTokenKind.Text));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: reads after the end keep returning false")]
+    public void TryRead_AfterEnd_ReturnsFalse()
+    {
+        var tokenizer = new TextTokenizer("a");
+
+        tokenizer.TryRead(out _).ShouldBeTrue();
+        tokenizer.TryRead(out _).ShouldBeFalse();
+        tokenizer.TryRead(out _).ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Text] - Tokenizer: a default instance reads nothing")]
+    public void TryRead_DefaultInstance_ReturnsFalse()
+    {
+        var tokenizer = default(TextTokenizer);
+
+        tokenizer.TryRead(out _).ShouldBeFalse();
+    }
+
+    private static List<TextToken> ReadAll(string text, TextTokenizerOptions? options = null)
+    {
+        var tokenizer = new TextTokenizer(text, options);
+        return ReadAll(ref tokenizer);
+    }
+
+    private static List<TextToken> ReadAll(ReadOnlySequence<char> text, TextTokenizerOptions? options)
+    {
+        var tokenizer = new TextTokenizer(text, options);
+        return ReadAll(ref tokenizer);
+    }
+
+    private static List<TextToken> ReadAll(ref TextTokenizer tokenizer)
+    {
+        var tokens = new List<TextToken>();
+        while (tokenizer.TryRead(out var token))
+        {
+            tokens.Add(token);
+        }
+
+        return tokens;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the base scanning primitive the text-derived format packages build on — the first piece of finishing the Text side of [L01.01.05.10] (#466) ahead of the `Content.Markdown` expansion (#468) and the future static content engine resource.

- **`TextTokenizer`** — a stack-only `ref struct` over `System.Buffers.SequenceReader<char>` accepting `string`, `ReadOnlyMemory<char>`, or `ReadOnlySequence<char>` input (literals match across segment boundaries). Text runs between matches are emitted as zero-copy slices; the tokens themselves are ordinary structs parsers can store.
- **`TextTokenizerOptions` / `TextTokenDefinition`** — a literal token table pre-populated with the three line-terminator defaults (`\r\n`, `\n`, lone `\r` — the `TextLineReader` recognition set). Overriding the defaults *is* editing the list; matching is ordinal, leftmost, longest-first among literals sharing a first character (`**` beats `*`). Definitions carry a caller-assigned `Id` for parser dispatch and a `TextTokenKind` category.
- **Whitespace runs as a rule, not a literal** — opt-in `TokenizeWhitespace` emits space/tab runs, with literals winning over runs (including literals that start with whitespace mid-run).
- **`TextPosition`** — physical, table-independent line/column/offset tracking: terminators count once even when split across value or segment boundaries, or when the newline defaults are removed and terminators travel inside text runs. Feeds parser diagnostics (`ContentFormatException.Position`); the tokenizer itself never throws for input.
- Invalid tables (null entries, duplicate texts) throw `ArgumentException` at construction, never during reads. Compilation happens per constructor — one tokenizer per text, documented in DESIGN.md.
- CI: adds `Assimalign.Cohesion.Content.Text` to the Content workflow matrix, which previously built only the family root (the broader Content-matrix audit is tracked separately).

## Design notes

`docs/DESIGN.md` gains a Tokenizer section recording the why-this-not-that decisions (literal table over rules/regex, defaults-as-removable-definitions, whitespace as a rule, physical positions, ref-struct-out/plain-structs-in-flight, compile-at-construction) and expanded non-goals (regex tokens, UTF-8 byte tokenizer, streaming bridge — deferred to #438).

## Testing

- 20 new facts in `TextTokenizerTests` (46 total in the package, all passing): default line-model degeneration, custom delimiters and ids, longest-first and unmatched-prefix behavior, overridden/cleared defaults, whitespace runs and whitespace-overlapping literals, position tracking (including the split-`\r\n` cross-segment case), multi-segment literal matching, zero-copy slicing, and construction-time validation.
- `dotnet build` clean for `Content.Text` and downstream `Content.Yaml`; NativeAOT posture unchanged (no reflection, no dynamic code).

## Work items resolved by this PR
Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)