### PR TITLE
fix(http): end the h3 request stream at response completion [L01.01.11.44]

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -463,7 +463,12 @@ emitted by the transport when it finalizes the exchange, not by the feature, and
   frame carrying `END_STREAM`.
 - **HTTP/3 — incremental DATA frames (RFC 9114).** Same shape over the QUIC request
   stream (a HEADERS frame with no `Content-Length`, then DATA frames). The body is
-  delimited by the QUIC stream end, so finalize only flushes.
+  delimited by the QUIC stream **end** (RFC 9114 §4.1), so when the response completes
+  the transport ends the request stream's write side — a graceful QUIC FIN via the
+  `IConnection` half-close contract (`Output.Complete()`). This happens for both the
+  buffered `SendAsync` path (after the HEADERS + optional DATA frame) and the streaming
+  sink's finalize; see "Ending the request stream at response completion" below for why
+  a missing FIN manifests as `H3_CLOSED_CRITICAL_STREAM` at the client.
 
 ### Backpressure (flow control)
 
@@ -1483,6 +1488,39 @@ gate (`_decoderWriteGate`); a `PipeWriter` tolerates no concurrent writers.
 A client opening a push stream (type 0x01) is `H3_STREAM_CREATION_ERROR`
 — only a server may push, and Cohesion does not push (see "server push
 (de-scoped)" below). The engine treats it as a connection error.
+
+### Ending the request stream at response completion
+
+An HTTP/3 response body is delimited by the **request stream's end** (RFC 9114
+§4.1), not by `Content-Length`: a real client (`System.Net.Http.Http3RequestStream`)
+stays in its response-content read until it observes the stream FIN, even for a
+zero-length body. So when a response completes, the engine ends the request stream's
+write side — the graceful QUIC FIN, signalled through the `IConnection` half-close
+contract by completing the stream's `Output` (`PipeWriter`). Both response paths do
+this: the buffered `SendAsync` after it flushes the HEADERS (+ optional DATA) frame,
+and the streaming sink's `CompleteFramedAsync` after its final flush. Completion is
+best-effort — the response bytes are already flushed, so a teardown race that disposed
+the stream underneath the completion is swallowed (a `QuicException` is an
+`IOException`).
+
+This was the fix for issue #928. Before it, `SendAsync` wrote HEADERS/DATA, flushed,
+and returned **without ending the stream**; the request stream's write side was then
+only completed at *connection* teardown (when the multiplexed connection disposes its
+bidirectional streams). A client therefore never saw the response terminate on a live
+connection and stayed reading until the connection was torn down, at which point the
+control/QPACK critical streams closing surfaced at the client as
+`H3_CLOSED_CRITICAL_STREAM` (0x104) — during `ReadResponseContentAsync`, never during
+header read. Ending the request stream at response completion means the exchange
+finishes cleanly on the wire well before any GOAWAY/`CONNECTION_CLOSE`. The two send
+observations tracked with #928 both resolve here: a bodyless 200 (no DATA frame) now
+completes the client's zero-length drain via the FIN, and the buffered-body content
+length always matches the DATA written because `ReadBodyAsync` reads the whole buffer
+(`MemoryStream.ToArray()`, position-independent), not from the stream's current position.
+
+The connection-first teardown below still completes any bidirectional stream that is
+still open at close — the request-stream FIN at response completion is the normal path,
+and the teardown completion remains the fallback for an exchange that never produced a
+response.
 
 ### Connection teardown — critical streams and close ordering
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
@@ -1088,7 +1088,42 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
         }
 
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // RFC 9114 §4.1 — an HTTP/3 response body is delimited by the request stream's end, so the
+        // response is not complete on the wire until the server ends its write side. End it now, with
+        // the response fully flushed: a real .NET HTTP/3 client stays in ReadResponseContentAsync until
+        // this FIN arrives, and if the stream is left dangling until connection teardown the client
+        // surfaces the teardown as H3_CLOSED_CRITICAL_STREAM (0x104) instead of completing the response.
+        CompleteResponseStreamWrites(http3Context);
+
         await http3Context.InvokeAfterResponseAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Ends the request stream's write side once the final response is fully written, emitting the
+    /// graceful QUIC FIN that delimits an HTTP/3 response body (RFC 9114 §4.1). Completing the
+    /// connection's outbound <see cref="PipeWriter"/> is the <see cref="IConnection"/> contract's
+    /// documented half-close signal. Best-effort: the response bytes are already flushed to the
+    /// transport, so a teardown race that disposes the stream underneath the completion is benign.
+    /// </summary>
+    /// <param name="http3Context">The exchange whose request-stream write side is ended.</param>
+    private static void CompleteResponseStreamWrites(Http3Context http3Context)
+    {
+        try
+        {
+            http3Context.StreamConnection.Output.Complete();
+        }
+        catch (InvalidOperationException)
+        {
+            // ObjectDisposedException derives from InvalidOperationException: a concurrent connection
+            // abort tore the stream down after the response flushed, so the FIN is moot.
+        }
+        catch (Exception ex) when (IsWireLevelFailure(ex))
+        {
+            // Completing flushes any residual bytes into the QUIC stream, which raises a wire-level
+            // failure (QuicException is an IOException) when the stream/connection is already gone.
+            // The response is already delivered, so the missed FIN rides on the connection close.
+        }
     }
 
     /// <summary>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
@@ -16,7 +16,10 @@ namespace Assimalign.Cohesion.Http.Connections.Internal.Http3;
 /// Backpressure is inherent: the QUIC transport applies per-stream flow control on the underlying
 /// <see cref="Stream"/> write, so a full window blocks the write until the peer grants more credit —
 /// no manual window accounting is needed here. The response body is delimited by the QUIC stream
-/// end, which the exchange's disposal signals; completion therefore only flushes.
+/// end (RFC 9114 §4.1): completion flushes the last <c>DATA</c> frame and then ends the request
+/// stream's write side (a graceful FIN via the <see cref="IConnection"/> half-close contract), so a
+/// real HTTP/3 client observes the streamed body terminate rather than waiting on connection
+/// teardown (which it would surface as <c>H3_CLOSED_CRITICAL_STREAM</c>).
 /// </remarks>
 internal sealed class Http3ResponseBodyStream : HttpResponseBodyStream
 {
@@ -49,8 +52,30 @@ internal sealed class Http3ResponseBodyStream : HttpResponseBodyStream
     protected override ValueTask FlushFramedAsync(CancellationToken cancellationToken)
         => new(_stream.FlushAsync(cancellationToken));
 
-    protected override ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
-        => new(_stream.FlushAsync(cancellationToken));
+    protected override async ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
+    {
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // RFC 9114 §4.1 — the streamed body is delimited by the request stream's end. End the write
+        // side (graceful QUIC FIN via the IConnection half-close contract) so the client sees the
+        // body terminate now; leaving it dangling until connection teardown surfaces at the client as
+        // H3_CLOSED_CRITICAL_STREAM. Best-effort: the DATA frames are already flushed, so a teardown
+        // race that disposed the stream underneath the completion is benign.
+        try
+        {
+            _context.StreamConnection.Output.Complete();
+        }
+        catch (InvalidOperationException)
+        {
+            // ObjectDisposedException derives from InvalidOperationException — the stream was torn
+            // down by a concurrent connection abort after the body flushed; the FIN is moot.
+        }
+        catch (IOException)
+        {
+            // QuicException is an IOException: the stream/connection is already gone, so the missed
+            // FIN rides on the connection close instead.
+        }
+    }
 
     private async ValueTask WriteFrameAsync(Http3FrameType frameType, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
     {

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
@@ -18,6 +18,10 @@
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.DigestFields" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.InMemory" />
+		<!-- Test-only: drives the HTTP/3 engine over a real QUIC loopback with a real .NET HTTP/3
+		     client (the transport LIBRARY takes no QUIC dependency — it is wired via UseHttp3 at
+		     composition time). Platform-guarded on QuicListener.IsSupported (see Http3RoundTripTests). -->
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Quic" />
 		<CohesionPackageReference Include="coverlet.collector" />
 		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
 		<CohesionPackageReference Include="Shouldly" />

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3RoundTripTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3RoundTripTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Quic;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+using ClientHttpMethod = System.Net.Http.HttpMethod;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+/// <summary>
+/// Real-QUIC round-trip coverage for the HTTP/3 transport: a real .NET HTTP/3 client drives the
+/// Cohesion h3 engine over a loopback QUIC connection and observes the full response. These pin the
+/// fix for issue #928 — the server now ends the request stream when a response completes (RFC 9114
+/// §4.1), so the client's response-content read finishes instead of tripping
+/// <c>H3_CLOSED_CRITICAL_STREAM</c> (0x104) when the connection is later torn down.
+/// </summary>
+/// <remarks>
+/// System.Net.Quic is Windows/Linux/macOS only, so the class is platform-annotated and every test
+/// returns early when <see cref="QuicListener.IsSupported"/> is <see langword="false"/> (no libmsquic),
+/// matching the gating idiom used by the existing QUIC and Web HTTP/3 suites.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+public class Http3RoundTripTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should complete a full request/response round-trip with status and body over real QUIC")]
+    public async Task Http3_OnRequest_ShouldCompleteFullRoundTripWithStatusAndBody()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — a loopback h3 server that answers 200 with a small text body.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            exchange.Response.Headers[HttpHeaderKey.ContentType] = "text/plain; charset=utf-8";
+            exchange.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes("hello-http3"));
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act — a real .NET HTTP/3 client reads the full response (headers AND content).
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/hello"), cancellationToken);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // Assert — the round-trip completed: negotiated 3.0, status 200, body intact.
+        response.Version.ShouldBe(NetHttpVersion.Version30);
+        ((int)response.StatusCode).ShouldBe(200);
+        body.ShouldBe("hello-http3");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should complete a bodyless 200 round-trip without hanging the client drain")]
+    public async Task Http3_OnBodylessResponse_ShouldCompleteRoundTripWithoutHanging()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — a 200 with no body (Content-Length: 0, no DATA frame). Before the fix the client's
+        // content-length-0 drain never completed because the request stream was never ended.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/empty"), cancellationToken);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // Assert — the client observed the (empty) body terminate and returned cleanly.
+        response.Version.ShouldBe(NetHttpVersion.Version30);
+        ((int)response.StatusCode).ShouldBe(200);
+        body.ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should return the full body when the response body stream is left at its end position")]
+    public async Task Http3_OnBufferedBodyWrittenToStreamEnd_ShouldReturnFullBody()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — the handler writes the body through Response.Body, leaving the default MemoryStream
+        // positioned at its end. The send path must emit the whole buffer (Content-Length AND DATA
+        // consistent), independent of the stream position — the body-position observation on #928.
+        const string payload = "written-to-end-position";
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(async exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            byte[] bytes = Encoding.UTF8.GetBytes(payload);
+            await exchange.Response.Body.WriteAsync(bytes, cancellationToken);
+        }, cancellationToken);
+
+        // Act
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/buffered"), cancellationToken);
+        byte[] received = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        // Assert — the full body arrived; Content-Length matched the DATA the client read.
+        ((int)response.StatusCode).ShouldBe(200);
+        response.Content.Headers.ContentLength.ShouldBe(payload.Length);
+        Encoding.UTF8.GetString(received).ShouldBe(payload);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should serve sequential requests on one connection, keeping the control/QPACK critical streams open")]
+    public async Task Http3_OnSequentialRequests_ShouldReuseConnectionAndKeepCriticalStreamsOpen()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — echo the request path in the body so each response is distinguishable. A real .NET
+        // HTTP/3 client reuses one QUIC connection across sequential requests; each request completing
+        // proves the server's control and QPACK streams stayed open for the connection lifetime (a
+        // closed critical stream is exactly the 0x104 error, which would fail the second request).
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            exchange.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes(exchange.Request.Path.Value));
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act / Assert — three requests over the reused connection all complete with their own body.
+        using HttpClient client = CreateHttp3Client();
+
+        foreach (string path in new[] { "/first", "/second", "/third" })
+        {
+            using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, path), cancellationToken);
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            response.Version.ShouldBe(NetHttpVersion.Version30);
+            ((int)response.StatusCode).ShouldBe(200);
+            body.ShouldBe(path);
+        }
+    }
+
+    private static HttpClient CreateHttp3Client()
+    {
+        HttpClientHandler handler = new()
+        {
+            // The loopback certificate is a throwaway self-signed test cert; accept it unconditionally.
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+
+        return new HttpClient(handler, disposeHandler: true);
+    }
+
+    private static async Task<HttpResponseMessage> GetExactHttp3Async(HttpClient client, Uri uri, CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
+        {
+            Version = NetHttpVersion.Version30,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact
+        };
+
+        return await client.SendAsync(request, cancellationToken);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/TestObjects/Http3LoopbackServer.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/TestObjects/Http3LoopbackServer.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections.Quic;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+/// <summary>
+/// A loopback HTTP/3 server harness for the transport's real-QUIC round-trip tests. It binds a
+/// <see cref="QuicConnectionListener"/> on a free loopback UDP port, drives every accepted
+/// connection through the HTTP/3 engine, and applies a test-supplied handler to each request
+/// before sending the response. Disposal stops the accept loop and releases the listener and
+/// certificate.
+/// </summary>
+/// <remarks>
+/// Mirrors the <c>Assimalign.Cohesion.Http.Connections.Examples.Http3</c> server wiring so the
+/// tests exercise the same composition a real deployment uses. QUIC is Windows/Linux/macOS only,
+/// so the harness (and its tests) are platform-annotated and gated at runtime on
+/// <see cref="System.Net.Quic.QuicListener.IsSupported"/>.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+internal sealed class Http3LoopbackServer : IAsyncDisposable
+{
+    private readonly HttpConnectionListener _listener;
+    private readonly X509Certificate2 _certificate;
+    private readonly CancellationTokenSource _shutdown;
+    private readonly Task _serveLoop;
+
+    private Http3LoopbackServer(
+        HttpConnectionListener listener,
+        X509Certificate2 certificate,
+        int port,
+        Func<IHttpContext, Task> handler)
+    {
+        _listener = listener;
+        _certificate = certificate;
+        _shutdown = new CancellationTokenSource();
+        BaseUri = new Uri($"https://127.0.0.1:{port}/");
+        _serveLoop = Task.Run(() => ServeAsync(handler, _shutdown.Token));
+    }
+
+    /// <summary>The base URI a real HTTP/3 client dials to reach this server.</summary>
+    public Uri BaseUri { get; }
+
+    /// <summary>
+    /// Binds a loopback HTTP/3 listener and starts serving. Each surfaced request is passed to
+    /// <paramref name="handler"/> (which sets the response), then the response is written and the
+    /// exchange disposed.
+    /// </summary>
+    /// <param name="handler">The per-request response handler.</param>
+    /// <param name="cancellationToken">A token that cancels the initial QUIC bind.</param>
+    /// <returns>The started server harness.</returns>
+    public static async Task<Http3LoopbackServer> StartAsync(Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        int port = AllocateUdpPort();
+        X509Certificate2 certificate = CreateCertificate();
+
+        QuicConnectionListener quicListener = await QuicConnectionListener.CreateAsync(transport =>
+        {
+            transport.EndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            transport.ServerAuthenticationOptions.ServerCertificate = certificate;
+            transport.ServerAuthenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 };
+        }, cancellationToken).ConfigureAwait(false);
+
+        HttpConnectionListener listener = HttpConnectionListener.Create(options => options.UseHttp3(quicListener));
+
+        return new Http3LoopbackServer(listener, certificate, port, handler);
+    }
+
+    private async Task ServeAsync(Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                IHttpConnection connection = await _listener.AcceptOrListenAsync(cancellationToken).ConfigureAwait(false);
+
+                // Serve each connection on its own task so a second client (or reconnect) is not
+                // blocked behind the first; the client under test reuses one connection for its
+                // sequential requests, which the receive loop yields in order.
+                _ = ServeConnectionAsync(connection, handler, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown requested — stop accepting.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The listener was disposed out from under the accept — teardown raced the loop.
+        }
+    }
+
+    private static async Task ServeConnectionAsync(IHttpConnection connection, Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using (connection.ConfigureAwait(false))
+            {
+                IHttpConnectionContext context = await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                await foreach (IHttpContext exchange in context.ReceiveAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    await handler(exchange).ConfigureAwait(false);
+                    await context.SendAsync(exchange, cancellationToken).ConfigureAwait(false);
+                    await exchange.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Test harness: any connection-scoped teardown (client abort, QUIC reset, idle timeout,
+            // or shutdown cancellation) is expected and must not fault the background serve loop.
+            // The assertions live on the client side of each test, not here.
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        _shutdown.Cancel();
+
+        try
+        {
+            await _serveLoop.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await _listener.DisposeAsync().ConfigureAwait(false);
+        _certificate.Dispose();
+        _shutdown.Dispose();
+    }
+
+    private static int AllocateUdpPort()
+    {
+        using Socket probe = new(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using RSA rsa = RSA.Create(2048);
+        CertificateRequest request = new("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        SubjectAlternativeNameBuilder subjectAlternativeNames = new();
+        subjectAlternativeNames.AddDnsName("localhost");
+        subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+
+        request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: false));
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+            new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, // id-kp-serverAuth
+            critical: false));
+
+        using X509Certificate2 ephemeral = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(10));
+
+        // Round-trip through PKCS#12 so the private key is persisted in a form the platform TLS
+        // stack (Schannel / MsQuic) accepts; a certificate with an ephemeral key is rejected on Windows.
+        return X509CertificateLoader.LoadPkcs12(
+            ephemeral.Export(X509ContentType.Pfx),
+            password: null,
+            X509KeyStorageFlags.Exportable);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
@@ -279,12 +279,6 @@ keep-alive unblock, post-stop connection refusal).
   before cancelling on shutdown (versus cancelling them with the drain token) is
   future work; it needs a two-phase signal ("finish the current exchange, accept
   no new ones on this connection") that this iteration does not implement.
-- **Full HTTP/3 response round-trip.** The HTTP/3 registration surface (issue
-  #767) has landed — see "HTTP/3 (QUIC) registration surface" below — and the
-  QUIC bind, h3 connection accept, and pipeline dispatch are verified. The full
-  client response round-trip is blocked by a pre-existing HTTP/3 server
-  control-stream defect in `Http.Connections` (`H3_CLOSED_CRITICAL_STREAM`),
-  which is Http-area work outside this module.
 - **Per-request service resolution.** DI/logging/config are builder-time only;
   the server resolves nothing per connection or per request.
 - **Re-implementing wire behaviour.** Protocol conformance and wire-level failure
@@ -594,17 +588,19 @@ advertised port is taken from that listener's bound endpoint. An application opt
 `options.AdvertiseAltService(...)` alongside a stream listener; the server then injects
 `Alt-Svc: h3=":<port>"` on the h1/h2 responses so clients can discover and upgrade to h3.
 
-### Known limitation — h3 response round-trip
+### h3 response round-trip — verified end to end
 
-The registration surface, the QUIC bind, the h3 connection accept, and pipeline dispatch
-(scheme + protocol) are verified end to end against a real .NET HTTP/3 client. The full
-**response** round-trip is currently blocked by a pre-existing HTTP/3 *server
-control-stream* defect in `Assimalign.Cohesion.Http.Connections`
-(`H3_CLOSED_CRITICAL_STREAM`, 0x104) that reproduces with that library's own Http3
-example, independent of this surface. The e2e test therefore makes the server-side
-observation (the protocol and scheme seen on the dispatched `IHttpContext`) its
-load-bearing assertion and treats the client response as best-effort. Closing the
-transport defect is Http-area work, tracked outside this issue.
+The registration surface, the QUIC bind, the h3 connection accept, pipeline dispatch
+(scheme + protocol), **and the full client response round-trip** (HTTP/3 status + body)
+are verified end to end against a real .NET HTTP/3 client
+(`WebHttp3HostingIntegrationTests`). The client round-trip was previously best-effort
+because of a pre-existing HTTP/3 *server send-path* defect in
+`Assimalign.Cohesion.Http.Connections` (issue #928): the request stream was never ended
+when a response completed, so the client's response-content read never finished and
+surfaced the eventual connection teardown as `H3_CLOSED_CRITICAL_STREAM` (0x104). That
+defect is fixed in `Http.Connections` (the send path now ends the request stream per RFC
+9114 §4.1), so the e2e test asserts the client-observed status and body alongside the
+server-side dispatch observation.
 
 ### AOT posture
 

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebHttp3HostingIntegrationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebHttp3HostingIntegrationTests.cs
@@ -38,13 +38,12 @@ namespace Assimalign.Cohesion.Web.Hosting.Tests;
 /// implementation (for example a missing libmsquic) it returns early, and the deferred-factory and
 /// platform-guard behaviour stays covered by <see cref="WebHttp3HostingExtensionsTests"/>.
 /// <para>
-/// The <em>server-side observation</em> (protocol + scheme seen on the dispatched
-/// <see cref="IHttpContext"/>) is the load-bearing assertion: it proves <c>UseHttp3</c> accepts a real
-/// QUIC h3 connection and drives it through the pipeline. The client's full response round-trip is
-/// observed best-effort: it currently trips a pre-existing HTTP/3 <em>server control-stream</em> defect
-/// (<c>H3_CLOSED_CRITICAL_STREAM</c>, 0x104) that reproduces with the <c>Http.Connections</c> Http3
-/// example independently of this registration surface, so a broken response read never hard-fails the
-/// suite.
+/// Both halves are load-bearing assertions: the client observes the full response round-trip (HTTP/3
+/// status <b>and</b> body), and the terminal middleware observes the protocol + transport-derived
+/// scheme on the dispatched <see cref="IHttpContext"/>. The client round-trip became a hard assertion
+/// once issue #928 — an <c>Http.Connections</c> HTTP/3 send-path defect that left the request stream
+/// unterminated and surfaced at the client as <c>H3_CLOSED_CRITICAL_STREAM</c> (0x104) — was fixed;
+/// the server now ends the request stream when the response completes (RFC 9114 §4.1).
 /// </para>
 /// </remarks>
 // System.Net.Quic is Windows/Linux/macOS only; annotated to match UseHttp3 and gated at runtime.
@@ -55,8 +54,8 @@ public class WebHttp3HostingIntegrationTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
-    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp3: Should accept and dispatch an HTTP/3 request over QUIC reporting the https scheme")]
-    public async Task UseHttp3_OverQuic_ShouldDispatchRequestWithHttp30AndHttpsScheme()
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp3: Should complete a full HTTP/3 response round-trip and dispatch reporting the https scheme")]
+    public async Task UseHttp3_OverQuic_ShouldCompleteResponseRoundTripAndDispatchWithHttps()
     {
         if (!QuicListener.IsSupported)
         {
@@ -83,7 +82,7 @@ public class WebHttp3HostingIntegrationTests
         WebApplication app = builder.Build();
 
         // The terminal middleware records the protocol and transport-derived scheme it observes, then
-        // answers 200 with a small body. The recorded observation is the load-bearing assertion.
+        // answers 200 with a small body. Both the observation and the client's received body are asserted.
         TaskCompletionSource<(CohesionHttpVersion Version, HttpScheme Scheme)> observed =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         app.Use((context, next) =>
@@ -102,35 +101,38 @@ public class WebHttp3HostingIntegrationTests
         IWebApplicationServer server = app.Context.ServiceProvider.GetRequiredService<IWebApplicationServer>();
         await server.StartAsync(cancellationToken);
 
-        // Drive a real HTTP/3 client as a background stimulus, on its own token so the observation can
-        // stop it promptly.
-        using CancellationTokenSource clientCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Task clientStimulus = DriveHttp3ClientAsync(new Uri($"https://127.0.0.1:{port}/secure?probe=h3"), clientCancellation.Token);
-
         try
         {
-            // Act / Assert — the request reached the pipeline over a real QUIC h3 connection and reports
-            // HTTP/3 with the transport-derived https scheme.
-            (CohesionHttpVersion version, HttpScheme scheme) = await observed.Task.WaitAsync(cancellationToken);
+            // Act — a real .NET HTTP/3 client completes the full round-trip: headers AND response body.
+            (Version version, int status, string body) = await GetHttp3ResponseAsync(
+                new Uri($"https://127.0.0.1:{port}/secure?probe=h3"), cancellationToken);
 
-            version.ShouldBe(CohesionHttpVersion.Http30);
-            scheme.ShouldBe(HttpScheme.Https);
+            // Assert — the client observed a complete HTTP/3 response.
+            version.ShouldBe(NetHttpVersion.Version30);
+            status.ShouldBe(200);
+            body.ShouldBe("hello-http3");
+
+            // Assert — the request reached the pipeline over a real QUIC h3 connection and reported
+            // HTTP/3 with the transport-derived https scheme.
+            (CohesionHttpVersion observedVersion, HttpScheme observedScheme) = await observed.Task.WaitAsync(cancellationToken);
+
+            observedVersion.ShouldBe(CohesionHttpVersion.Http30);
+            observedScheme.ShouldBe(HttpScheme.Https);
         }
         finally
         {
-            clientCancellation.Cancel();
             await server.StopAsync(CancellationToken.None);
-            await ObserveAsync(clientStimulus);
         }
     }
 
     /// <summary>
-    /// Repeatedly issues an exact-HTTP/3 request until one completes cleanly or the token is cancelled.
-    /// A clean completion is the healthy-platform path; connect/handshake races and the pre-existing h3
-    /// server control-stream defect are swallowed and retried, since the test asserts on the server-side
-    /// observation the first request already produced.
+    /// Issues an exact-HTTP/3 request and reads the full response, returning the negotiated version,
+    /// status code, and body. Connect/handshake races against server startup surface as a transient
+    /// <see cref="HttpRequestException"/> and are retried until the shared timeout; the HTTP/3
+    /// send-path defect that previously forced a best-effort read (issue #928) is fixed, so a healthy
+    /// platform returns a complete response.
     /// </summary>
-    private static async Task DriveHttp3ClientAsync(Uri uri, CancellationToken cancellationToken)
+    private static async Task<(Version Version, int Status, string Body)> GetHttp3ResponseAsync(Uri uri, CancellationToken cancellationToken)
     {
         using HttpClientHandler handler = new()
         {
@@ -139,49 +141,28 @@ public class WebHttp3HostingIntegrationTests
         };
         using HttpClient client = new(handler);
 
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
-            using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
-            {
-                Version = NetHttpVersion.Version30,
-                VersionPolicy = HttpVersionPolicy.RequestVersionExact
-            };
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
+                {
+                    Version = NetHttpVersion.Version30,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
 
-                return;
-            }
-            catch (OperationCanceledException)
-            {
-                return;
+                using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                return (response.Version, (int)response.StatusCode, body);
             }
             catch (HttpRequestException)
             {
-                // Connect/handshake not ready, or the pre-existing h3 response-stream defect; retry until
-                // the observation cancels this stimulus or the shared timeout fires.
-                try
-                {
-                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    return;
-                }
+                // Connect/handshake not ready yet — retry until the observation cancels or the timeout fires.
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
             }
-        }
-    }
-
-    private static async Task ObserveAsync(Task task)
-    {
-        try
-        {
-            await task.ConfigureAwait(false);
-        }
-        catch
-        {
-            // The test's assertions own the verdict; drain the background client quietly on teardown.
         }
     }
 


### PR DESCRIPTION
## Summary
Batch 5, stack **1/4** (base: `main`).

Root-caused and fixed the defect behind every failed HTTP/3 round-trip. **The control stream was innocent** — the issue title's hypothesis did not survive contact with the evidence:

- **Root cause**: an HTTP/3 response body is delimited by the request stream's end (RFC 9114 §4.1), not Content-Length — and the h3 send path never ended the stream's write side. `SendAsync` wrote HEADERS/DATA, flushed, and returned; the stream was only completed at whole-connection teardown. A real .NET client sits in `ReadResponseContentAsync` waiting for the FIN, and when teardown finally arrives it surfaces as `H3_CLOSED_CRITICAL_STREAM` (0x104) — the critical streams closing was the *symptom* the client happened to report, not the cause. Proven by a decisive experiment: adding the FIN flips the failing example to a clean `200` + body.
- **Fix (minimal, Lane A internal)**: emit the graceful QUIC FIN (`Output.Complete()` — the `IConnection` half-close contract) once the response is fully flushed, in both send paths: the buffered path (`CompleteResponseStreamWrites` at the end of `SendAsync`) and the streaming path (`Http3ResponseBodyStream.CompleteFramedAsync` now flushes *then* completes). Best-effort with narrowly-scoped catches (disposed / wire-level teardown races are benign — the bytes are already delivered).
- **The two associated observations from #767 bring-up**: the bodyless-200 hang was the SAME root cause (Content-Length: 0 + no FIN = client drains forever) — fixed and pinned. The body-position concern was NOT a live defect (`ReadBodyAsync` reads position-independently via `ToArray()`) — locked in with a regression test, no code change.
- **#767's e2e strengthened**: `WebHttp3HostingIntegrationTests` best-effort response handling flipped to hard client-observed status + body assertions; Web.Hosting DESIGN.md's "blocked defect" posture rewritten as verified. The Http.Connections h3 example now completes a full round-trip.

## Tests
Http.Connections **422** (4 new platform-guarded real-QUIC round-trip tests + a new `Http3LoopbackServer` harness; QUIC e2e genuinely ran on this machine, not skipped) · Web.Hosting **58** — all passing.

## Follow-up candidate (not filed)
Request-stream wrapper lifecycle is connection-scoped (`QuicMultiplexedConnection.\_streams` untracks only at connection teardown) — unbounded wrapper accumulation on long-lived h3 connections; pre-existing, neither introduced nor worsened here.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)