### PR TITLE
fix(http): percent-decode h1 request-target paths to h2/h3 parity; drop StaticFiles compensation [L01.01.11.43]

### DIFF
--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -330,6 +330,38 @@ No reflection, no runtime code generation. Hook dispatch is interface calls
 over a snapshotted array; the context is one small allocation per request,
 only when at least one interceptor is registered.
 
+## Request-target percent-decoding (h1/h2/h3 parity)
+
+`IHttpRequest.Path` is the **percent-decoded** path on every transport, produced by the same
+`HttpPath.FromUriComponent` decode (RFC 3986 §2.4). HTTP/2 and HTTP/3 run it over the `:path`
+pseudo-header (`Http2Stream.ParseQuery` / `Http3HeaderCodec.ParseQuery`); HTTP/1.1's
+`Http1MessageReader` runs it over the **origin-form** request-target path after
+`HttpRequestTarget` has split path from query (issue #895). Identical wire bytes therefore yield
+an identical `Path` on all three: `%2e%2e` decodes to `..` (so the encoded-traversal form a
+static-file or routing layer must reject reads the same everywhere), an ordinary octet like
+`%24` decodes to `$`, and an invalid or overlong escape (`%zz`, `%C0%AE`) is left intact per
+`UrlDecoder`.
+
+Two invariants are load-bearing:
+
+- **`%2F` is never decoded to a separator** — `UrlDecoder` skips it, so a catch-all route's
+  `{**}` identity form and a static mount's segment boundaries survive an encoded slash. The
+  query, by contrast, is decoded fully (including `%2F` → `/`) because it is split off before
+  the path decode and parsed through `HttpQuery.Parse`, not `FromUriComponent` — the same split
+  and the same query decode on all three transports.
+- **A decoded octet that is not a legal path character** (a space from `%20`, a control from
+  `%09`, `?`/`#`, or a NUL from `%00`) makes the request-target malformed. On h1 the reader
+  surfaces this as its existing malformed-request-target failure (an `InvalidDataException`
+  classified as a wire-level fault — the connection is dropped, never mistaken for a literal
+  reachable path), reaching the same reject outcome the shared decode produces on h2/h3.
+
+Why decode in the transport rather than in `HttpRequestTarget`: the value object is a purely
+syntactic RFC 9112 §3.2 parse whose `Path`/`RawValue` stay wire-faithful (its tests pin
+`/with%20space` as a literal), and h2/h3 already decode in their transport layer — so h1 matches
+them by decoding in `Http1MessageReader`, not by changing the shared parser. The other three
+request-target forms keep their existing handling (absolute-form's path is already normalized by
+`System.Uri`, authority-form/CONNECT carries none, asterisk-form is the literal `*`).
+
 ## IsSecure: capability-derived, single-source
 
 ### What it is

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/docs/DESIGN.md
@@ -463,7 +463,12 @@ emitted by the transport when it finalizes the exchange, not by the feature, and
   frame carrying `END_STREAM`.
 - **HTTP/3 — incremental DATA frames (RFC 9114).** Same shape over the QUIC request
   stream (a HEADERS frame with no `Content-Length`, then DATA frames). The body is
-  delimited by the QUIC stream end, so finalize only flushes.
+  delimited by the QUIC stream **end** (RFC 9114 §4.1), so when the response completes
+  the transport ends the request stream's write side — a graceful QUIC FIN via the
+  `IConnection` half-close contract (`Output.Complete()`). This happens for both the
+  buffered `SendAsync` path (after the HEADERS + optional DATA frame) and the streaming
+  sink's finalize; see "Ending the request stream at response completion" below for why
+  a missing FIN manifests as `H3_CLOSED_CRITICAL_STREAM` at the client.
 
 ### Backpressure (flow control)
 
@@ -1483,6 +1488,39 @@ gate (`_decoderWriteGate`); a `PipeWriter` tolerates no concurrent writers.
 A client opening a push stream (type 0x01) is `H3_STREAM_CREATION_ERROR`
 — only a server may push, and Cohesion does not push (see "server push
 (de-scoped)" below). The engine treats it as a connection error.
+
+### Ending the request stream at response completion
+
+An HTTP/3 response body is delimited by the **request stream's end** (RFC 9114
+§4.1), not by `Content-Length`: a real client (`System.Net.Http.Http3RequestStream`)
+stays in its response-content read until it observes the stream FIN, even for a
+zero-length body. So when a response completes, the engine ends the request stream's
+write side — the graceful QUIC FIN, signalled through the `IConnection` half-close
+contract by completing the stream's `Output` (`PipeWriter`). Both response paths do
+this: the buffered `SendAsync` after it flushes the HEADERS (+ optional DATA) frame,
+and the streaming sink's `CompleteFramedAsync` after its final flush. Completion is
+best-effort — the response bytes are already flushed, so a teardown race that disposed
+the stream underneath the completion is swallowed (a `QuicException` is an
+`IOException`).
+
+This was the fix for issue #928. Before it, `SendAsync` wrote HEADERS/DATA, flushed,
+and returned **without ending the stream**; the request stream's write side was then
+only completed at *connection* teardown (when the multiplexed connection disposes its
+bidirectional streams). A client therefore never saw the response terminate on a live
+connection and stayed reading until the connection was torn down, at which point the
+control/QPACK critical streams closing surfaced at the client as
+`H3_CLOSED_CRITICAL_STREAM` (0x104) — during `ReadResponseContentAsync`, never during
+header read. Ending the request stream at response completion means the exchange
+finishes cleanly on the wire well before any GOAWAY/`CONNECTION_CLOSE`. The two send
+observations tracked with #928 both resolve here: a bodyless 200 (no DATA frame) now
+completes the client's zero-length drain via the FIN, and the buffered-body content
+length always matches the DATA written because `ReadBodyAsync` reads the whole buffer
+(`MemoryStream.ToArray()`, position-independent), not from the stream's current position.
+
+The connection-first teardown below still completes any bidirectional stream that is
+still open at close — the request-stream FIN at response completion is the normal path,
+and the teardown completion remains the fallback for an exchange that never produced a
+response.
 
 ### Connection teardown — critical streams and close ordering
 

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1MessageReader.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http1/Http1MessageReader.cs
@@ -94,6 +94,37 @@ internal static class Http1MessageReader
                 $"The HTTP/1.1 request line '{requestLine}' has a malformed request-target: {targetError}");
         }
 
+        // RFC 3986 §2.4 / RFC 9112 §3.2.1 — percent-decode the origin-form request-target path so this
+        // transport surfaces IHttpRequest.Path identically to HTTP/2 and HTTP/3, which run the :path
+        // through HttpPath.FromUriComponent (Http2Stream.ParseQuery / Http3HeaderCodec.ParseQuery).
+        // HttpRequestTarget already split the path from the query on the first '?', so the query is
+        // decoded independently (below, via HttpQuery.Parse — the same path h2/h3 take) and the decode
+        // scopes to the path component only. FromUriComponent keeps %2F encoded (it never becomes a
+        // separator — the routing '{**}' identity invariant relies on it), decodes encoded dot segments
+        // to "..", and leaves invalid/overlong sequences intact per UrlDecoder. A decoded octet that is
+        // not a legal path character (a space, control, '?'/'#', or NUL) makes the target malformed —
+        // the same outcome the shared decode reaches on h2/h3; surface it as the transport's existing
+        // malformed-request-target failure rather than letting it escape the read loop. The other three
+        // request-target forms keep their current handling: absolute-form's path is already normalized by
+        // System.Uri, authority-form (CONNECT) carries none, and asterisk-form is the literal '*'.
+        HttpPath requestPath;
+        if (target.Form == HttpRequestTargetForm.Origin)
+        {
+            try
+            {
+                requestPath = HttpPath.FromUriComponent(target.Path.Value);
+            }
+            catch (Exception ex) when (ex is HttpException or InvalidOperationException)
+            {
+                throw new InvalidDataException(
+                    $"The HTTP/1.1 request line '{requestLine}' has a malformed request-target: {ex.Message}");
+            }
+        }
+        else
+        {
+            requestPath = target.Path;
+        }
+
         HttpHeaderCollection headers = await ReadHeadersAsync(stream, limits, readToken).ConfigureAwait(false);
 
         // The header section is fully received; disarm the request-headers deadline so the body
@@ -143,7 +174,7 @@ internal static class Http1MessageReader
             {
                 Version = HttpVersion.Http11,
                 Method = method,
-                Path = target.Path,
+                Path = requestPath,
                 Scheme = requestScheme,
                 Host = host,
                 Headers = headers.AsReadOnly(),
@@ -238,7 +269,7 @@ internal static class Http1MessageReader
 
             Http1Request request = new(
                 host,
-                target.Path,
+                requestPath,
                 method,
                 requestScheme,
                 queryCollection,

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ConnectionContext.cs
@@ -1088,7 +1088,42 @@ internal sealed class Http3ConnectionContext : HttpConnectionContext
         }
 
         await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // RFC 9114 §4.1 — an HTTP/3 response body is delimited by the request stream's end, so the
+        // response is not complete on the wire until the server ends its write side. End it now, with
+        // the response fully flushed: a real .NET HTTP/3 client stays in ReadResponseContentAsync until
+        // this FIN arrives, and if the stream is left dangling until connection teardown the client
+        // surfaces the teardown as H3_CLOSED_CRITICAL_STREAM (0x104) instead of completing the response.
+        CompleteResponseStreamWrites(http3Context);
+
         await http3Context.InvokeAfterResponseAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Ends the request stream's write side once the final response is fully written, emitting the
+    /// graceful QUIC FIN that delimits an HTTP/3 response body (RFC 9114 §4.1). Completing the
+    /// connection's outbound <see cref="PipeWriter"/> is the <see cref="IConnection"/> contract's
+    /// documented half-close signal. Best-effort: the response bytes are already flushed to the
+    /// transport, so a teardown race that disposes the stream underneath the completion is benign.
+    /// </summary>
+    /// <param name="http3Context">The exchange whose request-stream write side is ended.</param>
+    private static void CompleteResponseStreamWrites(Http3Context http3Context)
+    {
+        try
+        {
+            http3Context.StreamConnection.Output.Complete();
+        }
+        catch (InvalidOperationException)
+        {
+            // ObjectDisposedException derives from InvalidOperationException: a concurrent connection
+            // abort tore the stream down after the response flushed, so the FIN is moot.
+        }
+        catch (Exception ex) when (IsWireLevelFailure(ex))
+        {
+            // Completing flushes any residual bytes into the QUIC stream, which raises a wire-level
+            // failure (QuicException is an IOException) when the stream/connection is already gone.
+            // The response is already delivered, so the missed FIN rides on the connection close.
+        }
     }
 
     /// <summary>

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/src/Internal/Http3/Http3ResponseBodyStream.cs
@@ -16,7 +16,10 @@ namespace Assimalign.Cohesion.Http.Connections.Internal.Http3;
 /// Backpressure is inherent: the QUIC transport applies per-stream flow control on the underlying
 /// <see cref="Stream"/> write, so a full window blocks the write until the peer grants more credit —
 /// no manual window accounting is needed here. The response body is delimited by the QUIC stream
-/// end, which the exchange's disposal signals; completion therefore only flushes.
+/// end (RFC 9114 §4.1): completion flushes the last <c>DATA</c> frame and then ends the request
+/// stream's write side (a graceful FIN via the <see cref="IConnection"/> half-close contract), so a
+/// real HTTP/3 client observes the streamed body terminate rather than waiting on connection
+/// teardown (which it would surface as <c>H3_CLOSED_CRITICAL_STREAM</c>).
 /// </remarks>
 internal sealed class Http3ResponseBodyStream : HttpResponseBodyStream
 {
@@ -49,8 +52,30 @@ internal sealed class Http3ResponseBodyStream : HttpResponseBodyStream
     protected override ValueTask FlushFramedAsync(CancellationToken cancellationToken)
         => new(_stream.FlushAsync(cancellationToken));
 
-    protected override ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
-        => new(_stream.FlushAsync(cancellationToken));
+    protected override async ValueTask CompleteFramedAsync(CancellationToken cancellationToken)
+    {
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // RFC 9114 §4.1 — the streamed body is delimited by the request stream's end. End the write
+        // side (graceful QUIC FIN via the IConnection half-close contract) so the client sees the
+        // body terminate now; leaving it dangling until connection teardown surfaces at the client as
+        // H3_CLOSED_CRITICAL_STREAM. Best-effort: the DATA frames are already flushed, so a teardown
+        // race that disposed the stream underneath the completion is benign.
+        try
+        {
+            _context.StreamConnection.Output.Complete();
+        }
+        catch (InvalidOperationException)
+        {
+            // ObjectDisposedException derives from InvalidOperationException — the stream was torn
+            // down by a concurrent connection abort after the body flushed; the FIN is moot.
+        }
+        catch (IOException)
+        {
+            // QuicException is an IOException: the stream/connection is already gone, so the missed
+            // FIN rides on the connection close instead.
+        }
+    }
 
     private async ValueTask WriteFrameAsync(Http3FrameType frameType, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
     {

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Assimalign.Cohesion.Http.Connections.Tests.csproj
@@ -18,6 +18,10 @@
 		<CohesionProjectReference Include="Assimalign.Cohesion.Http.DigestFields" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections" />
 		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.InMemory" />
+		<!-- Test-only: drives the HTTP/3 engine over a real QUIC loopback with a real .NET HTTP/3
+		     client (the transport LIBRARY takes no QUIC dependency — it is wired via UseHttp3 at
+		     composition time). Platform-guarded on QuicListener.IsSupported (see Http3RoundTripTests). -->
+		<CohesionProjectReference Include="Assimalign.Cohesion.Connections.Quic" />
 		<CohesionPackageReference Include="coverlet.collector" />
 		<CohesionPackageReference Include="Microsoft.NET.Test.Sdk" />
 		<CohesionPackageReference Include="Shouldly" />

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3RoundTripTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/Http3RoundTripTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Quic;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+using ClientHttpMethod = System.Net.Http.HttpMethod;
+using NetHttpVersion = System.Net.HttpVersion;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+/// <summary>
+/// Real-QUIC round-trip coverage for the HTTP/3 transport: a real .NET HTTP/3 client drives the
+/// Cohesion h3 engine over a loopback QUIC connection and observes the full response. These pin the
+/// fix for issue #928 — the server now ends the request stream when a response completes (RFC 9114
+/// §4.1), so the client's response-content read finishes instead of tripping
+/// <c>H3_CLOSED_CRITICAL_STREAM</c> (0x104) when the connection is later torn down.
+/// </summary>
+/// <remarks>
+/// System.Net.Quic is Windows/Linux/macOS only, so the class is platform-annotated and every test
+/// returns early when <see cref="QuicListener.IsSupported"/> is <see langword="false"/> (no libmsquic),
+/// matching the gating idiom used by the existing QUIC and Web HTTP/3 suites.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+public class Http3RoundTripTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should complete a full request/response round-trip with status and body over real QUIC")]
+    public async Task Http3_OnRequest_ShouldCompleteFullRoundTripWithStatusAndBody()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — a loopback h3 server that answers 200 with a small text body.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            exchange.Response.Headers[HttpHeaderKey.ContentType] = "text/plain; charset=utf-8";
+            exchange.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes("hello-http3"));
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act — a real .NET HTTP/3 client reads the full response (headers AND content).
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/hello"), cancellationToken);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // Assert — the round-trip completed: negotiated 3.0, status 200, body intact.
+        response.Version.ShouldBe(NetHttpVersion.Version30);
+        ((int)response.StatusCode).ShouldBe(200);
+        body.ShouldBe("hello-http3");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should complete a bodyless 200 round-trip without hanging the client drain")]
+    public async Task Http3_OnBodylessResponse_ShouldCompleteRoundTripWithoutHanging()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — a 200 with no body (Content-Length: 0, no DATA frame). Before the fix the client's
+        // content-length-0 drain never completed because the request stream was never ended.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/empty"), cancellationToken);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // Assert — the client observed the (empty) body terminate and returned cleanly.
+        response.Version.ShouldBe(NetHttpVersion.Version30);
+        ((int)response.StatusCode).ShouldBe(200);
+        body.ShouldBeEmpty();
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should return the full body when the response body stream is left at its end position")]
+    public async Task Http3_OnBufferedBodyWrittenToStreamEnd_ShouldReturnFullBody()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — the handler writes the body through Response.Body, leaving the default MemoryStream
+        // positioned at its end. The send path must emit the whole buffer (Content-Length AND DATA
+        // consistent), independent of the stream position — the body-position observation on #928.
+        const string payload = "written-to-end-position";
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(async exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            byte[] bytes = Encoding.UTF8.GetBytes(payload);
+            await exchange.Response.Body.WriteAsync(bytes, cancellationToken);
+        }, cancellationToken);
+
+        // Act
+        using HttpClient client = CreateHttp3Client();
+        using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, "/buffered"), cancellationToken);
+        byte[] received = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        // Assert — the full body arrived; Content-Length matched the DATA the client read.
+        ((int)response.StatusCode).ShouldBe(200);
+        response.Content.Headers.ContentLength.ShouldBe(payload.Length);
+        Encoding.UTF8.GetString(received).ShouldBe(payload);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Http3: Should serve sequential requests on one connection, keeping the control/QPACK critical streams open")]
+    public async Task Http3_OnSequentialRequests_ShouldReuseConnectionAndKeepCriticalStreamsOpen()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            return;
+        }
+
+        // Arrange — echo the request path in the body so each response is distinguishable. A real .NET
+        // HTTP/3 client reuses one QUIC connection across sequential requests; each request completing
+        // proves the server's control and QPACK streams stayed open for the connection lifetime (a
+        // closed critical stream is exactly the 0x104 error, which would fail the second request).
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        CancellationToken cancellationToken = cancellation.Token;
+
+        await using Http3LoopbackServer server = await Http3LoopbackServer.StartAsync(exchange =>
+        {
+            exchange.Response.StatusCode = HttpStatusCode.Ok;
+            exchange.Response.Body = new MemoryStream(Encoding.UTF8.GetBytes(exchange.Request.Path.Value));
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        // Act / Assert — three requests over the reused connection all complete with their own body.
+        using HttpClient client = CreateHttp3Client();
+
+        foreach (string path in new[] { "/first", "/second", "/third" })
+        {
+            using HttpResponseMessage response = await GetExactHttp3Async(client, new Uri(server.BaseUri, path), cancellationToken);
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            response.Version.ShouldBe(NetHttpVersion.Version30);
+            ((int)response.StatusCode).ShouldBe(200);
+            body.ShouldBe(path);
+        }
+    }
+
+    private static HttpClient CreateHttp3Client()
+    {
+        HttpClientHandler handler = new()
+        {
+            // The loopback certificate is a throwaway self-signed test cert; accept it unconditionally.
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+
+        return new HttpClient(handler, disposeHandler: true);
+    }
+
+    private static async Task<HttpResponseMessage> GetExactHttp3Async(HttpClient client, Uri uri, CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
+        {
+            Version = NetHttpVersion.Version30,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact
+        };
+
+        return await client.SendAsync(request, cancellationToken);
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpRequestTargetDecodeParityTests.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/HttpRequestTargetDecodeParityTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests;
+
+/// <summary>
+/// Cross-transport parity for request-target percent-decoding (issue #895 / RFC 3986 §2.4). The
+/// HTTP/1.1 reader now surfaces <see cref="IHttpRequest.Path"/> from the origin-form request-target
+/// through the same <c>HttpPath.FromUriComponent</c> decode HTTP/2 and HTTP/3 run over the
+/// <c>:path</c> pseudo-header (<c>Http2Stream.ParseQuery</c> / <c>Http3HeaderCodec.ParseQuery</c>),
+/// so identical wire bytes yield an identical decoded path on every transport: <c>%2e%2e</c> decodes
+/// to <c>..</c>, <c>%2F</c> stays encoded (never a separator — the routing <c>{**}</c> identity
+/// invariant), ordinary octets decode, and invalid/overlong escapes are left intact per
+/// <c>UrlDecoder</c>. Query text is split off before the decode and parsed identically on both
+/// transports (<c>HttpQuery.Parse</c>), so it decodes fully — including <c>%2F</c> — on both.
+/// </summary>
+public class HttpRequestTargetDecodeParityTests
+{
+    [Theory(DisplayName = "Cohesion Test [Http.Connections] - Decode parity: h1 and h2 surface IHttpRequest.Path identically from an encoded request-target")]
+    [InlineData("/static/%2e%2e/x", "/static/../x")]        // encoded dot segments decode to ".."
+    [InlineData("/static/%2E%2E/x", "/static/../x")]        // percent-encoding hex is case-insensitive
+    [InlineData("/dir/a%2Fb", "/dir/a%2Fb")]                // %2F stays encoded (never a separator)
+    [InlineData("/dir/a%2fb", "/dir/a%2fb")]                // lowercase %2f is preserved too
+    [InlineData("/hello%24world", "/hello$world")]          // an ordinary encoded octet decodes
+    [InlineData("/bad%zz", "/bad%zz")]                      // an invalid escape is left unencoded
+    [InlineData("/over%C0%AE", "/over%C0%AE")]              // an overlong UTF-8 sequence is left unencoded
+    [InlineData("/plain/path", "/plain/path")]              // no percent-encoding — unchanged
+    public async Task RequestTargetPath_DecodesIdenticallyAcrossHttp1AndHttp2(string rawTarget, string expectedPath)
+    {
+        // Act — the identical wire bytes as an h1 origin-form request-target and an h2 :path.
+        IHttpContext? http1 = await ReadHttp1ContextAsync($"GET {rawTarget} HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        IHttpContext? http2 = await ReadHttp2ContextAsync(rawTarget);
+
+        // Assert — both transports produced a context, and both decoded the path to the same text.
+        http1.ShouldNotBeNull();
+        http2.ShouldNotBeNull();
+        http1!.Request.Path.Value.ShouldBe(expectedPath);
+        http2!.Request.Path.Value.ShouldBe(expectedPath);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Http.Connections] - Decode parity: h1 and h2 split the query on the first '?' and decode it identically")]
+    public async Task RequestTargetQuery_SplitsOnFirstQuestionMarkAndDecodesIdentically()
+    {
+        // Arrange — the path component keeps %2F encoded; the query component decodes fully (including
+        // %2F → '/') because the query goes through HttpQuery.Parse, not HttpPath.FromUriComponent.
+        const string rawTarget = "/items%2Fa?q=a%20b&p=%2F";
+
+        // Act
+        IHttpContext? http1 = await ReadHttp1ContextAsync($"GET {rawTarget} HTTP/1.1\r\nHost: api.test\r\n\r\n");
+        IHttpContext? http2 = await ReadHttp2ContextAsync(rawTarget);
+
+        // Assert
+        http1.ShouldNotBeNull();
+        http2.ShouldNotBeNull();
+
+        http1!.Request.Path.Value.ShouldBe("/items%2Fa");
+        http2!.Request.Path.Value.ShouldBe("/items%2Fa");
+
+        http1.Request.Query["q"].Value.ShouldBe("a b");
+        http2.Request.Query["q"].Value.ShouldBe("a b");
+        http1.Request.Query["p"].Value.ShouldBe("/");
+        http2.Request.Query["p"].Value.ShouldBe("/");
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Http.Connections] - Http1: a request-target whose decoded path holds an illegal character is rejected as malformed")]
+    [InlineData("/space%20name")]  // a decoded space is not a legal path character
+    [InlineData("/nul%00byte")]    // a decoded NUL is rejected
+    [InlineData("/tab%09stop")]    // a decoded tab is not a legal path character
+    public async Task Http1_RequestTargetPathDecodingToIllegalCharacter_DropsTheConnection(string rawTarget)
+    {
+        // A decoded octet that HttpPath rejects makes the request-target malformed — the same throw the
+        // shared HttpPath.FromUriComponent decode reaches on h2/h3. The h1 reader surfaces it as its
+        // existing malformed-request-target failure, so the connection is dropped with no context (it is
+        // never mistaken for a literal, reachable path).
+        IHttpContext? context = await ReadHttp1ContextAsync($"GET {rawTarget} HTTP/1.1\r\nHost: api.test\r\n\r\n");
+
+        context.ShouldBeNull();
+    }
+
+    private static async Task<IHttpContext?> ReadHttp1ContextAsync(string requestText)
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp1Request(requestText);
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp1(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext context = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        return await ReadFirstContextOrNullAsync(context);
+    }
+
+    private static async Task<IHttpContext?> ReadHttp2ContextAsync(string rawPath)
+    {
+        byte[] payload = HttpProtocolPayloadFactory.CreateHttp2Request(1, "GET", rawPath, "https", "api.test");
+        TestConnection connection = new(payload);
+        HttpConnectionListenerOptions options = new();
+        options.UseHttp2(new TestConnectionListener(connection));
+
+        await using HttpConnectionListener listener = new(options);
+        IHttpConnectionContext context = await (await listener.AcceptOrListenAsync()).OpenAsync();
+        return await ReadFirstContextOrNullAsync(context);
+    }
+
+    private static async Task<IHttpContext?> ReadFirstContextOrNullAsync(IHttpConnectionContext context)
+    {
+        await using IAsyncEnumerator<IHttpContext> enumerator = context.ReceiveAsync().GetAsyncEnumerator();
+        return await enumerator.MoveNextAsync() ? enumerator.Current : null;
+    }
+}

--- a/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/TestObjects/Http3LoopbackServer.cs
+++ b/libraries/Http/Assimalign.Cohesion.Http.Connections/tests/TestObjects/Http3LoopbackServer.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Cohesion.Connections.Quic;
+
+namespace Assimalign.Cohesion.Http.Connections.Tests.TestObjects;
+
+/// <summary>
+/// A loopback HTTP/3 server harness for the transport's real-QUIC round-trip tests. It binds a
+/// <see cref="QuicConnectionListener"/> on a free loopback UDP port, drives every accepted
+/// connection through the HTTP/3 engine, and applies a test-supplied handler to each request
+/// before sending the response. Disposal stops the accept loop and releases the listener and
+/// certificate.
+/// </summary>
+/// <remarks>
+/// Mirrors the <c>Assimalign.Cohesion.Http.Connections.Examples.Http3</c> server wiring so the
+/// tests exercise the same composition a real deployment uses. QUIC is Windows/Linux/macOS only,
+/// so the harness (and its tests) are platform-annotated and gated at runtime on
+/// <see cref="System.Net.Quic.QuicListener.IsSupported"/>.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+internal sealed class Http3LoopbackServer : IAsyncDisposable
+{
+    private readonly HttpConnectionListener _listener;
+    private readonly X509Certificate2 _certificate;
+    private readonly CancellationTokenSource _shutdown;
+    private readonly Task _serveLoop;
+
+    private Http3LoopbackServer(
+        HttpConnectionListener listener,
+        X509Certificate2 certificate,
+        int port,
+        Func<IHttpContext, Task> handler)
+    {
+        _listener = listener;
+        _certificate = certificate;
+        _shutdown = new CancellationTokenSource();
+        BaseUri = new Uri($"https://127.0.0.1:{port}/");
+        _serveLoop = Task.Run(() => ServeAsync(handler, _shutdown.Token));
+    }
+
+    /// <summary>The base URI a real HTTP/3 client dials to reach this server.</summary>
+    public Uri BaseUri { get; }
+
+    /// <summary>
+    /// Binds a loopback HTTP/3 listener and starts serving. Each surfaced request is passed to
+    /// <paramref name="handler"/> (which sets the response), then the response is written and the
+    /// exchange disposed.
+    /// </summary>
+    /// <param name="handler">The per-request response handler.</param>
+    /// <param name="cancellationToken">A token that cancels the initial QUIC bind.</param>
+    /// <returns>The started server harness.</returns>
+    public static async Task<Http3LoopbackServer> StartAsync(Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        int port = AllocateUdpPort();
+        X509Certificate2 certificate = CreateCertificate();
+
+        QuicConnectionListener quicListener = await QuicConnectionListener.CreateAsync(transport =>
+        {
+            transport.EndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            transport.ServerAuthenticationOptions.ServerCertificate = certificate;
+            transport.ServerAuthenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 };
+        }, cancellationToken).ConfigureAwait(false);
+
+        HttpConnectionListener listener = HttpConnectionListener.Create(options => options.UseHttp3(quicListener));
+
+        return new Http3LoopbackServer(listener, certificate, port, handler);
+    }
+
+    private async Task ServeAsync(Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                IHttpConnection connection = await _listener.AcceptOrListenAsync(cancellationToken).ConfigureAwait(false);
+
+                // Serve each connection on its own task so a second client (or reconnect) is not
+                // blocked behind the first; the client under test reuses one connection for its
+                // sequential requests, which the receive loop yields in order.
+                _ = ServeConnectionAsync(connection, handler, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown requested — stop accepting.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The listener was disposed out from under the accept — teardown raced the loop.
+        }
+    }
+
+    private static async Task ServeConnectionAsync(IHttpConnection connection, Func<IHttpContext, Task> handler, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using (connection.ConfigureAwait(false))
+            {
+                IHttpConnectionContext context = await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                await foreach (IHttpContext exchange in context.ReceiveAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    await handler(exchange).ConfigureAwait(false);
+                    await context.SendAsync(exchange, cancellationToken).ConfigureAwait(false);
+                    await exchange.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Test harness: any connection-scoped teardown (client abort, QUIC reset, idle timeout,
+            // or shutdown cancellation) is expected and must not fault the background serve loop.
+            // The assertions live on the client side of each test, not here.
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        _shutdown.Cancel();
+
+        try
+        {
+            await _serveLoop.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await _listener.DisposeAsync().ConfigureAwait(false);
+        _certificate.Dispose();
+        _shutdown.Dispose();
+    }
+
+    private static int AllocateUdpPort()
+    {
+        using Socket probe = new(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using RSA rsa = RSA.Create(2048);
+        CertificateRequest request = new("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        SubjectAlternativeNameBuilder subjectAlternativeNames = new();
+        subjectAlternativeNames.AddDnsName("localhost");
+        subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+
+        request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: false));
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+            new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, // id-kp-serverAuth
+            critical: false));
+
+        using X509Certificate2 ephemeral = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(10));
+
+        // Round-trip through PKCS#12 so the private key is persisted in a form the platform TLS
+        // stack (Schannel / MsQuic) accepts; a certificate with an ephemeral key is rejected on Windows.
+        return X509CertificateLoader.LoadPkcs12(
+            ephemeral.Export(X509ContentType.Pfx),
+            password: null,
+            X509KeyStorageFlags.Exportable);
+    }
+}

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/docs/DESIGN.md
@@ -279,12 +279,6 @@ keep-alive unblock, post-stop connection refusal).
   before cancelling on shutdown (versus cancelling them with the drain token) is
   future work; it needs a two-phase signal ("finish the current exchange, accept
   no new ones on this connection") that this iteration does not implement.
-- **Full HTTP/3 response round-trip.** The HTTP/3 registration surface (issue
-  #767) has landed — see "HTTP/3 (QUIC) registration surface" below — and the
-  QUIC bind, h3 connection accept, and pipeline dispatch are verified. The full
-  client response round-trip is blocked by a pre-existing HTTP/3 server
-  control-stream defect in `Http.Connections` (`H3_CLOSED_CRITICAL_STREAM`),
-  which is Http-area work outside this module.
 - **Per-request service resolution.** DI/logging/config are builder-time only;
   the server resolves nothing per connection or per request.
 - **Re-implementing wire behaviour.** Protocol conformance and wire-level failure
@@ -594,17 +588,19 @@ advertised port is taken from that listener's bound endpoint. An application opt
 `options.AdvertiseAltService(...)` alongside a stream listener; the server then injects
 `Alt-Svc: h3=":<port>"` on the h1/h2 responses so clients can discover and upgrade to h3.
 
-### Known limitation — h3 response round-trip
+### h3 response round-trip — verified end to end
 
-The registration surface, the QUIC bind, the h3 connection accept, and pipeline dispatch
-(scheme + protocol) are verified end to end against a real .NET HTTP/3 client. The full
-**response** round-trip is currently blocked by a pre-existing HTTP/3 *server
-control-stream* defect in `Assimalign.Cohesion.Http.Connections`
-(`H3_CLOSED_CRITICAL_STREAM`, 0x104) that reproduces with that library's own Http3
-example, independent of this surface. The e2e test therefore makes the server-side
-observation (the protocol and scheme seen on the dispatched `IHttpContext`) its
-load-bearing assertion and treats the client response as best-effort. Closing the
-transport defect is Http-area work, tracked outside this issue.
+The registration surface, the QUIC bind, the h3 connection accept, pipeline dispatch
+(scheme + protocol), **and the full client response round-trip** (HTTP/3 status + body)
+are verified end to end against a real .NET HTTP/3 client
+(`WebHttp3HostingIntegrationTests`). The client round-trip was previously best-effort
+because of a pre-existing HTTP/3 *server send-path* defect in
+`Assimalign.Cohesion.Http.Connections` (issue #928): the request stream was never ended
+when a response completed, so the client's response-content read never finished and
+surfaced the eventual connection teardown as `H3_CLOSED_CRITICAL_STREAM` (0x104). That
+defect is fixed in `Http.Connections` (the send path now ends the request stream per RFC
+9114 §4.1), so the e2e test asserts the client-observed status and body alongside the
+server-side dispatch observation.
 
 ### AOT posture
 

--- a/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebHttp3HostingIntegrationTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.Hosting/tests/WebHttp3HostingIntegrationTests.cs
@@ -38,13 +38,12 @@ namespace Assimalign.Cohesion.Web.Hosting.Tests;
 /// implementation (for example a missing libmsquic) it returns early, and the deferred-factory and
 /// platform-guard behaviour stays covered by <see cref="WebHttp3HostingExtensionsTests"/>.
 /// <para>
-/// The <em>server-side observation</em> (protocol + scheme seen on the dispatched
-/// <see cref="IHttpContext"/>) is the load-bearing assertion: it proves <c>UseHttp3</c> accepts a real
-/// QUIC h3 connection and drives it through the pipeline. The client's full response round-trip is
-/// observed best-effort: it currently trips a pre-existing HTTP/3 <em>server control-stream</em> defect
-/// (<c>H3_CLOSED_CRITICAL_STREAM</c>, 0x104) that reproduces with the <c>Http.Connections</c> Http3
-/// example independently of this registration surface, so a broken response read never hard-fails the
-/// suite.
+/// Both halves are load-bearing assertions: the client observes the full response round-trip (HTTP/3
+/// status <b>and</b> body), and the terminal middleware observes the protocol + transport-derived
+/// scheme on the dispatched <see cref="IHttpContext"/>. The client round-trip became a hard assertion
+/// once issue #928 — an <c>Http.Connections</c> HTTP/3 send-path defect that left the request stream
+/// unterminated and surfaced at the client as <c>H3_CLOSED_CRITICAL_STREAM</c> (0x104) — was fixed;
+/// the server now ends the request stream when the response completes (RFC 9114 §4.1).
 /// </para>
 /// </remarks>
 // System.Net.Quic is Windows/Linux/macOS only; annotated to match UseHttp3 and gated at runtime.
@@ -55,8 +54,8 @@ public class WebHttp3HostingIntegrationTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
-    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp3: Should accept and dispatch an HTTP/3 request over QUIC reporting the https scheme")]
-    public async Task UseHttp3_OverQuic_ShouldDispatchRequestWithHttp30AndHttpsScheme()
+    [Fact(DisplayName = "Cohesion Test [Web.Hosting] - UseHttp3: Should complete a full HTTP/3 response round-trip and dispatch reporting the https scheme")]
+    public async Task UseHttp3_OverQuic_ShouldCompleteResponseRoundTripAndDispatchWithHttps()
     {
         if (!QuicListener.IsSupported)
         {
@@ -83,7 +82,7 @@ public class WebHttp3HostingIntegrationTests
         WebApplication app = builder.Build();
 
         // The terminal middleware records the protocol and transport-derived scheme it observes, then
-        // answers 200 with a small body. The recorded observation is the load-bearing assertion.
+        // answers 200 with a small body. Both the observation and the client's received body are asserted.
         TaskCompletionSource<(CohesionHttpVersion Version, HttpScheme Scheme)> observed =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         app.Use((context, next) =>
@@ -102,35 +101,38 @@ public class WebHttp3HostingIntegrationTests
         IWebApplicationServer server = app.Context.ServiceProvider.GetRequiredService<IWebApplicationServer>();
         await server.StartAsync(cancellationToken);
 
-        // Drive a real HTTP/3 client as a background stimulus, on its own token so the observation can
-        // stop it promptly.
-        using CancellationTokenSource clientCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Task clientStimulus = DriveHttp3ClientAsync(new Uri($"https://127.0.0.1:{port}/secure?probe=h3"), clientCancellation.Token);
-
         try
         {
-            // Act / Assert — the request reached the pipeline over a real QUIC h3 connection and reports
-            // HTTP/3 with the transport-derived https scheme.
-            (CohesionHttpVersion version, HttpScheme scheme) = await observed.Task.WaitAsync(cancellationToken);
+            // Act — a real .NET HTTP/3 client completes the full round-trip: headers AND response body.
+            (Version version, int status, string body) = await GetHttp3ResponseAsync(
+                new Uri($"https://127.0.0.1:{port}/secure?probe=h3"), cancellationToken);
 
-            version.ShouldBe(CohesionHttpVersion.Http30);
-            scheme.ShouldBe(HttpScheme.Https);
+            // Assert — the client observed a complete HTTP/3 response.
+            version.ShouldBe(NetHttpVersion.Version30);
+            status.ShouldBe(200);
+            body.ShouldBe("hello-http3");
+
+            // Assert — the request reached the pipeline over a real QUIC h3 connection and reported
+            // HTTP/3 with the transport-derived https scheme.
+            (CohesionHttpVersion observedVersion, HttpScheme observedScheme) = await observed.Task.WaitAsync(cancellationToken);
+
+            observedVersion.ShouldBe(CohesionHttpVersion.Http30);
+            observedScheme.ShouldBe(HttpScheme.Https);
         }
         finally
         {
-            clientCancellation.Cancel();
             await server.StopAsync(CancellationToken.None);
-            await ObserveAsync(clientStimulus);
         }
     }
 
     /// <summary>
-    /// Repeatedly issues an exact-HTTP/3 request until one completes cleanly or the token is cancelled.
-    /// A clean completion is the healthy-platform path; connect/handshake races and the pre-existing h3
-    /// server control-stream defect are swallowed and retried, since the test asserts on the server-side
-    /// observation the first request already produced.
+    /// Issues an exact-HTTP/3 request and reads the full response, returning the negotiated version,
+    /// status code, and body. Connect/handshake races against server startup surface as a transient
+    /// <see cref="HttpRequestException"/> and are retried until the shared timeout; the HTTP/3
+    /// send-path defect that previously forced a best-effort read (issue #928) is fixed, so a healthy
+    /// platform returns a complete response.
     /// </summary>
-    private static async Task DriveHttp3ClientAsync(Uri uri, CancellationToken cancellationToken)
+    private static async Task<(Version Version, int Status, string Body)> GetHttp3ResponseAsync(Uri uri, CancellationToken cancellationToken)
     {
         using HttpClientHandler handler = new()
         {
@@ -139,49 +141,28 @@ public class WebHttp3HostingIntegrationTests
         };
         using HttpClient client = new(handler);
 
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
-            using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
-            {
-                Version = NetHttpVersion.Version30,
-                VersionPolicy = HttpVersionPolicy.RequestVersionExact
-            };
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                using HttpRequestMessage request = new(ClientHttpMethod.Get, uri)
+                {
+                    Version = NetHttpVersion.Version30,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
 
-                return;
-            }
-            catch (OperationCanceledException)
-            {
-                return;
+                using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                return (response.Version, (int)response.StatusCode, body);
             }
             catch (HttpRequestException)
             {
-                // Connect/handshake not ready, or the pre-existing h3 response-stream defect; retry until
-                // the observation cancels this stimulus or the shared timeout fires.
-                try
-                {
-                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    return;
-                }
+                // Connect/handshake not ready yet — retry until the observation cancels or the timeout fires.
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
             }
-        }
-    }
-
-    private static async Task ObserveAsync(Task task)
-    {
-        try
-        {
-            await task.ConfigureAwait(false);
-        }
-        catch
-        {
-            // The test's assertions own the verdict; drain the background client quietly on teardown.
         }
     }
 

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/docs/DESIGN.md
@@ -81,7 +81,6 @@ rule applied to a feature family that always ships together.
 ```
 GET/HEAD?  ──no──▶ next
 prefix match (segment-aligned, ordinal)? ──no──▶ next
-h1 percent-decode compensation (see below)
 unsafe segments (../.\:/NUL)? ──yes──▶ 404 (terminal)
 FileSystemPath.Parse  ──throws──▶ 404
 resolve: file | directory(+default doc | 301 append-slash) | miss ──▶ next
@@ -92,20 +91,22 @@ range (GET only; If-Range gate) ──▶ 416 | single 206 | full 200
 open stream → head (Content-*, ETag, Last-Modified, Accept-Ranges, Cache-Control, Vary) → body (GET)
 ```
 
-## HTTP/1.1 percent-decode parity (known transport gap)
+## HTTP/1.1 percent-decode parity (transport-owned)
 
-The h2/h3 transports percent-decode the request path before middleware sees it
-(`HttpPath.FromUriComponent`), but the HTTP/1.1 reader currently surfaces the raw
-request-target text (`HttpRequestTarget` does no decoding). Undefended, `%2e%2e` would read
-as a literal segment name on h1 and as `..` on h2 — the classic encoded-traversal split.
-The middleware compensates: when `Version == Http11` and the path contains `%`, it decodes
-once (`Uri.UnescapeDataString`) before prefix matching and the traversal gate, so every
-transport funnels the same text through the same defense. This also makes encoded *legit*
-names (`my%20file.txt`) resolve on h1.
+The traversal gate runs over the **decoded** request path, and every transport now decodes it
+before the middleware sees it: HTTP/1.1's `Http1MessageReader` percent-decodes the origin-form
+request-target through the same `HttpPath.FromUriComponent` HTTP/2 (`Http2Stream`) and HTTP/3
+(`Http3HeaderCodec`) run over the `:path` pseudo-header (issue #895). So `%2e%2e` arrives here as
+`..` on h1 exactly as on h2/h3, `%2F` stays encoded on all three (it never becomes a separator),
+and a decoded octet that is not a legal path character (a space, control, `?`/`#`, or NUL) makes
+the request-target malformed on every transport — so `my%20file.txt` is uniformly unreachable
+rather than resolving on h1 alone.
 
-This is a deliberate, removable wart: the right fix is decode parity in the h1 transport,
-filed as a follow-up work item — **remove this compensation in the same change** or h1 paths
-would double-decode.
+Because the transport owns the single decode, **the middleware must not decode again** — it reads
+`context.Request.Path.Value` verbatim. The former `Version == Http11` + `Uri.UnescapeDataString`
+compensation (which double-decoded relative to `FromUriComponent`, e.g. also collapsing `%2F` to a
+separator) was removed together with the h1 transport fix; re-introducing any middleware-side decode
+would double-decode a path the transport already handled.
 
 ## AOT posture
 

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilesMiddleware.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/src/Internal/StaticFilesMiddleware.cs
@@ -69,17 +69,12 @@ internal sealed class StaticFilesMiddleware : IWebApplicationMiddleware
             return;
         }
 
-        // Transport-parity compensation: the h2/h3 transports percent-decode the request path
-        // before it reaches middleware (HttpPath.FromUriComponent), but HTTP/1.x currently
-        // surfaces the raw request-target text. Decode here so the traversal gate and the file
-        // lookup see the same text on every transport — otherwise "%2e%2e" would read as a
-        // literal segment name on h1 and as ".." on h2. Remove once the h1 transport gains
-        // decode parity (filed as a follow-up; see docs/DESIGN.md).
+        // Every transport now percent-decodes the request-target path before middleware sees it
+        // (HttpPath.FromUriComponent in Http1MessageReader / Http2Stream / Http3HeaderCodec), so the
+        // traversal gate and the file lookup see the same decoded text regardless of protocol — "%2e%2e"
+        // arrives here as ".." on h1 exactly as it does on h2/h3. The middleware MUST NOT re-decode, or
+        // an encoded octet would decode twice; it trusts the transport's single decode.
         string path = context.Request.Path.Value;
-        if (context.Version == HttpVersion.Http11 && path.Contains('%'))
-        {
-            path = Uri.UnescapeDataString(path);
-        }
 
         if (!StaticFilePath.TryGetRelativePath(path, _prefix, out string remainder))
         {

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesEndToEndTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesEndToEndTests.cs
@@ -140,14 +140,17 @@ public class StaticFilesEndToEndTests
 
     [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: encoded traversal must never escape the mounted root")]
     [InlineData("/static/%2e%2e/secret.txt")]
+    [InlineData("/static/%2E%2E/secret.txt")]
     [InlineData("/static/%2e%2e/%2e%2e/secret.txt")]
     [InlineData("/static/..%5csecret.txt")]
     [InlineData("/static/nested/%2e%2e/%2e%2e/secret.txt")]
     public async Task E2E_EncodedTraversal_ShouldYield404(string attackPath)
     {
-        // Arrange — the transport percent-decodes these into literal dot segments before the
-        // middleware sees them; the URI client-side keeps them encoded, so the hostile form
-        // actually reaches the server (a literal "/../" would be normalized away by HttpClient).
+        // Arrange — every transport (HTTP/1.1 included, now that Http1MessageReader percent-decodes
+        // the request-target path to h2/h3 parity) decodes these into literal dot segments before the
+        // middleware sees them, so the traversal gate catches them uniformly; the URI client-side keeps
+        // them encoded, so the hostile form actually reaches the server (a literal "/../" would be
+        // normalized away by HttpClient).
         using CancellationTokenSource cancellation = new(TestTimeout);
         using InMemoryFileSystem site = StaticSite.Create(
             ("public.txt", "public"),
@@ -166,6 +169,29 @@ public class StaticFilesEndToEndTests
         // Assert
         response.StatusCode.ShouldBe(NetHttpStatusCode.NotFound);
         (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldNotContain("top-secret");
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: a legitimately percent-encoded name should decode over the wire and resolve")]
+    public async Task E2E_EncodedName_ShouldResolveDecodedFile()
+    {
+        // Arrange — the correctness counterpart to the traversal defense: a reserved character that is
+        // legitimately percent-encoded on the wire ("%24" → "$") must decode in the h1 transport and
+        // resolve the file whose name actually contains it. Before Http1MessageReader gained decode
+        // parity, "%24" reached the middleware raw and this file was unreachable on HTTP/1.1.
+        using CancellationTokenSource cancellation = new(TestTimeout);
+        using InMemoryFileSystem site = StaticSite.Create(("prices$.json", "{\"ok\":true}"));
+        await using WebApplicationTestFactory factory = CreateFactory(site);
+        using HttpClient client = factory.CreateClient();
+
+        // Act — keep the client from canonicalizing "%24" away so the encoded octet reaches the wire.
+        var rawUri = new Uri(
+            "http://localhost/prices%24.json",
+            new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+        using HttpResponseMessage response = await client.GetAsync(rawUri, cancellation.Token);
+
+        // Assert
+        response.StatusCode.ShouldBe(NetHttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellation.Token)).ShouldBe("{\"ok\":true}");
     }
 
     [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - E2E: Accept-Encoding negotiation should serve the precompressed sibling")]

--- a/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesMiddlewareTests.cs
+++ b/resources/Web/Assimalign.Cohesion.Web.StaticFiles/tests/StaticFilesMiddlewareTests.cs
@@ -182,41 +182,25 @@ public class StaticFilesMiddlewareTests
         passedThrough[0].ShouldBeFalse();
     }
 
-    [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: percent-encoded traversal on HTTP/1.1 should be rejected with 404")]
-    [InlineData("/static/%2e%2e/secret.txt")]
-    [InlineData("/static/%2E%2E/secret.txt")]
-    [InlineData("/static/..%2fsecret.txt")]
-    [InlineData("/static/..%5csecret.txt")]
-    public async Task Invoke_EncodedTraversalOnHttp11_ShouldRespond404(string path)
+    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: the middleware serves the path verbatim without re-decoding percent sequences")]
+    public async Task Invoke_PercentEncodedName_IsNotReDecodedByMiddleware()
     {
-        // Arrange — the HTTP/1.1 transport surfaces the raw request-target text, so the
-        // middleware's own decode step must expose these as dot segments before the gate runs
-        // (the fake context reports HttpVersion.Http11).
-        using InMemoryFileSystem site = StaticSite.Create(("public.txt", "public"));
+        // Arrange — every transport now percent-decodes the request-target path exactly once before
+        // middleware runs (Http1MessageReader / Http2Stream / Http3HeaderCodec via
+        // HttpPath.FromUriComponent). A literal "%2E" that still reaches the middleware came from a
+        // double-encoded wire target ("%252E") the transport decoded once, so it is a plain name
+        // character — decoding it again would resolve the wrong file. The middleware must treat
+        // "/report%2Etxt" verbatim and never turn it into "/report.txt". (The encoded-traversal and
+        // encoded-name decode behaviors themselves are pinned at the transport — see the
+        // Http.Connections parity suite and the E2E traversal/name tests.)
+        using InMemoryFileSystem site = StaticSite.Create(("report.txt", "sensitive-report"));
 
         // Act
-        TestHttpContext context = await RunAsync(
-            site, path, HttpMethod.Get,
-            options => options.RequestPath = new HttpPath("/static"));
+        TestHttpContext context = await RunAsync(site, "/report%2Etxt", HttpMethod.Get);
 
-        // Assert
-        context.Response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
-    }
-
-    [Fact(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: percent-encoded names on HTTP/1.1 should resolve to the decoded file")]
-    public async Task Invoke_EncodedNameOnHttp11_ShouldResolveDecodedFile()
-    {
-        // Arrange — the same decode step serves correctness, not just defense: a space-encoded
-        // request must reach the file whose name actually contains the space.
-        using InMemoryFileSystem site = StaticSite.Create(("my file.txt", "spaced"));
-
-        // Act
-        TestHttpContext context = await RunAsync(site, "/my%20file.txt", HttpMethod.Get);
-
-        // Assert
-        context.Response.StatusCode.ShouldBe(HttpStatusCode.Ok);
-        context.ReadResponseBody().ShouldBe("spaced");
-        Header(context, HttpHeaderKey.ContentType).ShouldBe("text/plain");
+        // Assert — report.txt is never served; a served body would mean the middleware re-decoded
+        // "%2E" into "." and resolved "/report.txt".
+        context.ReadResponseBody().ShouldNotContain("sensitive-report", Case.Sensitive);
     }
 
     [Theory(DisplayName = "Cohesion Test [Web.StaticFiles] - Invoke: backslash traversal should be rejected with 404")]


### PR DESCRIPTION
## Summary
Batch 5, stack **2/4** (base: `feature/L01.01.11.44-h3-control-stream`, PR #932).

Closes the transport divergence #777 discovered: h2/h3 percent-decode `:path` via `HttpPath.FromUriComponent` before middleware sees it; the h1 reader surfaced raw request-target text — so `%2e%2e` was a literal segment on h1 but `..` on h2/h3.

- **h1 fix** in `Http1MessageReader`: origin-form request-targets now run the already-split path through the identical `HttpPath.FromUriComponent` decode (`%2F` stays encoded — the routing `{**}` invariant; `%2e%2e` → `..`; invalid/overlong sequences left intact). Absolute/authority/asterisk forms keep current handling; query handling was already at parity (`HttpQuery.Parse` on all three). Decode failures surface as the transport's existing malformed-request-target failure — narrowly-scoped catch, no behavior change to limits/dispatch-at-head.
- **StaticFiles compensation removed same-change** (the `Http11`-gated `Uri.UnescapeDataString` that would now double-decode); its pinned tests re-pointed, DESIGN parity section rewritten, plus an anti-double-decode guard test.
- **The issue's `%20` premise inverted — worth owner attention**: decoded space/control/`#`/`?`/NUL are illegal `HttpPath` characters repo-wide, so parity means `my%20file.txt` is now **uniformly rejected on every transport** (h1 previously served it for static files only via the compensation; h2/h3 have always thrown). Making space-named resources reachable would be an `HttpPath` character-set decision, not a transport one — recorded as a follow-up candidate.

## Tests
Http.Connections **434** (12 new: h1+h2 parity matrix Theory over the four decode categories, query-contrast pin, h1 rejection Theory — h3 guaranteed by byte-identical `ParseQuery` code) · Web.StaticFiles **85** (real-h1 traversal e2e + positive `%24`→`$` round-trip) · Web.Routing **250** · Http core **1231** — all passing.

## Follow-up candidates (not filed)
1. **h2/h3 uncaught decode throws** — `Http2ConnectionContext`/h3 dispatch don't catch `ParseQuery` decode failures, so a malformed `:path` throws uncaught (h1 now handles it gracefully); should become a graceful stream reset. Robustness/DoS-adjacent.
2. `HttpPath` character-set widening if space-named resources should be servable.
3. `HttpFormReader`'s decode carries a pre-existing accuracy TODO.

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)