### PR TITLE
fix(content): restore Content.Ebml build and port VInt tests to xUnit

### DIFF
--- a/.github/workflows/library-content.yml
+++ b/.github/workflows/library-content.yml
@@ -17,7 +17,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         projects: [
             'Assimalign.Cohesion.Content',
-            'Assimalign.Cohesion.Content.Text'
+            'Assimalign.Cohesion.Content.Text',
+            'Assimalign.Cohesion.Content.Ebml'
         ]
     steps:
       - uses: actions/checkout@v4

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/src/VInt.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/src/VInt.cs
@@ -11,7 +11,9 @@ public readonly struct VInt
     private VInt(ulong encodedValue, int length)
     {
         if (length < 1 || length > 8)
+        {
             throw new ArgumentOutOfRangeException(nameof(length));
+        }
 
         EncodedValue = encodedValue;
         _length = (sbyte)length;
@@ -67,11 +69,17 @@ public readonly struct VInt
     public static VInt EncodeSize(ulong value, int length = 0)
     {
         if (value > MaxSizeValue)
+        {
             throw new ArgumentException("Value exceed VInt capacity", nameof(value));
+        }
         if (length < 0 || length > 8)
+        {
             throw new ArgumentOutOfRangeException(nameof(length));
+        }
         if (length > 0 && DataBitsMask[length] <= value)
+        {
             throw new ArgumentException("Specified width is not sufficient to encode value", nameof(value));
+        }
 
         if (length == 0)
         {
@@ -90,7 +98,9 @@ public readonly struct VInt
     public static VInt MakeId(uint elementId)
     {
         if (elementId > MaxElementIdValue)
+        {
             throw new ArgumentException("Value exceed VInt capacity", nameof(elementId));
+        }
 
         var id = EncodeSize(elementId);
         Debug.Assert(id._length <= 4);
@@ -105,7 +115,9 @@ public readonly struct VInt
     public static VInt UnknownSize(int length)
     {
         if (length < 0 || length > 8)
+        {
             throw new ArgumentOutOfRangeException(nameof(length));
+        }
 
         var sizeMarker = 1UL << (7 * length);
         var dataBits = (1UL << (7 * length)) - 1;
@@ -120,7 +132,9 @@ public readonly struct VInt
     public static VInt FromEncoded(ulong encodedValue)
     {
         if (encodedValue == 0)
+        {
             throw new ArgumentException("Zero is not a correct value", nameof(encodedValue));
+        }
 
         var mostSignificantOctetIndex = 7;
         while ((encodedValue >> mostSignificantOctetIndex * 8) == 0x0)
@@ -132,7 +146,9 @@ public readonly struct VInt
         var extraBytes = (marker >> 4 > 0) ? ExtraBytesSize[marker >> 4] : 4 + ExtraBytesSize[marker];
 
         if (extraBytes != mostSignificantOctetIndex)
+        {
             throw new ArgumentException("Width marker does not match its position", nameof(encodedValue));
+        }
 
         return new VInt(encodedValue, extraBytes + 1);
     }
@@ -152,13 +168,15 @@ public readonly struct VInt
     {
         buffer = buffer ?? new byte[maxLength];
 
-        if (source.ReadFully(buffer, 0, 1) == 0)
-        {
-            throw new EndOfStreamException();
-        }
+        // ReadExactly throws EndOfStreamException when the stream ends before
+        // the requested count is satisfied, which is exactly the contract this
+        // reader needs for both the width marker and its trailing octets.
+        source.ReadExactly(buffer, 0, 1);
 
         if (buffer[0] == 0)
+        {
             throw new EbmlDataFormatException("Length bigger than 8 is not supported");
+        }
         // TODO handle EBMLMaxSizeWidth
 
         var extraBytes = (buffer[0] & 0xf0) != 0
@@ -166,12 +184,11 @@ public readonly struct VInt
             : 4 + ExtraBytesSize[buffer[0]];
 
         if (extraBytes + 1 > maxLength)
-            throw new EbmlDataFormatException($"Expected VInt with a max length of {maxLength}. Got {extraBytes + 1}");
-
-        if (source.ReadFully(buffer, 1, extraBytes) != extraBytes)
         {
-            throw new EndOfStreamException();
+            throw new EbmlDataFormatException($"Expected VInt with a max length of {maxLength}. Got {extraBytes + 1}");
         }
+
+        source.ReadExactly(buffer, 1, extraBytes);
 
         ulong encodedValue = buffer[0];
         for (var i = 0; i < extraBytes; i++)
@@ -187,7 +204,7 @@ public readonly struct VInt
     /// <param name="stream"></param>
     public int Write(Stream stream)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        ArgumentNullException.ThrowIfNull(stream);
 
         var buffer = new byte[Length];
 
@@ -243,9 +260,8 @@ public readonly struct VInt
         return other.EncodedValue == EncodedValue && other._length == _length;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
-        if (ReferenceEquals(null, obj)) return false;
         return obj is VInt i && Equals(i);
     }
 

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/Assimalign.Cohesion.Content.Ebml.Tests.csproj
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/Assimalign.Cohesion.Content.Ebml.Tests.csproj
@@ -5,6 +5,7 @@
 		<CohesionPackageReference Include="xunit" />
 		<CohesionPackageReference Include="xunit.runner.visualstudio" />
 		<CohesionPackageReference Include="coverlet.collector" />
+		<CohesionPackageReference Include="Shouldly" />
 	</ItemGroup>
   <ItemGroup>
     <CohesionProjectReference Include="Assimalign.Cohesion.Content.Ebml" />

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/EbmlVIntReadTests.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/EbmlVIntReadTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.IO.Ebml.Tests.TestObjects;
+
+namespace Assimalign.IO.Ebml.Tests;
+
+public class EbmlVIntReadTests
+{
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - Read: decodes a stream-backed VInt of each width")]
+    [InlineData(0ul, 1)]
+    [InlineData(126ul, 1)]
+    [InlineData(300ul, 2)]
+    [InlineData(0xFFFFul, 3)]
+    [InlineData(0xdeffadul, 4)]
+    public void Read_FromStream_DecodesValueAndWidth(ulong value, int expectedLength)
+    {
+        // Arrange
+        var source = new MemoryStream(Encode(value));
+
+        // Act
+        var actual = VInt.Read(source, 8, new byte[8]);
+
+        // Assert
+        actual.Value.ShouldBe(value);
+        actual.Length.ShouldBe(expectedLength);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Ebml] - Read: reassembles a VInt delivered one byte per read")]
+    public void Read_WhenStreamReturnsPartialReads_ReadsUntilComplete()
+    {
+        // Arrange — a 4-byte VInt dripped one byte at a time forces the reader to
+        // keep reading rather than trusting a single Read call to fill the buffer.
+        var source = new ChunkedReadStream(Encode(0xdeffad), chunkSize: 1);
+
+        // Act
+        var actual = VInt.Read(source, 8, new byte[8]);
+
+        // Assert
+        actual.Value.ShouldBe(0xdeffadul);
+        actual.Length.ShouldBe(4);
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Ebml] - Read: empty stream reports end of stream")]
+    public void Read_FromEmptyStream_ShouldThrowEndOfStream()
+    {
+        // Arrange
+        var source = new MemoryStream([]);
+
+        // Act / Assert
+        Should.Throw<EndOfStreamException>(() => VInt.Read(source, 8, new byte[8]));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Ebml] - Read: truncated trailing octets report end of stream")]
+    public void Read_WhenTrailingOctetsAreTruncated_ShouldThrowEndOfStream()
+    {
+        // Arrange — width marker announces 4 bytes but only 2 are present.
+        var encoded = Encode(0xdeffad);
+        var source = new MemoryStream([encoded[0], encoded[1]]);
+
+        // Act / Assert
+        Should.Throw<EndOfStreamException>(() => VInt.Read(source, 8, new byte[8]));
+    }
+
+    [Fact(DisplayName = "Cohesion Test [Content.Ebml] - Read: rejects a VInt wider than the caller's maximum")]
+    public void Read_WhenWiderThanMaxLength_ShouldThrowEbmlDataFormat()
+    {
+        // Arrange — a 4-byte VInt offered to a reader that accepts at most 2.
+        var source = new MemoryStream(Encode(0xdeffad));
+
+        // Act / Assert
+        Should.Throw<EbmlDataFormatException>(() => VInt.Read(source, 2, new byte[2]));
+    }
+
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - Write then Read: round-trips the encoded value")]
+    [InlineData(0ul)]
+    [InlineData(127ul)]
+    [InlineData(300ul)]
+    [InlineData(0xFFFFul)]
+    [InlineData(0xdeffadul)]
+    public void Write_ThenRead_RoundTripsValue(ulong value)
+    {
+        // Arrange
+        var stream = new MemoryStream();
+        var written = VInt.EncodeSize(value).Write(stream);
+        stream.Position = 0;
+
+        // Act
+        var actual = VInt.Read(stream, 8, new byte[8]);
+
+        // Assert
+        actual.Value.ShouldBe(value);
+        actual.Length.ShouldBe(written);
+    }
+
+    private static byte[] Encode(ulong value)
+    {
+        var stream = new MemoryStream();
+        VInt.EncodeSize(value).Write(stream);
+        return stream.ToArray();
+    }
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/EbmlVIntTests.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/EbmlVIntTests.cs
@@ -1,109 +1,142 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
 namespace Assimalign.IO.Ebml.Tests;
 
 public class EbmlVIntTests
 {
-    [Xunit.InlineData()]
-    [TestCase(0, 1, ExpectedResult = 0x80ul)]
-    [TestCase(1, 1, ExpectedResult = 0x81ul)]
-    [TestCase(126, 1, ExpectedResult = 0xfeul)]
-    [TestCase(127, 2, ExpectedResult = 0x407ful)]
-    [TestCase(128, 2, ExpectedResult = 0x4080ul)]
-    [TestCase(0xdeffad, 4, ExpectedResult = 0x10deffadul)]
-    public ulong EncodeSize(int value, int expectedLength)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - EncodeSize: auto-width encoding picks the shortest form")]
+    [InlineData(0, 1, 0x80ul)]
+    [InlineData(1, 1, 0x81ul)]
+    [InlineData(126, 1, 0xfeul)]
+    [InlineData(127, 2, 0x407ful)]
+    [InlineData(128, 2, 0x4080ul)]
+    [InlineData(0xdeffad, 4, 0x10deffadul)]
+    public void EncodeSize_WithoutLength_EncodesToShortestForm(int value, int expectedLength, ulong expectedEncoded)
     {
-        var v = VInt.EncodeSize((ulong)value);
-        Assert.AreEqual(expectedLength, v.Length);
+        // Act
+        var actual = VInt.EncodeSize((ulong)value);
 
-        return v.EncodedValue;
+        // Assert
+        actual.Length.ShouldBe(expectedLength);
+        actual.EncodedValue.ShouldBe(expectedEncoded);
     }
 
-    [TestCase(0, 1, ExpectedResult = 0x80ul)]
-    [TestCase(0, 2, ExpectedResult = 0x4000ul)]
-    [TestCase(0, 3, ExpectedResult = 0x200000ul)]
-    [TestCase(0, 4, ExpectedResult = 0x10000000ul)]
-    [TestCase(127, 2, ExpectedResult = 0x407ful)]
-    public ulong EncodeSizeWithLength(int value, int length)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - EncodeSize: explicit length pads to the requested width")]
+    [InlineData(0, 1, 0x80ul)]
+    [InlineData(0, 2, 0x4000ul)]
+    [InlineData(0, 3, 0x200000ul)]
+    [InlineData(0, 4, 0x10000000ul)]
+    [InlineData(127, 2, 0x407ful)]
+    public void EncodeSize_WithLength_PadsToRequestedWidth(int value, int length, ulong expectedEncoded)
     {
-        var v = VInt.EncodeSize((ulong)value, length);
-        Assert.AreEqual(length, v.Length);
-        return v.EncodedValue;
+        // Act
+        var actual = VInt.EncodeSize((ulong)value, length);
+
+        // Assert
+        actual.Length.ShouldBe(length);
+        actual.EncodedValue.ShouldBe(expectedEncoded);
     }
 
-    [TestCase(127, 1)]
-    public void EncodeSizeWithIncorrectLength(int value, int length)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - EncodeSize: width too narrow for the value throws")]
+    [InlineData(127, 1)]
+    public void EncodeSize_WithInsufficientLength_ShouldThrow(int value, int length)
     {
-        Assert.Throws<ArgumentException>(() => VInt.EncodeSize((ulong)value, length));
+        // Act / Assert
+        Should.Throw<ArgumentException>(() => VInt.EncodeSize((ulong)value, length));
     }
 
-    [TestCase(1, ExpectedResult = 0xfful)]
-    [TestCase(2, ExpectedResult = 0x7ffful)]
-    [TestCase(3, ExpectedResult = 0x3ffffful)]
-    [TestCase(4, ExpectedResult = 0x1ffffffful)]
-    [TestCase(5, ExpectedResult = 0x0ffffffffful)]
-    [TestCase(6, ExpectedResult = 0x07fffffffffful)]
-    [TestCase(7, ExpectedResult = 0x03fffffffffffful)]
-    [TestCase(8, ExpectedResult = 0x01fffffffffffffful)]
-    public ulong CreatesReserved(int length)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - UnknownSize: all data bits set marks the value reserved")]
+    [InlineData(1, 0xfful)]
+    [InlineData(2, 0x7ffful)]
+    [InlineData(3, 0x3ffffful)]
+    [InlineData(4, 0x1ffffffful)]
+    [InlineData(5, 0x0ffffffffful)]
+    [InlineData(6, 0x07fffffffffful)]
+    [InlineData(7, 0x03fffffffffffful)]
+    [InlineData(8, 0x01fffffffffffffful)]
+    public void UnknownSize_ForEachWidth_IsReserved(int length, ulong expectedEncoded)
     {
-        var size = VInt.UnknownSize(length);
+        // Act
+        var actual = VInt.UnknownSize(length);
 
-        Assert.AreEqual(length, size.Length);
-        Assert.IsTrue(size.IsReserved);
-
-        return size.EncodedValue;
+        // Assert
+        actual.Length.ShouldBe(length);
+        actual.IsReserved.ShouldBeTrue();
+        actual.EncodedValue.ShouldBe(expectedEncoded);
     }
 
-    [TestCase(-1)]
-    [TestCase(0)]
-    [TestCase(9)]
-    public void CreatesReservedInvalidArgs(int length)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - UnknownSize: width outside 1-8 throws")]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(9)]
+    public void UnknownSize_WithWidthOutOfRange_ShouldThrow(int length)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => VInt.UnknownSize(length));
+        // Act / Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => VInt.UnknownSize(length));
     }
 
-    [TestCase(0x80ul, ExpectedResult = 0ul)]
-    [TestCase(0xaful, ExpectedResult = 0x2ful)]
-    [TestCase(0x40FFul, ExpectedResult = 0xFFul)]
-    [TestCase(0x2000FFul, ExpectedResult = 0xFFul)]
-    [TestCase(0x100000FFul, ExpectedResult = 0xFFul)]
-    [TestCase(0x1f1020FFul, ExpectedResult = 0xF1020FFul)]
-    public ulong CreatesFromEncodedValue(ulong encodedValue)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - FromEncoded: strips the width marker to recover the value")]
+    [InlineData(0x80ul, 0ul)]
+    [InlineData(0xaful, 0x2ful)]
+    [InlineData(0x40FFul, 0xFFul)]
+    [InlineData(0x2000FFul, 0xFFul)]
+    [InlineData(0x100000FFul, 0xFFul)]
+    [InlineData(0x1f1020FFul, 0xF1020FFul)]
+    public void FromEncoded_WithValidEncoding_RecoversValue(ulong encodedValue, ulong expectedValue)
     {
-        return VInt.FromEncoded(encodedValue).Value;
+        // Act
+        var actual = VInt.FromEncoded(encodedValue);
+
+        // Assert
+        actual.Value.ShouldBe(expectedValue);
     }
 
-    [TestCase(0ul)]
-    [TestCase(1ul)]
-    [TestCase(0x40ul)]
-    [TestCase(0x20ul)]
-    [TestCase(0x10ul)]
-    [TestCase(0x8000ul)]
-    public void CreatesFromEncodedValueInvalid(ulong encodedValue)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - FromEncoded: width marker not matching its position throws")]
+    [InlineData(0ul)]
+    [InlineData(1ul)]
+    [InlineData(0x40ul)]
+    [InlineData(0x20ul)]
+    [InlineData(0x10ul)]
+    [InlineData(0x8000ul)]
+    public void FromEncoded_WithMisplacedWidthMarker_ShouldThrow(ulong encodedValue)
     {
-        Assert.Throws<ArgumentException>(() => VInt.FromEncoded(encodedValue));
+        // Act / Assert
+        Should.Throw<ArgumentException>(() => VInt.FromEncoded(encodedValue));
     }
 
-    [TestCase(0ul, 1)]
-    [TestCase(126ul, 1)]
-    [TestCase(127ul, 2)]
-    [TestCase(128ul, 2)]
-    [TestCase(0xFFFFul, 3)]
-    [TestCase(0xFFffFFul, 4)]
-    public void CreatesSizeOrIdFromEncodedValue(ulong value, int expectedLength)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - EncodeSize: round-trips the value at the expected width")]
+    [InlineData(0ul, 1)]
+    [InlineData(126ul, 1)]
+    [InlineData(127ul, 2)]
+    [InlineData(128ul, 2)]
+    [InlineData(0xFFFFul, 3)]
+    [InlineData(0xFFffFFul, 4)]
+    public void EncodeSize_ForSizeOrId_RoundTripsValue(ulong value, int expectedLength)
     {
-        var v = VInt.EncodeSize(value);
-        Assert.IsFalse(v.IsReserved);
-        Assert.AreEqual(value, v.Value);
-        Assert.AreEqual(expectedLength, v.Length);
+        // Act
+        var actual = VInt.EncodeSize(value);
+
+        // Assert
+        actual.IsReserved.ShouldBeFalse();
+        actual.Value.ShouldBe(value);
+        actual.Length.ShouldBe(expectedLength);
     }
 
-    [TestCase(0x80ul, ExpectedResult = true)]
-    [TestCase(0x81ul, ExpectedResult = true)]
-    [TestCase(0x4001ul, ExpectedResult = false, Description = "Allows shorter form")]
-    [TestCase(0xfful, ExpectedResult = false, Description = "Reserved value")]
-    [TestCase(0x7ffful, ExpectedResult = false, Description = "Reserved value")]
-    public bool ValidIdentifiers(ulong encodedValue)
+    [Theory(DisplayName = "Cohesion Test [Content.Ebml] - IsValidIdentifier: only shortest-form, non-reserved encodings qualify")]
+    [InlineData(0x80ul, true)]
+    [InlineData(0x81ul, true)]
+    [InlineData(0x4001ul, false)] // Allows shorter form
+    [InlineData(0xfful, false)]   // Reserved value
+    [InlineData(0x7ffful, false)] // Reserved value
+    public void IsValidIdentifier_ForEncodedValue_ReflectsShortestFormAndReservation(ulong encodedValue, bool expected)
     {
-        return VInt.FromEncoded(encodedValue).IsValidIdentifier;
+        // Act
+        var actual = VInt.FromEncoded(encodedValue);
+
+        // Assert
+        actual.IsValidIdentifier.ShouldBe(expected);
     }
 }

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/TestObjects/ChunkedReadStream.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/TestObjects/ChunkedReadStream.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+
+namespace Assimalign.IO.Ebml.Tests.TestObjects;
+
+/// <summary>
+/// A read-only stream that yields at most a fixed number of bytes per <see cref="Read(byte[], int, int)"/>
+/// call, modelling the partial reads a network or pipe-backed stream is free to return. Any reader that
+/// assumes a single <c>Read</c> satisfies the full request will observe truncated data against this stream.
+/// </summary>
+internal sealed class ChunkedReadStream : Stream
+{
+    private readonly byte[] _data;
+    private readonly int _chunkSize;
+    private int _position;
+
+    public ChunkedReadStream(byte[] data, int chunkSize)
+    {
+        _data = data;
+        _chunkSize = chunkSize;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _data.Length;
+
+    public override long Position
+    {
+        get => _position;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var remaining = _data.Length - _position;
+        if (remaining <= 0)
+        {
+            return 0;
+        }
+
+        var toCopy = Math.Min(Math.Min(count, _chunkSize), remaining);
+        Array.Copy(_data, _position, buffer, offset, toCopy);
+        _position += toCopy;
+        return toCopy;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/Usings.cs
+++ b/libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;


### PR DESCRIPTION
## Summary

`Assimalign.Cohesion.Content.Ebml` has not compiled since the 10.0.0 bulk import (`e24469bb`) — the only commit its folder has ever received. `VInt.Read` called a `ReadFully` `Stream` extension that lives in a *different* assembly (`Content.Media`, namespace `Assimalign.IO`), producing CS1061, and `.editorconfig:89` (`csharp_prefer_braces = true:error`) turned 12 brace omissions in the same file into build errors.

Fixing the build exposed a second, larger problem: the test suite was written for **NUnit** (`[TestCase]`, `Assert.AreEqual`, `ExpectedResult=`) inside a project that references xunit only, so it had never compiled either. The CS1061 was not what kept those tests from running.

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests only
- [x] `chore` — build / tooling / CI

## Changes

- **`VInt.Read`**: replaced the missing `ReadFully` with the BCL `Stream.ReadExactly` (.NET 7+) — precisely "read N bytes or throw `EndOfStreamException`". Both call sites map to it exactly, including `extraBytes == 0` (no-op, no throw). The `Content.Media` copy uses the legacy `this T` extension syntax the repo forbids, so it was deliberately **not** reused; the BCL API also removes the cross-assembly helper dependency that issue #459 calls out.
- **IDE0011**: added braces at all 12 sites. `Write`'s null guard became `ArgumentNullException.ThrowIfNull`, and the redundant `ReferenceEquals(null, obj)` in `Equals` was dropped (`obj is VInt` already handles null); `obj` is now correctly `object?`.
- **Tests ported to xUnit + Shouldly**, all 40 original cases preserved, with repo-standard `[Theory(DisplayName = "Cohesion Test [Content.Ebml] - …")]` naming and `{Method}_{Scenario}_{ExpectedBehavior}` methods. Added the missing `Shouldly` reference and removed `Usings.cs` (global usings are forbidden; `Content.Text` uses explicit ones).
- **New coverage for `VInt.Read`** — previously untested, and the one path this fix changes. Includes a `ChunkedReadStream` fixture that yields one byte per `Read` call, which is exactly what distinguishes read-exactly from a naive read, plus truncation, empty-stream, over-width, and write/read round-trip cases.
- **CI**: added `Assimalign.Cohesion.Content.Ebml` to the `library-content.yml` matrix.

## Work items resolved

Advances #459 — the "consistent exact-read strategy / fails deterministically on truncated input / no reliance on unrelated namespaces" half of its acceptance criteria, plus the VInt encode-decode, truncated-input, and writer-round-trip test coverage.

**Not closing it:** `EbmlReader` and `EbmlWriter` are still empty stubs and `EbmlDocument`/`EbmlBody`/`EbmlHeader` are empty shells, so "reader iteration" and the document lifecycle remain unaddressed.

### Discovered (out-of-scope) work

Not fixed here, flagged for follow-up:

- **Namespaces do not match assembly names.** All 13 files use `Assimalign.IO.Ebml`, not `Assimalign.Cohesion.Content.Ebml` (`Content.Media` has the same problem with `Assimalign.IO`). Left as-is — renaming is a public-API break that deserves its own decision. Nothing outside each package consumes these namespaces, so the blast radius is small.
- **`Content.Media` still carries the duplicate `ReadFully`** in forbidden legacy `this` syntax; it should move to `Stream.ReadExactly` too. Related: #438 (shared exact-read primitives).
- **The same bulk-import debt likely affects `.Bmff`, `.Mkv`, `.Mpeg`, `.Pdf`, `.Exe`** — assume NUnit-era tests that never compiled, so adding them to CI is not a one-line change.
- Pre-existing `CS8618` warnings in `EbmlDocument.cs` are untouched.

## Testing & verification

- [x] `dotnet build` and the affected `dotnet test` projects pass locally.
- `dotnet test libraries/Content/Assimalign.Cohesion.Content.Ebml/tests/` → **60/60 passing**, in both Debug and **Release** (CI builds Release).
- `dotnet pack --configuration Release` succeeds — CI packs and pushes this project on `main`.
- The partial-read test was **mutation-checked**: reverting `ReadExactly` to a naive `Read` fails 2 tests, confirming the new coverage is not vacuous.
- ⚠️ **Verified on Windows only.** The code is pure arithmetic over in-memory buffers — no paths, encodings, or line endings — so cross-platform risk is low, but the ubuntu/macos legs are unconfirmed until this workflow runs.

## Checklist

- [x] Deferred/backlog items are linked without a closing keyword.
- [x] Follows the repo coding rules (`.claude/rules/`): `CohesionPackageReference` for Shouldly; no `Microsoft.Extensions.*`; no global usings; Shouldly-only assertions.
- [x] Remains NativeAOT- and trimming-safe — `ReadExactly` introduces no reflection or dynamic codegen.
- [x] Tests added/updated and passing; the project was already wired into all three `.slnx` files and is now in the CI workflow.
- [x] No dangling solution/project references left behind.
- [ ] Public APIs have XML docs — **pre-existing gap** in this package (several `<summary>` blocks are empty); not introduced or widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
